### PR TITLE
Ongoing attempt at Python 3 support (progress towards #203)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ gambit.wixobj
 gambit.wixpdb
 installer
 config.h
+stamp-h1
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 
 before_install:
 # Preinstalled pip packages: nose setuptools wheel
-  - pip install codecov coverage cython
+  - pip install codecov coverage cython future
 
 install:
 # Building from git repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+branches:
+  only:
+    - future
+os: linux
+dist: trusty
+language: python
+python:
+  - "2.7"
+
+before_install:
+# Preinstalled pip packages: nose setuptools wheel
+  - pip install codecov coverage cython
+
+install:
+# Building from git repository
+  - aclocal
+  - libtoolize
+  - automake --add-missing
+  - autoconf
+  - ./configure --disable-gui
+  - make
+  - sudo make install
+# Building the Python extensions
+  - cd src/python
+  - python setup.py build
+  - sudo env "PATH=$PATH" python setup.py install
+
+script:
+  - cd gambit/tests
+  - nosetests --with-coverage
+
+after_success:
+  - codecov
+
+notifications:
+  email: false

--- a/contrib/demos/poker.py
+++ b/contrib/demos/poker.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import gambit
 
 
@@ -51,9 +52,9 @@ g.root.children[1].children[0].children[0].outcome = bob_big
 g.root.children[1].children[0].children[1].outcome = alice_small
 g.root.children[1].children[1].outcome = bob_small
 
-print g.write()
+print(g.write())
 
-print gambit.gte.write_game(g)
+print(gambit.gte.write_game(g))
 
 file("poker.efg", "w").write(g.write()+"\n")
 file("poker.xml", "w").write(gambit.gte.write_game(g)+"\n")

--- a/contrib/scripts/build/acp.py
+++ b/contrib/scripts/build/acp.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 # This script builds an average cost pricing game
 # (See Chen, Razzolini and Turocy, _Economic Theory_)
 
+from builtins import str
+from builtins import range
 import sys
 import gambit
 
@@ -12,7 +14,7 @@ alphas = [ 48, 54, 58, 60 ]
 omegas = [ 180, 102, 0, 0 ]
 
 # Strategy space
-strats = range(0, 21)
+strats = list(range(0, 21))
 
 # Cost function
 def Cost(q):  return q*q
@@ -27,12 +29,12 @@ def Payoff(alpha, omega, own, others):
     return (gambit.Rational(omega) + gambit.Rational(alpha*own) -
             gambit.Rational(own, total) * gambit.Rational(Cost(total)))
 
-game = gambit.NewTable([ len(strats) for i in xrange(N) ])
+game = gambit.NewTable([ len(strats) for i in range(N) ])
 
 # Label each strategy
-for pl in xrange(N):
+for pl in range(N):
     player = game.GetPlayer(pl+1)
-    for st in xrange(player.NumStrategies()):
+    for st in range(player.NumStrategies()):
         strategy = player.GetStrategy(st+1)
         strategy.SetLabel(str(strats[st]))
 
@@ -44,8 +46,8 @@ for (i, cont) in enumerate(gambit.StrategyIterator(gambit.StrategySupportProfile
     cont.SetOutcome(outcome)
     # This is the vector of choices made in this contingency
     choices = [ int(cont.GetStrategy(pl+1).GetLabel())
-                for pl in xrange(N) ]
-    for pl in xrange(N):
+                for pl in range(N) ]
+    for pl in range(N):
         pay = Payoff(alphas[pl], omegas[pl], choices[pl],
                      choices[:pl] + choices[pl+1:])
         #print pay

--- a/contrib/scripts/build/acp.py
+++ b/contrib/scripts/build/acp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This script builds an average cost pricing game
 # (See Chen, Razzolini and Turocy, _Economic Theory_)
 
@@ -50,4 +51,4 @@ for (i, cont) in enumerate(gambit.StrategyIterator(gambit.StrategySupportProfile
         #print pay
         outcome.SetPayoff(pl+1, pay)
 
-print game.AsNfgFile()
+print(game.AsNfgFile())

--- a/contrib/scripts/build/minint.py
+++ b/contrib/scripts/build/minint.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 #
 
 
+from builtins import range
 import gambit, sys
 
 K = int(sys.argv[2])
@@ -13,7 +14,7 @@ nfg = gambit.NewTable([K for i in range(N)])
 
 # Pre-create outcomes.  Outcome 'i' is the outcome where player 'i' wins.
 
-for pl in xrange(1, nfg.NumPlayers() + 1):
+for pl in range(1, nfg.NumPlayers() + 1):
     outcome = nfg.NewOutcome()
     outcome.SetLabel('%d wins' % pl)
     outcome.SetPayoff(pl, "1")

--- a/contrib/scripts/build/minint.py
+++ b/contrib/scripts/build/minint.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # A Python script to test the Gambit Python wrapper by building
 # the minimum-unique-integer game
@@ -28,4 +29,4 @@ for profile in gambit.StrategyIterator(gambit.StrategySupportProfile(nfg)):
     # If we don't have a winner, leave outcome null, payoffs zero
 
     
-print nfg.AsNfgFile()
+print(nfg.AsNfgFile())

--- a/contrib/scripts/build/nim.py
+++ b/contrib/scripts/build/nim.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 
 
@@ -59,4 +60,4 @@ startPebbles = 5
 tree = torr.BuildTree([ "One", "Two" ], rules, 
                       lambda: NimHistory(0, startPebbles))
 tree.SetTitle("Nim with %d pebbles" % startPebbles)
-print tree.AsEfgFile()
+print(tree.AsEfgFile())

--- a/contrib/scripts/build/nim.py
+++ b/contrib/scripts/build/nim.py
@@ -9,9 +9,12 @@ from __future__ import print_function
 #
 
 # Maximum number of pebbles that can be removed
+from builtins import str
+from builtins import range
+from builtins import object
 K = 2
 
-class NimHistory:
+class NimHistory(object):
     # turn == player in [0,1] who has the turn; pile == number of stones left
     def __init__(self, turn, pile):
         self.turn = turn
@@ -24,20 +27,20 @@ class NimHistory:
 
     def PebblesLeft(self):   return self.pile
 
-class NimMove:
+class NimMove(object):
     def Apply(self, node, history):
         node.SetLabel("%d left" % history.PebblesLeft())
-        moves = xrange(1, min(history.PebblesLeft(), K) + 1)
+        moves = range(1, min(history.PebblesLeft(), K) + 1)
 
         player = node.GetGame().GetPlayer(history.CurrentMove() + 1)
         infoset = node.AppendMove(player, len(moves))
         for (i, move) in enumerate(moves):
             infoset.GetAction(i+1).SetLabel(str(move))
 
-        return [ node.GetChild(i) for i in xrange(1, len(moves)+1) ]
+        return [ node.GetChild(i) for i in range(1, len(moves)+1) ]
 
 
-class NimOutcome:
+class NimOutcome(object):
     def Apply(self, node, history):
         outcome = node.GetGame().NewOutcome()
         for pl in [ 0, 1 ]:

--- a/contrib/scripts/build/poker.py
+++ b/contrib/scripts/build/poker.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # This is an example of how to build poker-type games in Gambit
 #
@@ -53,4 +54,4 @@ rules = [ { "condition": AtRoot,
 
 tree = torr.BuildTree([ "Alice", "Bob" ], rules, torr.GenericHistory)
 
-print tree.AsEfgFile()
+print(tree.AsEfgFile())

--- a/contrib/scripts/build/randomnfg.py
+++ b/contrib/scripts/build/randomnfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # FILE: randomnfg.py -- Create random normal form games in Gambit
 #
@@ -65,7 +66,7 @@ if __name__ == '__main__':
 
     for iter in xrange(eval(sys.argv[1])):
         RandomizeGame(nfg, lambda: random.normalvariate(0, 1))
-        print nfg.AsNfgFile()
+        print(nfg.AsNfgFile())
 
 
         

--- a/contrib/scripts/build/randomnfg.py
+++ b/contrib/scripts/build/randomnfg.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 # call to random.normalvariate() in line 68.
 #
 
+from builtins import map
+from builtins import range
 import random
 import gambit
 
@@ -34,11 +36,11 @@ def CreateNfg(dim):
     nfg = gambit.NewTable(dim)
     profile = gambit.PureStrategyProfile(nfg)
 
-    for cont in CrossProduct([range(1, nfg.GetPlayer(pl).NumStrategies() + 1)
+    for cont in CrossProduct([list(range(1, nfg.GetPlayer(pl).NumStrategies() + 1))
                               for pl in range(1, nfg.NumPlayers() + 1)]):
-        map(lambda pl:
+        list(map(lambda pl:
             profile.SetStrategy(nfg.GetPlayer(pl).GetStrategy(cont[pl-1])),
-            range(1, nfg.NumPlayers() + 1))
+            list(range(1, nfg.NumPlayers() + 1))))
         profile.SetOutcome(nfg.NewOutcome())
     return nfg
     
@@ -55,8 +57,8 @@ def RandomizeGame(game, func):
     number with the desired distribution.
     """
     
-    for outc in xrange(1, game.NumOutcomes() + 1):
-        for pl in xrange(1, game.NumPlayers() + 1):
+    for outc in range(1, game.NumOutcomes() + 1):
+        for pl in range(1, game.NumPlayers() + 1):
            game.GetOutcome(outc).SetPayoff(pl, func())
     
 
@@ -64,7 +66,7 @@ if __name__ == '__main__':
     import sys
     nfg = CreateNfg([eval(sys.argv[i]) for i in range(2, len(sys.argv))]) 
 
-    for iter in xrange(eval(sys.argv[1])):
+    for iter in range(eval(sys.argv[1])):
         RandomizeGame(nfg, lambda: random.normalvariate(0, 1))
         print(nfg.AsNfgFile())
 

--- a/contrib/scripts/build/scp.py
+++ b/contrib/scripts/build/scp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This script builds a serial cost pricing game
 # (See Chen, Razzolini, and Turocy, _Economic Theory_)
 
@@ -69,4 +70,4 @@ for (i, cont) in enumerate(gambit.StrategyIterator(gambit.StrategySupportProfile
         #print pay
         outcome.SetPayoff(pl+1, pay)
 
-print game.AsNfgFile()
+print(game.AsNfgFile())

--- a/contrib/scripts/build/scp.py
+++ b/contrib/scripts/build/scp.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 # This script builds a serial cost pricing game
 # (See Chen, Razzolini, and Turocy, _Economic Theory_)
 
+from builtins import str
+from builtins import range
 import sys
 import gambit
 
@@ -12,7 +14,7 @@ alphas = [ 48, 54, 58, 60 ]
 omegas = [ 60, 20, 0, 0 ]
 
 # Strategy space
-strats = range(0, 21)
+strats = list(range(0, 21))
 
 # Cost function
 def Cost(q):  return q*q
@@ -40,18 +42,18 @@ def Payoff(alpha, omega, own, others):
 
     payoff = gambit.Rational(omega) + gambit.Rational(alpha*own)
 
-    for k in xrange(1, len(lower)+1):
+    for k in range(1, len(lower)+1):
         payoff -= gambit.Rational(Cost(Qsuper(lower, k)) -
                                   Cost(Qsuper(lower, k-1)),
                                   N + 1 - k)
     return payoff
 
-game = gambit.NewTable([ len(strats) for i in xrange(N) ])
+game = gambit.NewTable([ len(strats) for i in range(N) ])
 
 # Label each strategy
-for pl in xrange(N):
+for pl in range(N):
     player = game.GetPlayer(pl+1)
-    for st in xrange(player.NumStrategies()):
+    for st in range(player.NumStrategies()):
         strategy = player.GetStrategy(st+1)
         strategy.SetLabel(str(strats[st]))
 
@@ -63,8 +65,8 @@ for (i, cont) in enumerate(gambit.StrategyIterator(gambit.StrategySupportProfile
     cont.SetOutcome(outcome)
     # This is the vector of choices made in this contingency
     choices = [ int(cont.GetStrategy(pl+1).GetLabel())
-                for pl in xrange(N) ]
-    for pl in xrange(N):
+                for pl in range(N) ]
+    for pl in range(N):
         pay = Payoff(alphas[pl], omegas[pl], choices[pl],
                      choices[:pl] + choices[pl+1:])
         #print pay

--- a/contrib/scripts/build/torr.py
+++ b/contrib/scripts/build/torr.py
@@ -3,9 +3,13 @@
 # TORR is Tree Output by Recursive Rules
 #
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
 import gambit
 
-class ChanceMove:
+class ChanceMove(object):
     def __init__(self, actions, probs):
         self.actions = actions
         self.probs = probs
@@ -20,9 +24,9 @@ class ChanceMove:
             for (i, (name, prob)) in enumerate(zip(self.actions, self.probs)):
                 self.infoset.GetAction(i+1).SetLabel(name)
                 self.infoset.SetActionProb(i+1, str(prob))
-        return [ node.GetChild(i) for i in xrange(1, len(self.actions)+1) ]
+        return [ node.GetChild(i) for i in range(1, len(self.actions)+1) ]
 
-class Move:
+class Move(object):
     def __init__(self, player, actions):
         self.player = player
         self.actions = actions
@@ -36,9 +40,9 @@ class Move:
                                            len(self.actions))
             for (i, name) in enumerate(self.actions):
                 self.infoset.GetAction(i+1).SetLabel(name)
-        return [ node.GetChild(i) for i in xrange(1, len(self.actions)+1) ]
+        return [ node.GetChild(i) for i in range(1, len(self.actions)+1) ]
             
-class TerminalPayoff:
+class TerminalPayoff(object):
     def __init__(self, payoffs):
         self.payoffs = payoffs
 
@@ -52,7 +56,7 @@ class TerminalPayoff:
         return [ ]
         
 
-class GenericHistory:
+class GenericHistory(object):
     def __init__(self, actions = [ ]):
         self.actions = actions[:]
 

--- a/contrib/scripts/build/ttt.py
+++ b/contrib/scripts/build/ttt.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 
 
+from builtins import str
+from builtins import range
+from builtins import object
 import copy
 
 boardsize = 3
@@ -9,7 +12,7 @@ boardsize = 3
 # Represents a tic-tac-toe board.
 # Board coordinates are (i, j), i,j=0,1,2.
 #
-class TicTacToeHistory:
+class TicTacToeHistory(object):
     def __init__(self, board = [ [ "" for i in range(boardsize) ] for j in range(boardsize) ]):
         self.board = copy.deepcopy(board)
 
@@ -20,7 +23,7 @@ class TicTacToeHistory:
 
     def CurrentMove(self):
         filled = len([ (row, col)
-                       for row in xrange(boardsize) for col in xrange(boardsize)
+                       for row in range(boardsize) for col in range(boardsize)
                        if self.board[row][col] != "" ])
         if filled % 2 == 0:
             return "X"
@@ -28,28 +31,28 @@ class TicTacToeHistory:
             return "O"
 
     def IsWin(self, pl):
-        winconfig = [ pl for i in xrange(boardsize) ]
-        for row in xrange(boardsize):
+        winconfig = [ pl for i in range(boardsize) ]
+        for row in range(boardsize):
             if self.board[row] == winconfig:
                 return True
-        for col in xrange(boardsize):
+        for col in range(boardsize):
             if [ row[col] for row in self.board ] == winconfig:
                 return True
-        if [ self.board[i][i] for i in xrange(boardsize) ] == winconfig:
+        if [ self.board[i][i] for i in range(boardsize) ] == winconfig:
             return True
-        if [ self.board[boardsize-i-1][i] for i in xrange(boardsize) ] == winconfig:
+        if [ self.board[boardsize-i-1][i] for i in range(boardsize) ] == winconfig:
             return True
         return False
 
     def IsFull(self):
-        return len([ (row, col) for row in xrange(boardsize) for col in xrange(boardsize)
+        return len([ (row, col) for row in range(boardsize) for col in range(boardsize)
                      if self.board[row][col] == "" ]) == 0
 
     def EmptySquares(self):
-        return [ (row, col) for row in xrange(boardsize) for col in xrange(boardsize)
+        return [ (row, col) for row in range(boardsize) for col in range(boardsize)
                  if self.board[row][col] == "" ]
 
-class TicTacToeMove:
+class TicTacToeMove(object):
     def Apply(self, node, history):
         moves = history.EmptySquares()
 
@@ -62,7 +65,7 @@ class TicTacToeMove:
         for (i, move) in enumerate(moves):
             infoset.GetAction(i+1).SetLabel(str(move))
 
-        return [ node.GetChild(i) for i in xrange(1, len(moves)+1) ]
+        return [ node.GetChild(i) for i in range(1, len(moves)+1) ]
 
 
 import torr

--- a/contrib/scripts/build/ttt.py
+++ b/contrib/scripts/build/ttt.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 
 import copy
@@ -85,5 +86,5 @@ rules = [ { "condition": lambda history: history.IsWin("X"),
 
 
 tree = torr.BuildTree([ "X", "O" ], rules, TicTacToeHistory)
-print tree.AsEfgFile()
+print(tree.AsEfgFile())
 

--- a/contrib/scripts/enumpoly/countsupport.py
+++ b/contrib/scripts/enumpoly/countsupport.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import random
 import enumphc
@@ -20,7 +21,7 @@ if __name__ == '__main__':
                    for player in game.Players()
                    for strategy in player.Strategies() ]
 
-    print "ownuser,ownsystem,childuser,childsystem,supports,singular,nash,nonnash"
+    print("ownuser,ownsystem,childuser,childsystem,supports,singular,nash,nonnash")
     for iter in xrange(int(argv[1])):
         randomnfg.RandomizeGame(game, lambda: random.normalvariate(0, 1))
         #file("game-%04d.nfg" % iter, "w").write(game.AsNfgFile())

--- a/contrib/scripts/enumpoly/countsupport.py
+++ b/contrib/scripts/enumpoly/countsupport.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import range
 import random
 import enumphc
 import randomnfg
@@ -22,7 +23,7 @@ if __name__ == '__main__':
                    for strategy in player.Strategies() ]
 
     print("ownuser,ownsystem,childuser,childsystem,supports,singular,nash,nonnash")
-    for iter in xrange(int(argv[1])):
+    for iter in range(int(argv[1])):
         randomnfg.RandomizeGame(game, lambda: random.normalvariate(0, 1))
         #file("game-%04d.nfg" % iter, "w").write(game.AsNfgFile())
         logger = enumphc.CountLogger()

--- a/contrib/scripts/enumpoly/enumpoly.py
+++ b/contrib/scripts/enumpoly/enumpoly.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Compute all equilibria of a strategic game using support enumeration.
 #
@@ -17,6 +18,7 @@
 import gambit
 import phc
 import time, os
+from functools import reduce
 
 
 #############################################################################
@@ -235,8 +237,8 @@ class BertiniSolver(SupportSolver):
                 outfile = file("real_finite_solutions")
                 lines = iter(outfile)
 
-                lines.next()
-                lines.next()
+                next(lines)
+                next(lines)
                 while lines.next().strip() != "-1":
                     solution = { }
                     solution["vars"] = { }
@@ -269,8 +271,8 @@ class NullLogger:
 
 class StandardLogger(NullLogger):
     def OnNashSolution(self, profile):
-        print "NE," + ",".join(["%f" % max(profile[i], 0.0)
-                                for i in xrange(1, profile.MixedProfileLength() + 1)])
+        print("NE," + ",".join(["%f" % max(profile[i], 0.0)
+                                for i in xrange(1, profile.MixedProfileLength() + 1)]))
 
 class VerboseLogger(StandardLogger):
     def PrintSupport(self, support, label):
@@ -278,7 +280,7 @@ class VerboseLogger(StandardLogger):
                            [ str(int(support.Contains(strategy)))
                              for strategy in player.Strategies() ])
                     for player in support.Players() ]
-        print label + "," + ",".join(strings)
+        print(label + "," + ",".join(strings))
 
     def OnCandidateSupport(self, support):
         self.PrintSupport(support, "candidate")

--- a/contrib/scripts/enumpoly/enumpoly.py
+++ b/contrib/scripts/enumpoly/enumpoly.py
@@ -15,6 +15,10 @@ from __future__ import print_function
 #     Bertini (external binary required)
 #
 
+from builtins import next
+from builtins import str
+from builtins import range
+from builtins import object
 import gambit
 import phc
 import time, os
@@ -80,7 +84,7 @@ def Equations(support, player):
 #############################################################################
 
 def IsNash(profile, vars):
-    for i in xrange(1, profile.MixedProfileLength()+1):
+    for i in range(1, profile.MixedProfileLength()+1):
         if profile[i] < -negTolerance: return False
 
     for (pl, player) in enumerate(profile.GetGame().Players()):
@@ -88,7 +92,7 @@ def IsNash(profile, vars):
         payoff = profile.GetPayoff(player)
         total = 0.0
         for (st, strategy) in enumerate(player.Strategies()):
-            if "%s%d" % (playerchar, st) not in vars.keys():
+            if "%s%d" % (playerchar, st) not in list(vars.keys()):
                 if profile.GetStrategyValue(strategy) - payoff > payoffTolerance:
                     return False
             else:
@@ -116,7 +120,7 @@ def CheckEquilibrium(game, support, entry, logger):
         entry["vars"][playerchar + str(support.GetStrategy(pl+1,1).GetNumber()-1)] = complex(1.0 - total)
 
     x = ",".join([ "%f" % profile[i]
-                   for i in xrange(1, game.MixedProfileLength() + 1)])
+                   for i in range(1, game.MixedProfileLength() + 1)])
     if IsNash(profile, entry["vars"]):
         logger.OnNashSolution(profile)
     else:
@@ -131,7 +135,7 @@ def IsPureSupport(support):
 def ProfileFromPureSupport(game, support):
     profile = game.NewMixedStrategyDouble()
 
-    for index in xrange(1, game.MixedProfileLength() + 1):
+    for index in range(1, game.MixedProfileLength() + 1):
         profile[index] = 0.0
 
     for (pl, player) in enumerate(support.Players()):
@@ -144,7 +148,7 @@ def ProfileFromPureSupport(game, support):
 # Solver classes
 #############################################################################
 
-class SupportSolver:
+class SupportSolver(object):
     def __init__(self, logger):
         self.logger = logger
 
@@ -212,13 +216,13 @@ class BertiniSolver(SupportSolver):
 
         variables = [ ]
         for (pl, player) in enumerate(game.Players()):
-            for st in xrange(support.NumStrategies(pl+1) - 1):
+            for st in range(support.NumStrategies(pl+1) - 1):
                 variables.append("%c%d" % (playerletters[pl], st+1))
                            
         bertiniInput = "CONFIG\n\nEND;\n\nINPUT\n\n"
         bertiniInput += "variable_group %s;\n" % ", ".join(variables)
         bertiniInput += "function %s;\n\n" % ", ".join([ "e%d" % i
-                                                         for i in xrange(len(eqns)) ])
+                                                         for i in range(len(eqns)) ])
 
         for (eq, eqn) in enumerate(eqns):
             bertiniInput += "e%d = %s\n" % (eq, eqn)
@@ -263,7 +267,7 @@ class BertiniSolver(SupportSolver):
 # Logger classes for storing and reporting output
 #############################################################################
 
-class NullLogger:
+class NullLogger(object):
     def OnCandidateSupport(self, support): pass
     def OnSingularSupport(self, support): pass
     def OnNashSolution(self, profile): pass
@@ -272,7 +276,7 @@ class NullLogger:
 class StandardLogger(NullLogger):
     def OnNashSolution(self, profile):
         print("NE," + ",".join(["%f" % max(profile[i], 0.0)
-                                for i in xrange(1, profile.MixedProfileLength() + 1)]))
+                                for i in range(1, profile.MixedProfileLength() + 1)]))
 
 class VerboseLogger(StandardLogger):
     def PrintSupport(self, support, label):
@@ -290,11 +294,11 @@ class VerboseLogger(StandardLogger):
     def OnNonNashSolution(self, profile):
         print ("noneqm," +
                ",".join([str(profile[i])
-                         for i in xrange(1, profile.MixedProfileLength() + 1)]) +
+                         for i in range(1, profile.MixedProfileLength() + 1)]) +
                "," + str(profile.GetLiapValue()))
                                 
         
-class CountLogger:
+class CountLogger(object):
     def __init__(self):
         self.candidates = 0
         self.singulars = 0

--- a/contrib/scripts/enumpoly/phc.py
+++ b/contrib/scripts/enumpoly/phc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 
 ###########################################################################
@@ -112,10 +113,10 @@ def RunPHC(phcpath, filename, equations):
         outfile.close()
     else:
         # For convenience, print the equation sets that cause problems
-        print equations
+        print(equations)
         os.remove(infilename)
         os.remove(outfilename)
-        raise ValueError, "PHC run failed"
+        raise ValueError("PHC run failed")
     
     os.remove(outfilename)
     os.remove(infilename)
@@ -130,7 +131,7 @@ if __name__ == '__main__':
                     "b1 + b2 - 1;\n"
                     "a2 - a1;\n"
                     "a1 + a2 - 1;\n")
-    print output
+    print(output)
 
     # 2x2x2.nfg, full support
     output = RunPHC("./phc", "foo",
@@ -142,4 +143,4 @@ if __name__ == '__main__':
                     "b1+b2-1;\n"
                     "c1+c2-1;\n"
                     )
-    print output
+    print(output)

--- a/contrib/scripts/tools/msgame.py
+++ b/contrib/scripts/tools/msgame.py
@@ -2,6 +2,9 @@
 Implementation of mean statistic games for Gambit
 """
 
+from builtins import str
+from builtins import range
+from builtins import object
 import csv
 import gambit
 
@@ -31,7 +34,7 @@ class MSGame(object):
     def __init__(self, N, contribs):
         self.N = N
         self.contribs = contribs
-        self.statistics = xrange((self.N-1)*min(self.contribs),
+        self.statistics = range((self.N-1)*min(self.contribs),
                                  (self.N-1)*max(self.contribs)+1)
     def AsTable(self):
         return [ [ own, others, self.Payoff(own, others) ]
@@ -45,7 +48,7 @@ class MSGame(object):
                  for own in self.statistics ]
             
     def AsNfg(self):
-        game = gambit.NewTable([ len(self.contribs) for i in xrange(self.N) ])
+        game = gambit.NewTable([ len(self.contribs) for i in range(self.N) ])
 
         # Label each strategy by its contribution
         for (pl, player) in enumerate(game.Players()):
@@ -59,8 +62,8 @@ class MSGame(object):
             cont.SetOutcome(outcome)
             # This is the vector of choices made in this contingency
             choices = [ int(cont.GetStrategy(pl+1).GetLabel())
-                        for pl in xrange(self.N) ]
-            for pl in xrange(self.N):
+                        for pl in range(self.N) ]
+            for pl in range(self.N):
                 outcome.SetPayoff(pl+1,
                                   self.Payoff(choices[pl],
                                               sum(choices)-choices[pl]))

--- a/contrib/scripts/tools/qretools.py
+++ b/contrib/scripts/tools/qretools.py
@@ -1,7 +1,10 @@
 """
 A set of utilities for computing and analyzing quantal response equilbria
 """
+from __future__ import division
 
+from past.utils import old_div
+from builtins import object
 import os, sys
 import gambit
 
@@ -60,9 +63,9 @@ def PlotAverages(profiles):
         return
 
     ax = pylab.subplot(111)
-    p = pylab.plot([ qre.lam/(1.0+qre.lam) for qre in profiles ],
+    p = pylab.plot([ old_div(qre.lam,(1.0+qre.lam)) for qre in profiles ],
                    [ qre.ExpectedChoice()[0] for qre in profiles ])
-    ax.xaxis.set_major_formatter(matplotlib.ticker.FuncFormatter(lambda x, pos: "%.2f" % (x/(1.0-x))))
+    ax.xaxis.set_major_formatter(matplotlib.ticker.FuncFormatter(lambda x, pos: "%.2f" % (old_div(x,(1.0-x)))))
     
     pylab.show()
     

--- a/src/python/gambit/__init__.py
+++ b/src/python/gambit/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #
 # This file is part of Gambit
 # Copyright (c) 1994-2016, The Gambit Project (http://www.gambit-project.org)
@@ -21,8 +22,8 @@
 #
 
 import gambit.lib.libgambit
-import nash
-import gte
+from . import nash
+from . import gte
 
 __version__ = gambit.lib.libgambit.__version__
 Rational = gambit.lib.libgambit.Rational

--- a/src/python/gambit/enumeration.py
+++ b/src/python/gambit/enumeration.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 
+from builtins import object
 class SupportEnumeration(object):
     def enumerate_supports(self, game):
         return self.admissible_supports(game.support_profile(), list(game.strategies))
@@ -33,7 +34,7 @@ class SupportEnumeration(object):
             profile = temp_profile
 
         # Step 2: y' and z'
-        new_rest = filter(lambda x: x in list(profile), str_rest)
+        new_rest = [x for x in str_rest if x in list(profile)]
 
         # Step 3: return x if z' is empty
         if not new_rest:

--- a/src/python/gambit/gameiter.py
+++ b/src/python/gambit/gameiter.py
@@ -23,6 +23,7 @@
 Iterator tools over games in pure Python.
 """
 
+from builtins import object
 class Contingencies(object):
     """
     An object representing the contingencies of strategies in a strategic game.

--- a/src/python/gambit/games/contest.py
+++ b/src/python/gambit/games/contest.py
@@ -23,8 +23,9 @@
 """
 Implementation of contest games.
 """
+from __future__ import absolute_import
 
-import meanstat
+from . import meanstat
 from gambit.lib.libgambit import Rational
 
 class TullockGame(meanstat.MeanStatisticGame):

--- a/src/python/gambit/games/contest.py
+++ b/src/python/gambit/games/contest.py
@@ -24,7 +24,9 @@
 Implementation of contest games.
 """
 from __future__ import absolute_import
+from __future__ import division
 
+from past.utils import old_div
 from . import meanstat
 from gambit.lib.libgambit import Rational
 
@@ -93,7 +95,7 @@ class GeneralTullockGame(meanstat.MeanStatisticGame):
             p_own = math.pow(own, self.r)
             p_other = math.pow(other, self.r)
         try:
-            p_win = p_own / (p_own + p_other)
+            p_win = old_div(p_own, (p_own + p_other))
             return p_win * (self.omega - self.cost(own) + self.prize) + \
                    (1.0-p_win) * (self.omega - self.cost(own))
         except ZeroDivisionError:

--- a/src/python/gambit/games/meanstat.py
+++ b/src/python/gambit/games/meanstat.py
@@ -133,22 +133,22 @@ class MeanStatisticGame(object):
     def __getitem__(self, key):
         key = list(key)
         if len(key) != self.N:
-            raise KeyError, "number of strategies != number of players"
+            raise KeyError("number of strategies != number of players")
         for i in xrange(len(key)):
             if isinstance(key[i], int):
                 if key[i] < 0 or key[i] >= len(self.choices):
-                    raise IndexError, "index %d out of range" % i
+                    raise IndexError("index %d out of range" % i)
             elif isinstance(key[i], str):
                 try:
                     key[i] = [ x.label for x in self.players[i].strategies ].index(key[i])
                 except ValueError:
-                    raise IndexError, "index %d not found" % i
+                    raise IndexError("index %d not found" % i)
             elif isinstance(key[i], Strategy):
                 if key[i].player != self.players[i]:
-                    raise IndexError, "strategy %d for wrong player" % i
+                    raise IndexError("strategy %d for wrong player" % i)
                 key[i] = key[i].st
             else:
-                raise TypeError, "unknown index type for index %d" % i
+                raise TypeError("unknown index type for index %d" % i)
         return Outcome(self, tuple(key))
 
     def __setitem__(self, key, value):
@@ -197,7 +197,7 @@ class MixedStrategyProfile(object):
 
     def __add__(self, other):
         if not hasattr(other, "game") or other.game != self.game:
-            raise ValueError, "adding a non-MixedProfile to a MixedProfile"
+            raise ValueError("adding a non-MixedProfile to a MixedProfile")
         p = self.game.mixed_strategy_profile()
         for i in xrange(len(self)):
             p[i] = self[i] + other[i]

--- a/src/python/gambit/games/meanstat.py
+++ b/src/python/gambit/games/meanstat.py
@@ -46,6 +46,8 @@ class Strategy(object):
     def __ne__(self, other):
         if not isinstance(other, Strategy):  return True
         return self.player != other.player or self.st != other.st
+    def __hash__(self):
+        return hash((self.player, self.st))
     @property
     def label(self):   return self.player.game.labels[self.st]
         
@@ -74,6 +76,8 @@ class Player(object):
     def __ne__(self, other):
         if not isinstance(other, Player):  return True
         return self.game != other.game or self.pl != other.pl
+    def __hash__(self):
+        return hash((self.game, self.pl))
     @property
     def strategies(self):    return Strategies(self)
     @property
@@ -102,6 +106,8 @@ class Outcome(object):
     def __ne__(self, other):
         if not isinstance(other, Outcome):  return True
         return self.game != other.game or self.index != other.index
+    def __hash__(self):
+        return hash((self.game, self.index))
     def __getitem__(self, pl):
         if not isinstance(pl, int) or pl < 0 or pl >= self.game.N:
             raise IndexError

--- a/src/python/gambit/games/meanstat.py
+++ b/src/python/gambit/games/meanstat.py
@@ -24,7 +24,12 @@
 """
 Representation of mean-statistic games.
 """
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import gambit
 
 class Strategy(object):
@@ -117,9 +122,9 @@ class MeanStatisticGame(object):
     def __init__(self, N, min_choice, max_choice, step_choice=1,
                  label_prefix="S"):
         self.N = N
-        self.choices = xrange(min_choice, max_choice+1, step_choice)
+        self.choices = range(min_choice, max_choice+1, step_choice)
         self.labels = [ label_prefix+str(c) for c in self.choices ]
-        self.statistics = xrange((self.N-1)*min(self.choices),
+        self.statistics = range((self.N-1)*min(self.choices),
                                  (self.N-1)*max(self.choices)+1,
                                  step_choice)
 
@@ -134,7 +139,7 @@ class MeanStatisticGame(object):
         key = list(key)
         if len(key) != self.N:
             raise KeyError("number of strategies != number of players")
-        for i in xrange(len(key)):
+        for i in range(len(key)):
             if isinstance(key[i], int):
                 if key[i] < 0 or key[i] >= len(self.choices):
                     raise IndexError("index %d out of range" % i)
@@ -159,13 +164,13 @@ class MeanStatisticGame(object):
 
     def to_table(self):
         g = gambit.new_table([ len(self.choices) ] * self.N)
-        for pl in xrange(self.N):
+        for pl in range(self.N):
             for (st, label) in enumerate(self.labels):
                 g.players[pl].strategies[st].label = label
         for cont in g.contingencies:
             g_outc = g[cont]
             t_outc = self[cont]
-            for pl in xrange(self.N):
+            for pl in range(self.N):
                 g_outc[pl] = t_outc[pl]
         return g
 
@@ -187,11 +192,11 @@ class MixedStrategyProfile(object):
     def __repr__(self):
         return "Mixed strategy profile on '%s': [%s]" % \
                (self.game.title,
-                ", ".join([ str(self[i]) for i in xrange(len(self)) ]))
+                ", ".join([ str(self[i]) for i in range(len(self)) ]))
 
     def __rmul__(self, fac):
         p = self.game.mixed_strategy_profile()
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             p[i] = fac * self[i]
         return p
 
@@ -199,17 +204,17 @@ class MixedStrategyProfile(object):
         if not hasattr(other, "game") or other.game != self.game:
             raise ValueError("adding a non-MixedProfile to a MixedProfile")
         p = self.game.mixed_strategy_profile()
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             p[i] = self[i] + other[i]
         return p
 
     def set_centroid(self):
-        self.profile = [ 1.0 / len(self.game.choices) for i in self.game.choices ]
+        self.profile = [ old_div(1.0, len(self.game.choices)) for i in self.game.choices ]
 
     def normalize(self):
         den = sum(self.profile)
         if den != 0:
-            self.profile = [ x/den for x in self.profile ]
+            self.profile = [ old_div(x,den) for x in self.profile ]
                 
     def strategy_value(self, st):
         return sum([ prob * self.game.payoff(self.game.choices[st],
@@ -255,17 +260,17 @@ class MixedStrategyProfile(object):
         elif K == 1:
             return prob
         elif K == 2:
-            v = [ 0.0 for i in xrange(2*len(prob)-1) ]
+            v = [ 0.0 for i in range(2*len(prob)-1) ]
             for (i, p) in enumerate(prob):
                 for (j, q) in enumerate(prob):
                     v[i+j] += p*q
             return v
         else:
-            K1 = K / 2
-            K2 = K / 2 + K % 2
+            K1 = old_div(K, 2)
+            K2 = old_div(K, 2) + K % 2
             v1 = self.sum_dist(K1, prob)
             v2 = self.sum_dist(K2, prob)
-            v = [ 0.0 for i in xrange(len(v1)+len(v2)-1) ]
+            v = [ 0.0 for i in range(len(v1)+len(v2)-1) ]
             for (i, p) in enumerate(v1):
                 for (j, q) in enumerate(v2):
                     v[i+j] += p*q

--- a/src/python/gambit/games/public.py
+++ b/src/python/gambit/games/public.py
@@ -23,8 +23,9 @@
 """
 Voluntary public-goods contribution games.
 """
+from __future__ import absolute_import
 
-import meanstat
+from . import meanstat
 
 class CobbDouglasVCGame(meanstat.MeanStatisticGame):
     """

--- a/src/python/gambit/gte.py
+++ b/src/python/gambit/gte.py
@@ -63,7 +63,7 @@ def read_game(f):
         raise NotImplementedError("Reading and writing GTE files requires lxml module.")
     tree = etree.parse(f)
     if tree.xpath("/gte/@version")[0] != "0.1":
-        raise ValueError, "GTE reader only supports version 0.1"
+        raise ValueError("GTE reader only supports version 0.1")
 
     g = gambit.lib.libgambit.new_tree()
     for p in tree.xpath("/gte/players/player"):

--- a/src/python/gambit/gte.py
+++ b/src/python/gambit/gte.py
@@ -24,6 +24,7 @@
 File format interface with Game Theory Explorer
 """
 
+from builtins import str
 from fractions import Fraction
 try:
     from lxml import etree

--- a/src/python/gambit/levelk.py
+++ b/src/python/gambit/levelk.py
@@ -22,6 +22,7 @@
 """
 Provides support for level-k/cognitive hierarchy modeling
 """
+from __future__ import print_function
 
 import math
 import scipy.optimize
@@ -104,7 +105,7 @@ def fit_coghier(game, data, min_tau, max_tau, min_lam, max_lam,
     results = [ ]
     for lam in scipy.linspace(min_lam, max_lam, grid_size):
         if verbose:
-            print "Searching lambda=%.3f" % lam
+            print("Searching lambda=%.3f" % lam)
         for tau in scipy.linspace(min_tau, max_tau, grid_size):
             profile = compute_coghier(game, tau, lam)
             profile.logL = log_like(profile, data)
@@ -112,12 +113,12 @@ def fit_coghier(game, data, min_tau, max_tau, min_lam, max_lam,
         results.sort(lambda x, y: cmp(y.logL, x.logL))
         results = results[:sample_cands]
         if verbose:
-            print "tau,lam,logL"
+            print("tau,lam,logL")
             for profile in results:
-                print "%f,%f,%f" % (profile.tau, profile.lam, profile.logL)
-            print
+                print("%f,%f,%f" % (profile.tau, profile.lam, profile.logL))
+            print()
 
-    if verbose: print
+    if verbose: print()
     for start in results[:sample_cands]:
         params = scipy.optimize.fmin(lambda x: objective(x, game, data),
                                      (start.tau, start.lam),
@@ -127,7 +128,7 @@ def fit_coghier(game, data, min_tau, max_tau, min_lam, max_lam,
         profile.logL = log_like(profile, data)
         results.append(profile)
         if verbose:
-            print "%f,%f,%f" % (profile.tau, profile.lam, profile.logL)
+            print("%f,%f,%f" % (profile.tau, profile.lam, profile.logL))
     results.sort(lambda x, y: cmp(y.logL, x.logL))
     return results[0]
                             

--- a/src/python/gambit/levelk.py
+++ b/src/python/gambit/levelk.py
@@ -23,7 +23,12 @@
 Provides support for level-k/cognitive hierarchy modeling
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.builtins import cmp
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 import math
 import scipy.optimize
 import scipy.stats
@@ -32,14 +37,14 @@ from gambit.profiles import Solution
 def logit_br(game, profile, lam):
     def do_sum(maxi, logpi, lam, values):
         logp = [ logpi + lam * (values[j] - values[maxi])
-                for j in xrange(len(values)) ]
+                for j in range(len(values)) ]
         return sum([ math.exp(p) for p in logp ]) - 1.0
     values = profile.strategy_values()
     maxi = values.index(max(values))
     logp0 = scipy.optimize.newton(lambda x: do_sum(maxi, x, lam, values),
                                   0.0)
     br = game.mixed_strategy_profile()
-    for i in xrange(len(profile)):
+    for i in range(len(profile)):
         br[i] = math.exp(logp0 + lam*(values[i]-values[maxi]))
     return br
 
@@ -69,10 +74,10 @@ def compute_coghier(game, tau, lam):
     if tau <= 0.0 or lam <= 0.0:
         return CognitiveHierarchyProfile(tau, lam, p)
     accum = float(scipy.stats.poisson(tau).pmf(0))
-    for k in xrange(1, max(3, int(5*tau))):
+    for k in range(1, max(3, int(5*tau))):
         br = logit_br(game, p, lam=lam)
         prob = float(scipy.stats.poisson(tau).pmf(k))
-        p = (1.0/(prob+accum)) * (prob*br + accum*p)
+        p = (old_div(1.0,(prob+accum))) * (prob*br + accum*p)
         accum += prob
     return CognitiveHierarchyProfile(tau, lam, p)
 

--- a/src/python/gambit/lib/behav.pxi
+++ b/src/python/gambit/lib/behav.pxi
@@ -21,6 +21,7 @@
 #
 from libcpp cimport bool
 from cython.operator cimport dereference as deref
+from functools import reduce
 
 cdef class MixedBehaviorProfile(object):
     def __repr__(self):    

--- a/src/python/gambit/lib/behav.pxi
+++ b/src/python/gambit/lib/behav.pxi
@@ -106,6 +106,8 @@ cdef class MixedBehaviorProfile(object):
                     self.infoset = infoset
                 def __eq__(self, other):
                     return list(self) == list(other)
+                def __hash__(self):
+                    return hash(list(self))
                 def __len__(self):
                     return len(self.infoset.actions)
                 def __repr__(self):
@@ -127,6 +129,8 @@ cdef class MixedBehaviorProfile(object):
                     self.player = player
                 def __eq__(self, other):
                     return list(self) == list(other)
+                def __hash__(self):
+                    return hash(list(self))
                 def __len__(self):
                     return len(self.player.infosets)
                 def __repr__(self):

--- a/src/python/gambit/lib/mixed.pxi
+++ b/src/python/gambit/lib/mixed.pxi
@@ -83,6 +83,8 @@ cdef class MixedStrategyProfile(object):
                     self.player = player
                 def __eq__(self, other):
                     return list(self) == list(other)
+                def __hash__(self):
+                    return hash(list(self))
                 def __len__(self):
                     return len(self.player.strategies)
                 def __repr__(self):

--- a/src/python/gambit/lib/mixed.pxi
+++ b/src/python/gambit/lib/mixed.pxi
@@ -23,6 +23,7 @@ import itertools
 
 from cython.operator cimport dereference as deref
 from gambit.lib.error import UndefinedOperationError
+from functools import reduce
 
 
 cdef class MixedStrategyProfile(object):

--- a/src/python/gambit/lib/stratspt.pxi
+++ b/src/python/gambit/lib/stratspt.pxi
@@ -22,6 +22,7 @@
 import itertools
 from cython.operator cimport dereference as deref
 from gambit.lib.error import UndefinedOperationError
+from functools import reduce
 
 cdef class StrategySupportProfile(Collection):
     """

--- a/src/python/gambit/nash.py
+++ b/src/python/gambit/nash.py
@@ -23,6 +23,7 @@
 A set of utilities for computing Nash equilibria
 """
 
+from builtins import object
 import sys
 import subprocess
 from fractions import Fraction

--- a/src/python/gambit/pctrace.py
+++ b/src/python/gambit/pctrace.py
@@ -22,6 +22,7 @@
 """
 Trace a smooth parameterized curve using a predictor-corrector method.
 """
+from __future__ import print_function
 
 import math
 import numpy
@@ -163,7 +164,7 @@ def trace_path(start, startLam, maxLam, compute_lhs, compute_jac,
         newT = q[-1]    # new tangent
         if sum(t * newT) < 0.0:
             # Bifurcation detected
-            print "Detected bifurcation near %f" % x[-1]
+            print("Detected bifurcation near %f" % x[-1])
 
             omega = -omega
         t = newT[:]
@@ -252,7 +253,7 @@ def newt(q, b, u, v, w, p, pv, r, pert, dmax, dmin, ctmax, cdmax,
     d1 = ynorm(w)
 
     if d1 > dmax:
-        print "newt: fail on LHS norm test"
+        print("newt: fail on LHS norm test")
         return False, r, v
 
     for k in xrange(n):
@@ -276,7 +277,7 @@ def newt(q, b, u, v, w, p, pv, r, pert, dmax, dmin, ctmax, cdmax,
     d3 = ynorm(p)
     contr = d3 / (d1 + dmin)
     if contr > ctmax:
-        print "newt: fail on contraction test"
+        print("newt: fail on contraction test")
         test = False
     
     for k in reversed(xrange(n-1)):
@@ -289,7 +290,7 @@ def newt(q, b, u, v, w, p, pv, r, pert, dmax, dmin, ctmax, cdmax,
         givens(b, q, b[k,k], b[k+1,k], k, k+1, k)
 
     if b[n-1,n-1] < 0.0:
-        print "newt: fail on diagonal sign test"
+        print("newt: fail on diagonal sign test")
         test = False
         b[n-1,n-1] = -b[n-1,n-1]
         for k in xrange(n1):
@@ -299,7 +300,7 @@ def newt(q, b, u, v, w, p, pv, r, pert, dmax, dmin, ctmax, cdmax,
     for i in xrange(1,n):
         for k in xrange(i-1):
             if abs(b[k,i]) > cdmax * abs(b[i,i]):
-                print "... reconditioning ..."
+                print("... reconditioning ...")
                 if b[i,i] > 0.0:
                     b[i,i] = abs(b[k,i]) / cdmax
                 else:
@@ -392,15 +393,15 @@ def trace_path_nojac(start, startLam, maxLam, compute_lhs,
 
         # Predictor step
         u = x + h*omega*t
-        print "PREDICTOR"
+        print("PREDICTOR")
         callback(u)
         w = compute_lhs(u)
-        print w
-        print ynorm(w)
+        print(w)
+        print(ynorm(w))
 
         test = upd(q, b, x, u, y, w, t, h, angmax)
         if not test:
-            print "Fail angle test..."
+            print("Fail angle test...")
             h = h / acfac
             q = qq
             b = bb
@@ -409,7 +410,7 @@ def trace_path_nojac(start, startLam, maxLam, compute_lhs,
         test, r, v = newt(q, b, u, v, w, p, pv, r, pert, dmax, dmin, ctmax, cdmax,
                        compute_lhs)
         if not test:
-            print "Fail Newton test..."
+            print("Fail Newton test...")
             h = h / acfac
             q = qq
             b = bb
@@ -432,11 +433,11 @@ def trace_path_nojac(start, startLam, maxLam, compute_lhs,
         y = r[:]
 
         if callback is not None:
-            print "ACCEPTED"
+            print("ACCEPTED")
             callback(x)
-        print y
-        print ynorm(y)
-        print
+        print(y)
+        print(ynorm(y))
+        print()
         
     return x
 

--- a/src/python/gambit/profiles.py
+++ b/src/python/gambit/profiles.py
@@ -32,5 +32,5 @@ class Solution(object):
     def __len__(self):            return len(self._profile)
     def __getitem__(self, i):     return self._profile[i]
     def __setitem__(self, i, v):
-        raise TypeError, "solution profile object does not support probability assignment"
+        raise TypeError("solution profile object does not support probability assignment")
     def __getattr__(self, attr):  return getattr(self._profile, attr)

--- a/src/python/gambit/profiles.py
+++ b/src/python/gambit/profiles.py
@@ -23,6 +23,7 @@
 Base classes for strategy profiles.
 """
 
+from builtins import object
 class Solution(object):
     """
     Generic object representing a strategy profile which is

--- a/src/python/gambit/qre.py
+++ b/src/python/gambit/qre.py
@@ -22,10 +22,12 @@
 """
 A set of utilities for computing and analyzing quantal response equilbria
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import math
 import numpy
-import pctrace
+from . import pctrace
 
 from gambit.profiles import Solution
 
@@ -91,7 +93,7 @@ def sym_compute_jac(game, point):
 def printer(game, point):
     profile = game.mixed_strategy_profile(point=[math.exp(x) for x in point[:-1]])
     lam = point[-1]
-    print lam, profile
+    print(lam, profile)
 
 
 
@@ -246,7 +248,7 @@ class StrategicQREPathTracer(object):
             raise NotImplementedError
         
 
-from nash import ExternalSolver
+from .nash import ExternalSolver
     
 class ExternalStrategicQREPathTracer(ExternalSolver):
     """

--- a/src/python/gambit/qre.py
+++ b/src/python/gambit/qre.py
@@ -24,7 +24,11 @@ A set of utilities for computing and analyzing quantal response equilbria
 """
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import zip
+from builtins import object
+from past.utils import old_div
 import math
 import numpy
 from . import pctrace
@@ -109,7 +113,7 @@ class LogitQRE(Solution):
     @property
     def lam(self):      return self._lam
     @property
-    def mu(self):       return 1.0 / self._lam
+    def mu(self):       return old_div(1.0, self._lam)
 
 class StrategicQREPathTracer(object):
     """

--- a/src/python/gambit/tests/test_behav.py
+++ b/src/python/gambit/tests/test_behav.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import gambit
 import fractions
 
@@ -184,7 +185,7 @@ class TestGambitMixedBehavGame(object):
         assert self.profile_rational["U3"] == fractions.Fraction("1/98")
         self.profile_rational["D3"] = fractions.Fraction("97/98")
         assert self.profile_rational["D3"] == fractions.Fraction("97/98")
-        print self.profile_rational
+        print(self.profile_rational)
         assert self.profile_rational == [fractions.Fraction("2/9"), 
                                         fractions.Fraction("7/9"), 
                                         fractions.Fraction("4/13"), 

--- a/src/python/gambit/tests/test_behav.py
+++ b/src/python/gambit/tests/test_behav.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from builtins import range
+from builtins import object
 import gambit
 import fractions
 
@@ -423,7 +425,7 @@ class TestGambitMixedBehavGame(object):
         assert self.profile_double.belief(self.game.infosets[0])[0] == 1.0
         for i in self.game.infosets:
             belief = self.profile_double.belief(i)
-            for n in xrange(0, len(i.members)):
+            for n in range(0, len(i.members)):
                 assert self.profile_double.belief(i.members[n]) == belief[n]
             assert abs(sum(belief) - 1.0) < 1e-13
 
@@ -436,6 +438,6 @@ class TestGambitMixedBehavGame(object):
         assert self.profile_rational.belief(self.game.infosets[0])[0] == fractions.Fraction(1,1)
         for i in self.game.infosets:
             belief = self.profile_rational.belief(i)
-            for n in xrange(0, len(i.members)):
+            for n in range(0, len(i.members)):
                 assert self.profile_rational.belief(i.members[n]) == belief[n]
             assert sum(belief) == fractions.Fraction(1,1)

--- a/src/python/gambit/tests/test_extensive.py
+++ b/src/python/gambit/tests/test_extensive.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 
 class TestGambitExtensiveGame(object):

--- a/src/python/gambit/tests/test_extensive_outcomes.py
+++ b/src/python/gambit/tests/test_extensive_outcomes.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 from nose.tools import assert_raises
 import warnings

--- a/src/python/gambit/tests/test_file.py
+++ b/src/python/gambit/tests/test_file.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 import nose.tools
 

--- a/src/python/gambit/tests/test_game.py
+++ b/src/python/gambit/tests/test_game.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 import fractions
 import nose.tools

--- a/src/python/gambit/tests/test_infosets.py
+++ b/src/python/gambit/tests/test_infosets.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 import nose.tools
 from gambit.lib.error import MismatchError

--- a/src/python/gambit/tests/test_mixed.py
+++ b/src/python/gambit/tests/test_mixed.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 import fractions
 from nose.tools import assert_raises

--- a/src/python/gambit/tests/test_node.py
+++ b/src/python/gambit/tests/test_node.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 from nose.tools import assert_raises
 from gambit.lib.error import MismatchError, UndefinedOperationError

--- a/src/python/gambit/tests/test_outcomes.py
+++ b/src/python/gambit/tests/test_outcomes.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 from nose.tools import assert_raises
 import warnings

--- a/src/python/gambit/tests/test_players.py
+++ b/src/python/gambit/tests/test_players.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 import warnings
 import fractions

--- a/src/python/gambit/tests/test_strategic.py
+++ b/src/python/gambit/tests/test_strategic.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 import warnings
 

--- a/src/python/gambit/tests/test_strategies.py
+++ b/src/python/gambit/tests/test_strategies.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import gambit
 import warnings
 from nose.tools import assert_raises

--- a/src/python/gambit/tests/test_stratprofiles.py
+++ b/src/python/gambit/tests/test_stratprofiles.py
@@ -1,3 +1,4 @@
+from builtins import object
 import gambit
 import fractions
 import nose.tools

--- a/src/python/gambit/tests/test_stratspt.py
+++ b/src/python/gambit/tests/test_stratspt.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import gambit
 import fractions
 import nose.tools

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -23,14 +23,8 @@
 from setuptools import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
+from Cython.Build import cythonize
 
-# setuptools DWIM monkey-patch madness
-# http:#mail.python.org/pipermail/distutils-sig/2007-September/thread.html#8204
-import sys
-if 'setuptools.extension' in sys.modules:
-    m = sys.modules['setuptools.extension']
-    m.Extension.__dict__ = m._Extension.__dict__
-    
 import glob
 libgame = Extension("gambit.lib.libgambit",
                     sources=[ "gambit/lib/libgambit.pyx" ] +
@@ -53,7 +47,7 @@ setup(name="gambit",
       author_email="ted.turocy@gmail.com",
       url="http://www.gambit-project.org",
       packages=['gambit', 'gambit.games', 'gambit.lib'],
-      ext_modules=[libgame],
+      ext_modules=cythonize([libgame]),
       cmdclass = {'build_ext': build_ext},
       entry_points="""
       [console_scripts]


### PR DESCRIPTION
**Introduction**
These 6 commits hopefully prepare the ground for a full Python 2 / 3 compatible code base. 

**Rationale**
The commits do the following:
1. I  have set up [Travis CI](https://travis-ci.org/rhalbersma/gambit) and [Codecov](https://codecov.io/gh/rhalbersma/gambit/branch/future) on my fork in the `future` branch.
2. I followed the `futurize` best practices by running the automated `--stage1` and `--stage2` steps, keeping all tests green. 
3. `futurize` does not touch Cython files, so `functools.reduce` needs to be manually imported.
4. Running the nosetests with `python2 -3` signalled quite a few deprecated warnings concerning user-defined `__eq__` functions without an accompanying `__hash__` function. I have added hash support consistent with equality: if equality is on a tuple/list of class members, then the hashing will be on the same data structure (tuple or list of the data members of `self`).
5. Running `python3 setup.py build` because of the new Python 3 class system (see this [Q&A on StackOverflow](https://stackoverflow.com/questions/40367569/dictionary-not-writable-generic-old-setup-py)). 

**Status**
- The project builds correctly under python2 and runs all unit tests without error.
- Running the unit tests with `python2 -3 nosetests` gives no warnings in code from `gambit`, and only a handful about system code. 
- Running `python3 setup.py build` also builds without errors.
- Running `nosetests` in Python3 mode fails on all unit tests, mostly because of `byte` / `str` incompatibility.

**Guidance needed**
- How would you like to tackle Python2 / Python3 string compatibility? My preferred option would be to treat the current `cython` interface of talking to the C++ code through `std::string` or `char *`. This will keep callers using Python2 happy, but requires converting Python3 unicode string literals to `byte`, e.g. using a `.encode('utf-8')` member function call.
- Gambit also produces quite a bit of `char *` strings from `c_str()` member functions. When those talk to users, then they need to be marshalled through `.decode()`. Separating the internal `c_str()` calls from the ones bubbling up to the interface seems quite a bit of work.
- There are also bound to be some issues with `file()` and `open()` incompatibilities between Python2 and Python3. The way forward is to use `open()` everywhere, with the appropriate `b` flags for byte stream reading. 

If you agree with the approach taken so far, I can try and plough ahead with the string and file issues. Merging the pull request would eventually be best done in one squashed commit, or piece meal, whatever your preference is.

