### PR TITLE
Wheel CI: Run more often, automatically deploy to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,10 @@
 name: pygambit wheels
-
 on:
   push:
-    tags:
-      - 'v*'
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   windows:
@@ -11,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.x'
       - name: Set up dependencies
         run: |
           python -m pip install --upgrade pip
@@ -26,5 +27,11 @@ jobs:
         env:
           CIBW_SKIP: "pp*"
       - uses: actions/upload-artifact@v3
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         with:
           path: ./src/wheelhouse/*.whl
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Improve the wheel CI by:
- Running more often, not only on tags, but also on pushes, pull requests and once a week, to test the workflow. Artifacts and deployment to PyPI only happens when a tag is created.
- Add a step that automatically deploy wheels to PyPI. It only deploys to PyPI when a tag is created.

To deploy to PyPI is uses the [PyPI publish GitHub Action](https://github.com/pypa/gh-action-pypi-publish). It uses the [API token](https://pypi.org/help/#apitoken) feature of PyPI, which is recommended to restrict the access the action has.

The secret used in `${{ secrets.PYPI_API_TOKEN }}` needs to be created on the settings page. See [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).