### PR TITLE
Use std::unique_ptr on gnmgame class

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -43,6 +43,9 @@
    */
 #undef LT_OBJDIR
 
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
 /* Name of package */
 #undef PACKAGE
 

--- a/src/libgambit/libgambit.h
+++ b/src/libgambit/libgambit.h
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <iomanip>
 #include <config.h>
+#include <memory>
 
 namespace Gambit {
 

--- a/src/tools/gt/cmatrix.h
+++ b/src/tools/gt/cmatrix.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <iomanip>
 #include <vector>
+#include <memory>
 
 using namespace std;
 class cmatrix;

--- a/src/tools/gt/gnmgame.cc
+++ b/src/tools/gt/gnmgame.cc
@@ -28,8 +28,8 @@ gnmgame::gnmgame(int numPlayers, int *actions): numPlayers(numPlayers) {
     numStrategies *= actions[i];
   }
 
-  this->actions = new int[numPlayers];
-  strategyOffset = new int[numPlayers+1];
+  this->actions = std::unique_ptr<int[]>(new int[numPlayers]);
+  strategyOffset = std::unique_ptr<int[]>(new int[numPlayers+1]);
   numActions = 0;
   maxActions = 0;
   for(i = 0; i < numPlayers; i++) {
@@ -43,8 +43,8 @@ gnmgame::gnmgame(int numPlayers, int *actions): numPlayers(numPlayers) {
 }
   
 gnmgame::~gnmgame() {
-  delete[] strategyOffset;
-  delete[] actions;
+ // delete[] strategyOffset;
+ // delete[] actions;
 }
 
 

--- a/src/tools/gt/gnmgame.h
+++ b/src/tools/gt/gnmgame.h
@@ -240,9 +240,9 @@ class gnmgame {
   int Pivot(cmatrix &T, int pr, int pc, std::vector<int> &row, std::vector<int> &col, 
 	    double &D);
 
-  int *strategyOffset;
+  std::unique_ptr<int[]> strategyOffset;
   int numPlayers, numStrategies, numActions;
-  int *actions;
+  std::unique_ptr<int[]> actions;
   int maxActions;
 };
 


### PR DESCRIPTION
Please change line in main Makefile:
CXXFLAGS = .... -std=c++0x

This is my first Gambit pull request and an initial update to C++11 STL. Only one file is class is modified to use unique_ptr. The other files mentioned as candidates in ticket #112 are more problematic. I believe there is an issue of inheritance, so lots of function definitions will need to be changed.
