### PR TITLE
CI: Use Python 3.10 instead of 3.1

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,12 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.7', '3.10']
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Set up dependencies
         run: |
           python -m pip install --upgrade pip
@@ -38,8 +40,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Set up dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The `3.10` is currently interpreted as a number, and thus Python 3.1 is used. Changing it to `'3.10'` as a string fixes this.