### PR TITLE
Add type checking in __setitem__ on strategy profiles.

### DIFF
--- a/src/python/gambit/lib/behav.pxi
+++ b/src/python/gambit/lib/behav.pxi
@@ -122,6 +122,9 @@ cdef class MixedBehavProfile(object):
             self._setplayer(index, value)
         elif isinstance(index, str):
             self[self._resolve_index(index)] = value
+        else:
+            raise TypeError("profile indexes must be int, str, Player, Infoset or Action, not %s" %
+                            index.__class__.__name__)
 
     def is_defined_at(self, infoset):
         if isinstance(infoset, str):

--- a/src/python/gambit/lib/mixed.pxi
+++ b/src/python/gambit/lib/mixed.pxi
@@ -75,6 +75,9 @@ cdef class MixedStrategyProfile(object):
             self._setprob((<Strategy>index).strategy.deref().GetId(), value)
         elif isinstance(index, str):
             self[self._resolve_index(index)] = value
+        else:
+            raise TypeError("profile indexes must be int, str or Strategy, not %s" %
+                            index.__class__.__name__)
 
     def payoff(self, player):
         if isinstance(player, Player):


### PR DESCRIPTION
Raising an exception if an invalid indexing object passing to
**setitem** operator.

Fix issue #58.
