### PR TITLE
Create initial CI configuration with GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 6 1 * *' # Run 1st of every month at 06:00 UTC
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install -y automake autoconf libtool
+      - run: aclocal
+      - run: libtoolize
+      - run: automake --add-missing
+      - run: autoconf
+
+      - run: ./configure
+      - run: make
+      - run: sudo make install
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install automake autoconf libtool wxwidgets
+      - run: aclocal
+      - run: glibtoolize
+      - run: automake --add-missing
+      - run: autoconf
+
+      - run: ./configure
+      - run: make
+      - run: sudo make install
+      - run: make osx-bundle


### PR DESCRIPTION
Creates an initial CI configuration with GitHub Actions that builds gambit on each push, pull request and once a month for Ubuntu and macOS.

GitHub Actions can be enabled for the gambit repository here: https://github.com/gambitproject/gambit/actions.

In the mean time an example run with this configuration can be found [on my fork](https://github.com/EwoutH/gambit/actions/runs/1687685824).

-----

The Linux (Ubuntu) build unfortunately currently fails:

```
/usr/bin/ld: src/solvers/gtracer/aggame.o: in function `Gambit::gametracer::aggame::SymPayoffMatrix(Gambit::gametracer::cmatrix&, Gambit::gametracer::cvector&, double)':
/home/runner/work/gambit/gambit/src/solvers/gtracer/aggame.cc:403: undefined reference to `Gambit::agg::AGG::doProjection(int, int, double*)'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:1990: gambit-gnm] Error 1
make[1]: Leaving directory '/home/runner/work/gambit/gambit'
make: *** [Makefile:2388: all-recursive] Error 1
Error: Process completed with exit code 2.
```

@tturocy Do you know if this issue has anything to do with the build environment or steps, or is unrelated?