### PR TITLE
Fix the build error with wxWidgets 2.8.12.

### DIFF
--- a/src/labenski/src/sheet.cpp
+++ b/src/labenski/src/sheet.cpp
@@ -2582,7 +2582,11 @@ bool wxSheetDataObject::SetData(size_t len, const void *buf)
     if (len < 2u)
         return false; // I guess?
     
+#if wxCHECK_VERSION(2, 9, 0)
     wxString strBuf((const wchar_t*) wxConvertMB2WX((const char *)buf), len); // probably not Unicode safe
+#else
+    wxString strBuf(wxConvertMB2WX((const char *)buf), len); // probably not Unicode safe
+#endif
     m_data = strBuf;
     
     //wxPrintf(wxT("Data len %d %d\n"), m_data.Len(), len);


### PR DESCRIPTION
After the wx2.9.4 branch merge into the master, I test it with wx2.8.12 and wx2.9.4 on linux platform(ubuntu11.10) and I find will break the build of wx2.8.12 while wx2.9.4 works fine.

The error message is below:

```
src/labenski/src/sheet.cpp: In member function ‘virtual bool wxSheetDataObject::SetData(size_t, const void*)’:
src/labenski/src/sheet.cpp:2586:76: error: call of overloaded ‘wxString(const wchar_t*, size_t&)’ is ambiguous
src/labenski/src/sheet.cpp:2586:76: note: candidates are:
/usr/local/include/wx-2.8/wx/string.h:1283:3: note: wxString::wxString(const void*, const void*) <near match>
/usr/local/include/wx-2.8/wx/string.h:1283:3: note:   no known conversion for argument 2 from ‘size_t {aka unsigned int}’ to ‘const void*’
/usr/local/include/wx-2.8/wx/string.h:694:3: note: wxString::wxString(size_t, wxChar) <near match>
/usr/local/include/wx-2.8/wx/string.h:694:3: note:   no known conversion for argument 1 from ‘const wchar_t*’ to ‘size_t {aka unsigned int}’
/usr/local/include/wx-2.8/wx/string.h:692:3: note: wxString::wxString(wxChar, size_t) <near match>
/usr/local/include/wx-2.8/wx/string.h:692:3: note:   no known conversion for argument 1 from ‘const wchar_t*’ to ‘wxChar {aka char}’
```

It causes by there is no matching wxString constructor. My currently solution is using the macro to distinguish wx2.8.12 and wx2.9.4, each wx version using the Corresponding constuctor.

@tturocy please review it.
