### PR TITLE
Throw exception on unbalanced quotes while parsing Savefile, fixes #118

### DIFF
--- a/src/libgambit/file.cc
+++ b/src/libgambit/file.cc
@@ -221,6 +221,8 @@ GameFileToken GameParserState::GetNextToken(void)
 
       ReadChar(a);
       while  (a != '\"' || lastslash)  {
+        if(m_file.eof())
+          throw InvalidFileException(CreateLineMsg("Lexical error while parsing"));
         if (lastslash && a == '"')
           m_lastText += '"';
         else if (lastslash)  {


### PR DESCRIPTION
Raising an exception when EOF is encountered before balancing of quotes.
