### PR TITLE
Fix error condition in integer parser

### DIFF
--- a/library/src/file.cc
+++ b/library/src/file.cc
@@ -141,7 +141,7 @@ GameFileToken GameParserState::GetNextToken(void)
       if (c == 'e' || c == 'E') {
         buf += c;
         ReadChar(c);
-        if (c == '+' && c == '-' && !isdigit(c)) {
+        if (c != '+' && c != '-' && !isdigit(c)) {
           throw InvalidFileException(CreateLineMsg("Invalid Token +/-"));
         }
         buf += c;
@@ -171,7 +171,7 @@ GameFileToken GameParserState::GetNextToken(void)
     else if (c == 'e' || c == 'E') {
       buf += c;
       ReadChar(c);
-      if (c == '+' && c == '-' && !isdigit(c)) {
+      if (c != '+' && c != '-' && !isdigit(c)) {
         throw InvalidFileException(CreateLineMsg("Invalid Token +/-"));
       }
       buf += c;


### PR DESCRIPTION
The current condition will always be false (`c` can't be equal to both `'+'` and `'-'`). It seems pretty clear that the following was intended.

Thanks for your time,
Michael McConville
University of Utah