### PR TITLE
Do not package Cython-generated file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -267,7 +267,6 @@ EXTRA_DIST = \
 	src/python/gambit/lib/error.py \
 	src/python/gambit/lib/game.pxi \
 	src/python/gambit/lib/infoset.pxi \
-	src/python/gambit/lib/libgambit.cpp \
 	src/python/gambit/lib/libgambit.pyx \
 	src/python/gambit/lib/mixed.pxi \
 	src/python/gambit/lib/nash.pxi \


### PR DESCRIPTION
The Python interface requires Cython. Therefore, files auto-generated by Cython should not be packaged. This is meant to fix #231 