### PR TITLE
Convert between mixed and behavior strategy profiles in Python

### DIFF
--- a/doc/pyapi.rst
+++ b/doc/pyapi.rst
@@ -325,6 +325,10 @@ not affected by whether behavior or mixed strategies are used, the
 equilibria returned by specific solution methods may differ, when
 using a call which does not necessarily return all equilibria.
 
+It is also possible to convert between mixed and behavior strategic
+profiles using :meth:`gambit.MixedProfile.as_behav` and 
+:meth:`gambit.BehavProfile.as_mixed`.
+
 
 API documentation
 -----------------
@@ -628,6 +632,13 @@ API documentation
    .. py:method:: __setitem__(strategy, prob)
 
       Sets the probability ``strategy`` is played in the profile to ``prob``. 
+
+   .. py:method:: as_behav()
+
+      Returns a behavior strategy profile :py:class:`BehavProfile` associated
+      to the profile.
+
+      :raises: :literal:`NotImplementedError` if the game does not have a tree representation.
          
    .. py:method:: payoff(player)
 
@@ -644,7 +655,6 @@ API documentation
       Returns the expected payoffs for a player's set of strategies 
       to choosing ``strategy`` if all other players play according to 
       the profile.
-
 
    .. py:method:: liap_value()
 
@@ -671,6 +681,11 @@ API documentation
    .. py:method:: __setitem__(action, prob)
 
       Sets the probability ``action`` is played in the profile to ``prob``. 
+
+   .. py:method:: as_mixed()
+
+      Returns a behavior strategy profile as a :py:class:`BehavProfile` 
+      object associated to the profile.
          
    .. py:method:: payoff(player)
 

--- a/src/python/gambit/lib/behav.pxi
+++ b/src/python/gambit/lib/behav.pxi
@@ -1,4 +1,5 @@
 from libcpp cimport bool
+from cython.operator cimport dereference as deref
 
 cdef class MixedBehavProfile(object):
     def __repr__(self):    return str(list(self))
@@ -220,6 +221,12 @@ cdef class MixedBehavProfileDouble(MixedBehavProfile):
         return self.profile.GetActionValue(action.action)
     def _regret(self, Action action):
         return self.profile.GetRegret(action.action)
+
+    def as_mixed(self):
+        cdef MixedStrategyProfileDouble mixed
+        mixed = MixedStrategyProfileDouble()
+        mixed.profile = new_MixedFromBehavDouble(deref(self.profile))
+        return mixed
     
     property liap_value:
         def __get__(self):
@@ -275,6 +282,12 @@ cdef class MixedBehavProfileRational(MixedBehavProfile):
     def _regret(self, Action action):
         return fractions.Fraction(rat_str(self.profile.GetRegret(action.action)).c_str())
     
+    def as_mixed(self):
+        cdef MixedStrategyProfileRational mixed
+        mixed = MixedStrategyProfileRational()
+        mixed.profile = new_MixedFromBehavRational(deref(self.profile))
+        return mixed
+
     property liap_value:
         def __get__(self):
             return fractions.Fraction(rat_str(self.profile.GetLiapValue()).c_str())

--- a/src/python/gambit/lib/libgambit.pyx
+++ b/src/python/gambit/lib/libgambit.pyx
@@ -189,6 +189,7 @@ cdef extern from "libgambit/mixed.h":
         double GetStrategyValue(c_GameStrategy)
         double GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
         double GetLiapValue()
+    c_MixedStrategyProfileDouble *new_MixedFromBehavDouble "new MixedStrategyProfile<double>"(c_MixedBehavProfileDouble)
     c_MixedStrategyProfileDouble *new_MixedStrategyProfileDouble "new MixedStrategyProfile<double>"(c_Game)
     void del_MixedStrategyProfileDouble "delete"(c_MixedStrategyProfileDouble *)
 
@@ -200,6 +201,7 @@ cdef extern from "libgambit/mixed.h":
         c_Rational GetStrategyValue(c_GameStrategy)
         c_Rational GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
         c_Rational GetLiapValue()
+    c_MixedStrategyProfileRational *new_MixedFromBehavRational "new MixedStrategyProfile<Rational>"(c_MixedBehavProfileRational)
     c_MixedStrategyProfileRational *new_MixedStrategyProfileRational "new MixedStrategyProfile<Rational>"(c_Game)
     void del_MixedStrategyProfileRational "delete"(c_MixedStrategyProfileRational *)
 
@@ -217,6 +219,7 @@ cdef extern from "libgambit/behav.h":
         double GetActionValue(c_GameAction)
         double GetRegret(c_GameAction)
         double GetLiapValue()
+    c_MixedBehavProfileDouble *new_BehavFromMixedDouble "new MixedBehavProfile<double>"(c_MixedStrategyProfileDouble) except +NotImplementedError
     c_MixedBehavProfileDouble *new_MixedBehavProfileDouble "new MixedBehavProfile<double>"(c_Game)
     void del_MixedBehavProfileDouble "delete"(c_MixedBehavProfileDouble *)
 
@@ -233,6 +236,7 @@ cdef extern from "libgambit/behav.h":
         c_Rational GetActionValue(c_GameAction)
         c_Rational GetRegret(c_GameAction)
         c_Rational GetLiapValue()
+    c_MixedBehavProfileRational *new_BehavFromMixedRational "new MixedBehavProfile<Rational>"(c_MixedStrategyProfileRational) except +NotImplementedError
     c_MixedBehavProfileRational *new_MixedBehavProfileRational "new MixedBehavProfile<Rational>"(c_Game)
     void del_MixedBehavProfileRational "delete"(c_MixedBehavProfileRational *)
 

--- a/src/python/gambit/lib/mixed.pxi
+++ b/src/python/gambit/lib/mixed.pxi
@@ -1,3 +1,5 @@
+from cython.operator cimport dereference as deref
+
 cdef class MixedStrategyProfile(object):
     def __repr__(self):    return str(list(self))
     def __richcmp__(MixedStrategyProfile self, other, whichop):
@@ -138,6 +140,15 @@ cdef class MixedStrategyProfileDouble(MixedStrategyProfile):
     def liap_value(self):
         return self.profile.GetLiapValue()
 
+    def as_behav(self):
+        cdef MixedBehavProfileDouble behav
+        if not self.game.is_tree:
+            raise NotImplementedError("Mixed behavior profiles are not "\
+                                          "defined for strategic games")
+        behav = MixedBehavProfileDouble()
+        behav.profile = new_BehavFromMixedDouble(deref(self.profile))
+        return behav
+
     property game:
         def __get__(self):
             cdef Game g
@@ -173,6 +184,15 @@ cdef class MixedStrategyProfileRational(MixedStrategyProfile):
         return fractions.Fraction(rat_str(self.profile.GetPayoffDeriv(pl, s1.strategy, s2.strategy)).c_str())
     def liap_value(self):
         return fractions.Fraction(rat_str(self.profile.GetLiapValue()).c_str())
+
+    def as_behav(self):
+        cdef MixedBehavProfileRational behav
+        if not self.game.is_tree:
+            raise NotImplementedError("Mixed behavior profiles are not "\
+                                          "defined for strategic games")
+        behav = MixedBehavProfileRational()
+        behav.profile = new_BehavFromMixedRational(deref(self.profile))
+        return behav
     
     property game:
         def __get__(self):

--- a/src/python/gambit/tests/test_behav.py
+++ b/src/python/gambit/tests/test_behav.py
@@ -360,3 +360,22 @@ class TestGambitMixedBehavGame(object):
         "Test to retrieve Lyapunov values"
         assert self.profile_double.liap_value == 0.0625
         assert self.profile_rational.liap_value == fractions.Fraction("1/16")
+
+    def test_as_mixed(self):
+        "Test converting the profile to a mixed strategy one"
+        mixed_double = self.profile_double.as_mixed()
+        mixed_rational = self.profile_rational.as_mixed()
+
+        assert mixed_double[0] == self.profile_double[0]
+        assert mixed_double[1] == self.profile_double[1]
+        assert mixed_double[2] == self.profile_double[2]
+        assert mixed_double[3] == self.profile_double[3]
+        assert mixed_double[4] == self.profile_double[4]
+        assert mixed_double[5] == self.profile_double[5]
+
+        assert mixed_rational[0] == self.profile_rational[0]
+        assert mixed_rational[1] == self.profile_rational[1]
+        assert mixed_rational[2] == self.profile_rational[2]
+        assert mixed_rational[3] == self.profile_rational[3]
+        assert mixed_rational[4] == self.profile_rational[4]
+        assert mixed_rational[5] == self.profile_rational[5]

--- a/src/python/gambit/tests/test_mixed.py
+++ b/src/python/gambit/tests/test_mixed.py
@@ -1,5 +1,6 @@
 import gambit
 import fractions
+from nose.tools import assert_raises
 
 class TestGambitMixedStrategyGame(object):
     def setUp(self):
@@ -12,11 +13,19 @@ class TestGambitMixedStrategyGame(object):
         self.profile_double = self.game.mixed_profile()
         self.profile_rational = self.game.mixed_profile(True)
 
+        self.tree_game = gambit.read_game("test_games/mixed_behavior_game.efg")
+
+        self.tree_profile_double = self.tree_game.mixed_profile()
+        self.tree_profile_rational = self.tree_game.mixed_profile(True)
+
         
     def tearDown(self):
         del self.game
+        del self.tree_game
         del self.profile_double
         del self.profile_rational
+        del self.tree_profile_double
+        del self.tree_profile_rational
             
 
     def test_getting_profile(self):
@@ -70,8 +79,6 @@ class TestGambitMixedStrategyGame(object):
 
         assert self.profile_double[self.game.players[0]]["cooperate"] == 0.5
         assert self.profile_rational[self.game.players[0]]["cooperate"] == fractions.Fraction("1/2")
-
-
         
     def test_set_probabilities(self):
         "Test setting probabilities"
@@ -89,4 +96,28 @@ class TestGambitMixedStrategyGame(object):
         "Test retrieving Lyapunov values"
         assert self.profile_double.liap_value() == 0.0
         assert self.profile_rational.liap_value() == fractions.Fraction("0")
+
+    def test_as_behav_tree(self):
+        "Test converting the profile to a behavior one"
+        behav_double = self.tree_profile_double.as_behav()
+        behav_rational = self.tree_profile_rational.as_behav()
+
+        assert behav_double[0] == self.tree_profile_double[0]
+        assert behav_double[1] == self.tree_profile_double[1]
+        assert behav_double[2] == self.tree_profile_double[2]
+        assert behav_double[3] == self.tree_profile_double[3]
+        assert behav_double[4] == self.tree_profile_double[4]
+        assert behav_double[5] == self.tree_profile_double[5]
+
+        assert behav_rational[0] == self.tree_profile_rational[0]
+        assert behav_rational[1] == self.tree_profile_rational[1]
+        assert behav_rational[2] == self.tree_profile_rational[2]
+        assert behav_rational[3] == self.tree_profile_rational[3]
+        assert behav_rational[4] == self.tree_profile_rational[4]
+        assert behav_rational[5] == self.tree_profile_rational[5]
+
+    def test_as_behav_error(self):  
+        "Test raising an error when trying to convert a profile from a strategic game"
+        assert_raises(NotImplementedError, self.profile_double.as_behav)
+        assert_raises(NotImplementedError, self.profile_rational.as_behav)
 


### PR DESCRIPTION
Implements two new methods, as_behav() and as_mixed() on MixedStrategyProfile and MixedBehavProfile, respectively, according to issue #31. Also provides tests and a bit of documentation.
