### PR TITLE
Adjust sizing of player toolbar for both types of games

### DIFF
--- a/src/gui/efgpanel.cc
+++ b/src/gui/efgpanel.cc
@@ -592,7 +592,7 @@ public:
 
 gbtTreePlayerToolbar::gbtTreePlayerToolbar(wxWindow *p_parent, 
 					   gbtGameDocument *p_doc)
-  : wxPanel(p_parent, -1, wxDefaultPosition, wxSize(110, -1)), 
+  : wxPanel(p_parent, -1, wxDefaultPosition, wxSize(210, -1)), 
     gbtGameView(p_doc)
 { 
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);

--- a/src/gui/nfgpanel.cc
+++ b/src/gui/nfgpanel.cc
@@ -276,7 +276,7 @@ public:
 
 gbtTablePlayerToolbar::gbtTablePlayerToolbar(gbtNfgPanel *p_parent, 
 					     gbtGameDocument *p_doc)
-  : wxPanel(p_parent, -1, wxDefaultPosition, wxSize(160, -1)), 
+  : wxPanel(p_parent, -1, wxDefaultPosition, wxSize(210, -1)), 
     gbtGameView(p_doc),
     m_nfgPanel(p_parent)
 { 


### PR DESCRIPTION
This commit further adjusts the sizing for both types of games.
Before:
![Sizing before changes](http://i48.tinypic.com/20pdfe1.png)

After:
![Sizing after changes](http://i48.tinypic.com/8vz2ts.png)
