### PR TITLE
setup.py: Add project URLs for documentation, source code and issues

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -77,6 +77,11 @@ setuptools.setup(
     author="Theodore Turocy",
     author_email="ted.turocy@gmail.com",
     url="http://www.gambit-project.org",
+    project_urls={
+        'Documentation': 'https://gambitproject.readthedocs.io/',
+        'Source': 'https://github.com/gambitproject/gambit',
+        'Tracker': 'https://github.com/gambitproject/gambit/issues',
+    },
     python_requires=">=3.7",
     install_requires=[
         'lxml',  # used for reading/writing GTE files


### PR DESCRIPTION
A small addition to `setup.py`, in which the `project_urls` property is defined with links to the documentation, source code and issue tracker.

This allows PyPI to display direct links to the documentation, source code and issue tracker.

<img width="143" alt="Screenshot_741" src="https://user-images.githubusercontent.com/15776622/173004854-8ddd0bd3-0864-4b2c-a6ab-8f89f57ffbef.png">

See https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls