### PR TITLE
Simplify the calling and implementation of Nash-finding algorithms

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -9,16 +9,6 @@ Representation of games and related concepts
 .. automodule:: pygambit.gambit
    :members:
    :undoc-members:
-   :exclude-members: LCPBehaviorSolverDouble, LCPBehaviorSolverRational,
-                     LCPStrategySolverDouble, LCPStrategySolverRational,
-                     LPBehaviorSolverDouble, LPBehaviorSolverRational,
-                     LPStrategySolverDouble, LPStrategySolverRational,
-                     LiapBehaviorSolver, LiapStrategySolver,
-                     IPAStrategySolver, GNMStrategySolver,
-                     EnumMixedLrsStrategySolver,
-                     EnumMixedStrategySolverDouble, EnumMixedStrategySolverRational,
-                     EnumPureAgentSolver, EnumPureStrategySolver
-
 
 Computation on supports
 -----------------------
@@ -32,7 +22,19 @@ Computation of Nash equilibria
 
 .. automodule:: pygambit.nash
    :members:
+   :exclude-members: ExternalEnumMixedSolver, ExternalEnumPolySolver,
+                     ExternalEnumPureSolver, ExternalGlobalNewtonSolver,
+                     ExternalIteratedPolymatrixSolver, ExternalLCPSolver,
+                     ExternalLPSolver, ExternalLogitSolver,
+                     ExternalLyapunovSolver, ExternalSimpdivSolver,
+                     ExternalSolver
+
+
+Computation of quantal response equilibria
+------------------------------------------
 
 .. automodule:: pygambit.qre
    :members:
+   :exclude-members: ExternalStrategicQREPathTracer,
+                     sym_compute_jac, sym_compute_lhs
 

--- a/doc/pyapi.rst
+++ b/doc/pyapi.rst
@@ -303,126 +303,25 @@ Computing Nash equilibria
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Interfaces to algorithms for computing Nash equilibria are collected
-in the module :py:mod:`pygambit.nash`.  There are two choices for
-calling these algorithms: directly within Python, or via the
-corresponding Gambit :ref:`command-line tool <command-line>`.
+in the module :py:mod:`pygambit.nash`.
 
-Calling an algorithm directly within Python has less overhead, which
-makes this approach well-suited to the analysis of smaller games,
-where the expected running time is small.  In addition, these
-interfaces may offer more fine-grained control of the behavior
-of some algorithms.  
 
-Calling the Gambit command-line tool launches the algorithm as a
-separate process.  This makes it easier to abort during the run of the
-algorithm (preserving where possible the equilibria which have already
-been found), and also makes the program more robust to any internal
-errors which may arise in the calculation.
+==========================================    ========================================
+Method                                        Python function
+==========================================    ========================================
+:ref:`gambit-enumpure <gambit-enumpure>`      :py:func:`pygambit.nash.enumpure_solve`
+:ref:`gambit-enummixed <gambit-enummixed>`    :py:func:`pygambit.nash.enummixed_solve`
+:ref:`gambit-lp <gambit-lp>`                  :py:func:`pygambit.nash.lp_solve`
+:ref:`gambit-lcp <gambit-lcp>`                :py:func:`pygambit.nash.lcp_solve`
+:ref:`gambit-liap <gambit-liap>`              :py:func:`pygambit.nash.liap_solve`
+:ref:`gambit-logit <gambit-logit>`            :py:func:`pygambit.nash.logit_solve`
+:ref:`gambit-simpdiv <gambit-simpdiv>`        :py:func:`pygambit.nash.simpdiv_solve`
+:ref:`gambit-ipa <gambit-ipa>`                :py:func:`pygambit.nash.ipa_solve`
+:ref:`gambit-gnm <gambit-gnm>`                :py:func:`pygambit.nash.gnm_solve`
+==========================================    ========================================
 
-Calling command-line tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The interface to each command-line tool is encapsulated in a class
-with the word "External" in the name.  These operate by
-creating a subprocess, which calls the corresponding Gambit
-:ref:`command-line tool <command-line>`.  Therefore, a working
-Gambit installation needs to be in place, with the command-line tools
-located in the executable search path.
-
-======================    ========================
-Method                    Python class
-======================    ========================
-gambit-enumpure           ExternalEnumPureSolver
-gambit-enummixed          ExternalEnumMixedSolver
-gambit-lp                 ExternalLPSolver
-gambit-lcp                ExternalLCPSolver
-gambit-simpdiv            ExternalSimpdivSolver
-gambit-gnm                ExternalGlobalNewtonSolver
-gambit-enumpoly           ExternalEnumPolySolver
-gambit-liap               ExternalLyapunovSolver
-gambit-ipa                ExternalIteratedPolymatrixSolver
-gambit-logit              ExternalLogitSolver
-======================    ========================
-
-For example, consider the game :file:`e02.nfg` from the set of standard
-Gambit examples.  This game has a continuum of equilibria, in which
-the first player plays his first strategty with probability one,
-and the second player plays a mixed strategy, placing at least
-probability one-half on her first strategy::
-
-  In [1]: g = pygambit.Game.read_game("e02.nfg")
-
-  In [2]: solver = pygambit.nash.ExternalEnumPureSolver()
-
-  In [3]: solver.solve(g)
-  Out[3]: [[1.0, 0.0, 0.0, 1.0, 0.0]]
-
-  In [4]: solver = pygambit.nash.ExternalEnumMixedSolver()
-
-  In [5]: solver.solve(g)
-  Out[5]: [[1.0, 0.0, 0.0, 1.0, 0.0], [1.0, 0.0, 0.0, 0.5, 0.5]]
-
-  In [6]: solver = pygambit.nash.ExternalLogitSolver()
-
-  In [7]: solver.solve(g)
-  Out[7]: [[0.99999999997881173, 0.0, 2.1188267679986399e-11, 0.50001141005647654, 0.49998858994352352]]
-
-In this example, the pure strategy solver returns the unique
-equilibrium in pure strategies.  Solving using
-:program:`gambit-enummixed` gives two equilibria, which are the
-extreme points of the set of equilibria.  Solving by tracing the
-quantal response equilibrium correspondence produces a close numerical
-approximation to one equilibrium; in fact, the equilibrium which is
-the limit of the principal branch is the one in which the second
-player randomizes with equal probability on both strategies.
-
-When a game's representation is in extensive form, these solvers
-default to using the version of the algorithm which operates on the
-extensive game, where available, and returns a list of
-:py:class:`pygambit.MixedBehaviorProfile` objects.  This can be overridden when
-calling :py:meth:`solve` via the ``use_strategic`` parameter::
-
-  In [1]: g = pygambit.Game.read_game("e02.efg")
-
-  In [2]: solver = pygambit.nash.ExternalLCPSolver()
-
-  In [3]: solver.solve(g)
-  Out[3]: [<NashProfile for 'Selten (IJGT, 75), Figure 2': [1.0, 0.0, 0.5, 0.5, 0.5, 0.5]>]
-
-  In [4]: solver.solve(g, use_strategic=True)
-  Out[4]: [<NashProfile for 'Selten (IJGT, 75), Figure 2': [1.0, 0.0, 0.0, 1.0, 0.0]>]
-
-As this game is in extensive form, in the first call, the returned
-profile is a :py:class:`MixedBehaviorProfile`, while in the second, it
-is a :py:class:`MixedStrategyProfile`.  While the set of equilibria is
-not affected by whether behavior or mixed strategies are used, the
-equilibria returned by specific solution methods may differ, when
-using a call which does not necessarily return all equilibria.
-
-Calling internally-linked libraries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Where available, versions of algorithms which have been linked
-internally into the Python library are generally called via
-convenience functions.  The following table lists the algorithms
-available via this approach.
-
-========================================  ========================
-Method                                    Python function
-========================================  ========================
-:ref:`gambit-enumpure <gambit-enumpure>`  :py:func:`gambit.nash.enumpure_solve`
-:ref:`gambit-lp <gambit-lp>`              :py:func:`gambit.nash.lp_solve`
-:ref:`gambit-lcp <gambit-lcp>`            :py:func:`gambit.nash.lcp_solve`
-========================================  ========================
-
-Parameters are available to modify the operation of the algorithm.
-The most common ones are ``use_strategic``, to indicate the use of a
-strategic form version of an algorithm where both extensive and
-strategic versions are available, and ``rational``, to indicate
-computation using rational arithmetic, where this is an option to the
-algorithm.
-
-For example, taking again the game :file:`e02.efg` as an example::
+For example, taking the game :file:`e02.efg` as an example::
 
   In [1]: g = pygambit.Game.read_game("e02.efg")
 

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -585,6 +585,8 @@ strategies each, with a unique equilibrium in mixed strategies::
    NE,1/3,2/3,1/3,2/3
 
 
+.. _gambit-liap:
+
 :program:`gambit-liap`: Compute Nash equilibria using function minimization
 ---------------------------------------------------------------------------
 
@@ -740,6 +742,8 @@ Computing an equilibrium in mixed strategies of :download:`e02.efg
 
    NE,1,0,0,1,0
 
+
+.. _gambit-logit:
 
 :program:`gambit-logit`: Compute quantal response equilbria
 -----------------------------------------------------------

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -1,5 +1,6 @@
 from libcpp cimport bool
 from libcpp.string cimport string
+from libcpp.memory cimport shared_ptr
 
 
 cdef extern from "gambit.h":
@@ -366,98 +367,45 @@ cdef extern from "util.h":
      c_MixedStrategyProfileRational *copyitem_list_mspr "copyitem"(c_List[c_MixedStrategyProfileRational], int)
      c_MixedBehaviorProfileDouble *copyitem_list_mbpd "copyitem"(c_List[c_MixedBehaviorProfileDouble], int)
      c_MixedBehaviorProfileRational *copyitem_list_mbpr "copyitem"(c_List[c_MixedBehaviorProfileRational], int)
-     c_LogitQREMixedStrategyProfile *copyitem_list_qrem "copyitem"(c_List[c_LogitQREMixedStrategyProfile], int)
+     shared_ptr[c_LogitQREMixedStrategyProfile] copyitem_list_qrem "sharedcopyitem"(c_List[c_LogitQREMixedStrategyProfile], int)
 
 
 cdef extern from "solvers/enumpure/enumpure.h":
-    cdef cppclass c_NashEnumPureStrategySolver "EnumPureStrategySolver":
-        c_NashEnumPureStrategySolver()
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashEnumPureAgentSolver "EnumPureAgentSolver":
-        c_NashEnumPureAgentSolver()
-        c_List[c_MixedBehaviorProfileRational] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileRational] EnumPureStrategySolve(c_Game) except +RuntimeError
+    c_List[c_MixedBehaviorProfileRational] EnumPureAgentSolve(c_Game) except +RuntimeError
 
 cdef extern from "solvers/enummixed/enummixed.h":
-    cdef cppclass c_NashEnumMixedStrategySolverDouble "EnumMixedStrategySolver<double>":
-        c_NashEnumMixedStrategySolverDouble()
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashEnumMixedStrategySolverRational "EnumMixedStrategySolver<Rational>":
-        c_NashEnumMixedStrategySolverRational()
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashEnumMixedLrsStrategySolver "EnumMixedLrsStrategySolver":
-        c_NashEnumMixedLrsStrategySolver()
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileDouble] EnumMixedStrategySolveDouble(c_Game) except +RuntimeError
+    c_List[c_MixedStrategyProfileRational] EnumMixedStrategySolveRational(c_Game) except +RuntimeError
+    c_List[c_MixedStrategyProfileRational] EnumMixedStrategySolveLrs(c_Game) except +RuntimeError
 
 cdef extern from "solvers/lcp/lcp.h":
-    cdef cppclass c_NashLcpStrategySolverDouble "NashLcpStrategySolver<double>":
-        c_NashLcpStrategySolverDouble(int, int)
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashLcpStrategySolverRational "NashLcpStrategySolver<Rational>":
-        c_NashLcpStrategySolverRational(int, int)
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashLcpBehaviorSolverDouble "NashLcpBehaviorSolver<double>":
-        c_NashLcpBehaviorSolverDouble(int, int)
-        c_List[c_MixedBehaviorProfileDouble] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
-    cdef cppclass c_NashLcpBehaviorSolverRational "NashLcpBehaviorSolver<Rational>":
-        c_NashLcpBehaviorSolverRational(int, int)
-        c_List[c_MixedBehaviorProfileRational] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileDouble] LcpStrategySolveDouble(c_Game, int p_stopAfter, int p_maxDepth) except +RuntimeError
+    c_List[c_MixedStrategyProfileRational] LcpStrategySolveRational(c_Game, int p_stopAfter, int p_maxDepth) except +RuntimeError
+    c_List[c_MixedBehaviorProfileDouble] LcpBehaviorSolveDouble(c_Game, int p_stopAfter, int p_maxDepth) except +RuntimeError
+    c_List[c_MixedBehaviorProfileRational] LcpBehaviorSolveRational(c_Game, int p_stopAfter, int p_maxDepth) except +RuntimeError
 
 cdef extern from "tools/lp/nfglp.h":
-    cdef cppclass c_NashLpStrategySolverDouble "NashLpStrategySolver<double>":
-        c_NashLpStrategySolverDouble()
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashLpStrategySolverRational "NashLpStrategySolver<Rational>":
-        c_NashLpStrategySolverRational()
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileDouble] LpStrategySolveDouble(c_Game) except +RuntimeError
+    c_List[c_MixedStrategyProfileRational] LpStrategySolveRational(c_Game) except +RuntimeError
 
 cdef extern from "tools/lp/efglp.h":
-    cdef cppclass c_NashLpBehavSolverDouble "NashLpBehavSolver<double>":
-        c_NashLpBehavSolverDouble()
-        c_List[c_MixedBehaviorProfileDouble] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
-    cdef cppclass c_NashLpBehavSolverRational "NashLpBehavSolver<Rational>":
-        c_NashLpBehavSolverRational()
-        c_List[c_MixedBehaviorProfileRational] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
+    c_List[c_MixedBehaviorProfileDouble] LpBehaviorSolveDouble(c_Game) except +RuntimeError
+    c_List[c_MixedBehaviorProfileRational] LpBehaviorSolveRational(c_Game) except +RuntimeError
 
 cdef extern from "solvers/liap/liap.h":
-    cdef cppclass c_NashLiapStrategySolver "NashLiapStrategySolver":
-        c_NashLiapStrategySolver(int)
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
-
-    cdef cppclass c_NashLiapBehaviorSolver "NashLiapBehaviorSolver":
-        c_NashLiapBehaviorSolver(int)
-        c_List[c_MixedBehaviorProfileDouble] Solve(c_BehaviorSupportProfile) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileDouble] LiapStrategySolve(c_Game, int p_maxitsN) except +RuntimeError
+    c_List[c_MixedBehaviorProfileDouble] LiapBehaviorSolve(c_Game, int p_maxitsN) except +RuntimeError
 
 cdef extern from "solvers/simpdiv/simpdiv.h":
-    cdef cppclass c_NashSimpdivStrategySolver "NashSimpdivStrategySolver":
-        c_NashSimpdivStrategySolver()
-        c_List[c_MixedStrategyProfileRational] Solve(c_Game) except +RuntimeError
-        c_List[c_MixedStrategyProfileRational] Solve(c_MixedStrategyProfileRational) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileRational] SimpdivStrategySolve(c_Game) except +RuntimeError
 
 cdef extern from "solvers/ipa/ipa.h":
-    cdef cppclass c_NashIPAStrategySolver "NashIPAStrategySolver":
-        c_NashIPAStrategySolver()
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
-
+    c_List[c_MixedStrategyProfileDouble] IPAStrategySolve(c_Game) except +RuntimeError
 
 cdef extern from "solvers/gnm/gnm.h":
-    cdef cppclass c_NashGNMStrategySolver "NashGNMStrategySolver":
-        c_NashGNMStrategySolver()
-        c_List[c_MixedStrategyProfileDouble] Solve(c_Game) except +RuntimeError
+    c_List[c_MixedStrategyProfileDouble] GNMStrategySolve(c_Game) except +RuntimeError
+
 
 
 cdef extern from "tools/logit/nfglogit.h":
@@ -478,7 +426,7 @@ cdef extern from "tools/logit/nfglogit.h":
                                                   double, double, double) except +RuntimeError
 
 cdef extern from "nash.h":
-    c_LogitQREMixedStrategyProfile *_logit_estimate "logit_estimate"(c_MixedStrategyProfileDouble *)
-    c_LogitQREMixedStrategyProfile *_logit_atlambda "logit_atlambda"(c_Game, double)
+    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_estimate "logit_estimate"(c_MixedStrategyProfileDouble *)
+    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_atlambda "logit_atlambda"(c_Game, double)
     c_List[c_LogitQREMixedStrategyProfile] _logit_principal_branch "logit_principal_branch"(c_Game, double)
 

--- a/src/pygambit/nash.h
+++ b/src/pygambit/nash.h
@@ -31,7 +31,7 @@ public:
   int overflow(int c) { return c; }
 };
 
-LogitQREMixedStrategyProfile *
+std::shared_ptr<LogitQREMixedStrategyProfile>
 logit_estimate(MixedStrategyProfile<double> *p_frequencies)
 {
   LogitQREMixedStrategyProfile start(p_frequencies->GetGame());
@@ -40,18 +40,19 @@ logit_estimate(MixedStrategyProfile<double> *p_frequencies)
   std::ostream null_stream(&null_buffer);
   LogitQREMixedStrategyProfile result = alg.Estimate(start, *p_frequencies, 
 						     null_stream, 1000000.0, 1.0);
-  return new LogitQREMixedStrategyProfile(result);
+  return make_shared<LogitQREMixedStrategyProfile>(result);
 }
 
-LogitQREMixedStrategyProfile *
+std::shared_ptr<LogitQREMixedStrategyProfile>
 logit_atlambda(const Game &p_game, double p_lambda)
 {
   LogitQREMixedStrategyProfile start(p_game);
   StrategicQREPathTracer alg;
   NullBuffer null_buffer;
   std::ostream null_stream(&null_buffer);
-  return new LogitQREMixedStrategyProfile(alg.SolveAtLambda(start, null_stream,
-							    p_lambda, 1.0));
+  return make_shared<LogitQREMixedStrategyProfile>(
+    alg.SolveAtLambda(start, null_stream, p_lambda, 1.0)
+  );
 }
 
 List<LogitQREMixedStrategyProfile>

--- a/src/pygambit/nash.pxi
+++ b/src/pygambit/nash.pxi
@@ -19,420 +19,183 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
-
+import cython
 from libcpp.memory cimport shared_ptr, make_shared
+from cython.operator cimport dereference as deref
 
 
-cdef class EnumPureStrategySolver:
-    cdef c_NashEnumPureStrategySolver *alg
+import typing
 
-    def __cinit__(self):
-        self.alg = new c_NashEnumPureStrategySolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
+@cython.cfunc
+def _convert_mspd(
+        inlist: c_List[c_MixedStrategyProfileDouble]
+) -> typing.List[MixedStrategyProfileDouble]:
+    ret = []
+    for i in range(inlist.Length()):
+        p = MixedStrategyProfileDouble()
+        p.profile = copyitem_list_mspd(inlist, i+1)
+        ret.append(p)
+    return ret
 
-cdef class EnumPureAgentSolver:
-    cdef c_NashEnumPureAgentSolver *alg
+@cython.cfunc
+def _convert_mspr(
+        inlist: c_List[c_MixedStrategyProfileRational]
+) -> typing.List[MixedStrategyProfileRational]:
+    ret = []
+    for i in range(inlist.Length()):
+        p = MixedStrategyProfileRational()
+        p.profile = copyitem_list_mspr(inlist, i+1)
+        ret.append(p)
+    return ret
 
-    def __cinit__(self, p_stopAfter=0, p_maxDepth=0):
-        self.alg = new c_NashEnumPureAgentSolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileRational] solns
-        cdef MixedBehaviorProfileRational p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileRational()
-            p.profile = copyitem_list_mbpr(solns, i+1)
-            ret.append(p)
-        return ret
+@cython.cfunc
+def _convert_mbpd(
+        inlist: c_List[c_MixedBehaviorProfileDouble]
+) -> typing.List[MixedBehaviorProfileDouble]:
+    ret = []
+    for i in range(inlist.Length()):
+        p = MixedBehaviorProfileDouble()
+        p.profile = copyitem_list_mbpd(inlist, i+1)
+        ret.append(p)
+    return ret
 
+@cython.cfunc
+def _convert_mbpr(
+        inlist: c_List[c_MixedBehaviorProfileRational]
+) -> typing.List[MixedBehaviorProfileRational]:
+    ret = []
+    for i in range(inlist.Length()):
+        p = MixedBehaviorProfileRational()
+        p.profile = copyitem_list_mbpr(inlist, i+1)
+        ret.append(p)
+    return ret
 
-cdef class EnumMixedStrategySolverDouble:
-    cdef c_NashEnumMixedStrategySolverDouble *alg
+def _enumpure_strategy_solve(game: Game) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(EnumPureStrategySolve(game.game))
 
-    def __cinit__(self):
-        self.alg = new c_NashEnumMixedStrategySolverDouble()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
+def _enumpure_agent_solve(game: Game) -> typing.List[MixedBehaviorProfileRational]:
+    return _convert_mbpr(EnumPureAgentSolve(game.game))
 
-cdef class EnumMixedStrategySolverRational:
-    cdef c_NashEnumMixedStrategySolverRational *alg
+def _enummixed_strategy_solve_double(game: Game) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(EnumMixedStrategySolveDouble(game.game))
 
-    def __cinit__(self):
-        self.alg = new c_NashEnumMixedStrategySolverRational()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
+def _enummixed_strategy_solve_rational(game: Game) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(EnumMixedStrategySolveRational(game.game))
 
-cdef class EnumMixedLrsStrategySolver:
-    cdef c_NashEnumMixedLrsStrategySolver *alg
+def _enummixed_strategy_solve_lrs(game: Game) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(EnumMixedStrategySolveLrs(game.game))
 
-    def __cinit__(self):
-        self.alg = new c_NashEnumMixedLrsStrategySolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
+def _lcp_behavior_solve_double(
+        game: Game, stop_after: int, max_depth: int
+) -> typing.List[MixedBehaviorProfileDouble]:
+    return _convert_mbpd(LcpBehaviorSolveDouble(game.game, stop_after, max_depth))
 
+def _lcp_behavior_solve_rational(
+        game: Game, stop_after: int, max_depth: int
+) -> typing.List[MixedBehaviorProfileRational]:
+    return _convert_mbpr(LcpBehaviorSolveRational(game.game, stop_after, max_depth))
 
-cdef class LCPBehaviorSolverDouble:
-    cdef c_NashLcpBehaviorSolverDouble *alg
+def _lcp_strategy_solve_double(
+        game: Game, stop_after: int, max_depth: int
+) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(LcpStrategySolveDouble(game.game, stop_after, max_depth))
 
-    def __cinit__(self, p_stopAfter=0, p_maxDepth=0):
-        self.alg = new c_NashLcpBehaviorSolverDouble(p_stopAfter, p_maxDepth)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileDouble] solns
-        cdef MixedBehaviorProfileDouble p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileDouble()
-            p.profile = copyitem_list_mbpd(solns, i+1)
-            ret.append(p)
-        return ret
+def _lcp_strategy_solve_rational(
+        game: Game, stop_after: int, max_depth: int
+) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(LcpStrategySolveRational(game.game, stop_after, max_depth))
 
-cdef class LCPBehaviorSolverRational:
-    cdef c_NashLcpBehaviorSolverRational *alg
+def _lp_behavior_solve_double(game: Game) -> typing.List[MixedBehaviorProfileDouble]:
+    return _convert_mbpd(LpBehaviorSolveDouble(game.game))
 
-    def __cinit__(self, p_stopAfter=0, p_maxDepth=0):
-        self.alg = new c_NashLcpBehaviorSolverRational(p_stopAfter, p_maxDepth)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileRational] solns
-        cdef MixedBehaviorProfileRational p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileRational()
-            p.profile = copyitem_list_mbpr(solns, i+1)
-            ret.append(p)
-        return ret
+def _lp_behavior_solve_rational(game: Game) -> typing.List[MixedBehaviorProfileRational]:
+    return _convert_mbpr(LpBehaviorSolveRational(game.game))
 
-cdef class LCPStrategySolverDouble:
-    cdef c_NashLcpStrategySolverDouble *alg
+def _lp_strategy_solve_double(game: Game) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(LpStrategySolveDouble(game.game))
 
-    def __cinit__(self, p_stopAfter=0, p_maxDepth=0):
-        self.alg = new c_NashLcpStrategySolverDouble(p_stopAfter, p_maxDepth)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
+def _lp_strategy_solve_rational(game: Game) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(LpStrategySolveRational(game.game))
 
-cdef class LCPStrategySolverRational:
-    cdef c_NashLcpStrategySolverRational *alg
+def _liap_strategy_solve(game: Game, maxiter: int) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(LiapStrategySolve(game.game, maxiter))
 
-    def __cinit__(self, p_stopAfter=0, p_maxDepth=0):
-        self.alg = new c_NashLcpStrategySolverRational(p_stopAfter, p_maxDepth)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
+def _liap_behavior_solve(game: Game, maxiter: int) -> typing.List[MixedBehaviorProfileDouble]:
+    return _convert_mbpd(LiapBehaviorSolve(game.game, maxiter))
+
+def _simpdiv_strategy_solve(game: Game) -> typing.List[MixedStrategyProfileRational]:
+    return _convert_mspr(SimpdivStrategySolve(game.game))
+
+def _ipa_strategy_solve(game: Game) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(IPAStrategySolve(game.game))
+
+def _gnm_strategy_solve(game: Game) -> typing.List[MixedStrategyProfileDouble]:
+    return _convert_mspd(GNMStrategySolve(game.game))
 
 
+@cython.cclass
+class LogitQREMixedStrategyProfile:
+    thisptr = cython.declare(shared_ptr[c_LogitQREMixedStrategyProfile])
 
-
-cdef class LPBehaviorSolverDouble:
-    cdef c_NashLpBehavSolverDouble *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashLpBehavSolverDouble()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileDouble] solns
-        cdef MixedBehaviorProfileDouble p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileDouble()
-            p.profile = copyitem_list_mbpd(solns, i+1)
-            ret.append(p)
-        return ret
-
-cdef class LPBehaviorSolverRational:
-    cdef c_NashLpBehavSolverRational *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashLpBehavSolverRational()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileRational] solns
-        cdef MixedBehaviorProfileRational p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileRational()
-            p.profile = copyitem_list_mbpr(solns, i+1)
-            ret.append(p)
-        return ret
-
-cdef class LPStrategySolverDouble:
-    cdef c_NashLpStrategySolverDouble *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashLpStrategySolverDouble()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
-
-cdef class LPStrategySolverRational:
-    cdef c_NashLpStrategySolverRational *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashLpStrategySolverRational()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
-
-
-cdef class LiapStrategySolver:
-    cdef c_NashLiapStrategySolver *alg
-
-    def __cinit__(self, maxiter=100):
-        self.alg = new c_NashLiapStrategySolver(maxiter)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
-
-
-cdef class LiapBehaviorSolver:
-    cdef c_NashLiapBehaviorSolver *alg
-
-    def __cinit__(self, maxiter=100):
-        self.alg = new c_NashLiapBehaviorSolver(maxiter)
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedBehaviorProfileDouble] solns
-        cdef MixedBehaviorProfileDouble p
-        cdef shared_ptr[c_BehaviorSupportProfile] profile
-        profile = make_shared[c_BehaviorSupportProfile](game.game)
-        solns = self.alg.Solve(deref(profile))
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedBehaviorProfileDouble()
-            p.profile = copyitem_list_mbpd(solns, i+1)
-            ret.append(p)
-        return ret
-
-
-cdef class SimpdivStrategySolver:
-    cdef c_NashSimpdivStrategySolver *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashSimpdivStrategySolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileRational] solns
-        cdef MixedStrategyProfileRational p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileRational()
-            p.profile = copyitem_list_mspr(solns, i+1)
-            ret.append(p)
-        return ret
-
-cdef class IPAStrategySolver:
-    cdef c_NashIPAStrategySolver *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashIPAStrategySolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
-
-cdef class GNMStrategySolver:
-    cdef c_NashGNMStrategySolver *alg
-
-    def __cinit__(self):
-        self.alg = new c_NashGNMStrategySolver()
-    def __dealloc__(self):
-        del self.alg
-    def solve(self, Game game):
-        cdef c_List[c_MixedStrategyProfileDouble] solns
-        cdef MixedStrategyProfileDouble p
-        solns = self.alg.Solve(game.game)
-        ret = [ ]
-        for i in xrange(solns.Length()):
-            p = MixedStrategyProfileDouble()
-            p.profile = copyitem_list_mspd(solns, i+1)
-            ret.append(p)
-        return ret
-
-
-cdef class LogitQREMixedStrategyProfile:
-    cdef c_LogitQREMixedStrategyProfile *thisptr
     def __init__(self, game=None):
         if game is not None:
-            self.thisptr = new c_LogitQREMixedStrategyProfile((<Game>game).game)
-    def __dealloc__(self):
-        del self.thisptr
+            self.thisptr = make_shared[c_LogitQREMixedStrategyProfile](
+                cython.cast(Game, game).game
+            )
+
     def __repr__(self):
         return "LogitQREMixedStrategyProfile(lam=%f,profile=%s)" % (self.lam, self.profile)
 
     def __len__(self):
-        return self.thisptr.MixedProfileLength()
+        return deref(self.thisptr).MixedProfileLength()
+
     def __getitem__(self, int i):
-        return self.thisptr.getitem(i+1)
+        return deref(self.thisptr).getitem(i+1)
 
     @property
     def game(self) -> Game:
         """The game on which this mixed strategy profile is defined."""
-        cdef Game g
         g = Game()
-        g.game = self.thisptr.GetGame()
+        g.game = deref(self.thisptr).GetGame()
         return g
 
     @property
     def lam(self) -> double:
         """The value of the precision parameter."""
-        return self.thisptr.GetLambda()
+        return deref(self.thisptr).GetLambda()
 
     @property
     def log_like(self) -> double:
         """The log-likelihood of the data."""
-        return self.thisptr.GetLogLike()
+        return deref(self.thisptr).GetLogLike()
 
     @property
     def profile(self) -> MixedStrategyProfileDouble:
         """The mixed strategy profile."""
-        cdef MixedStrategyProfileDouble profile
         profile = MixedStrategyProfileDouble()
         profile.profile = new c_MixedStrategyProfileDouble(deref(self.thisptr).GetProfile())
         return profile
 
-def logit_estimate(MixedStrategyProfileDouble p_profile):
+def logit_estimate(profile: MixedStrategyProfileDouble) -> LogitQREMixedStrategyProfile:
     """Estimate QRE corresponding to mixed strategy profile using
     maximum likelihood along the principal branch.
     """
-    cdef LogitQREMixedStrategyProfile ret
     ret = LogitQREMixedStrategyProfile()
-    ret.thisptr = _logit_estimate(p_profile.profile)
+    ret.thisptr = _logit_estimate(profile.profile)
     return ret
 
-def logit_atlambda(Game p_game, double p_lambda):
+def logit_atlambda(game: Game, lam: float) -> LogitQREMixedStrategyProfile:
     """Compute the first QRE along the principal branch with the given
     lambda parameter.
     """
-    cdef LogitQREMixedStrategyProfile ret
     ret = LogitQREMixedStrategyProfile()
-    ret.thisptr = _logit_atlambda(p_game.game, p_lambda)
+    ret.thisptr = _logit_atlambda(game.game, lam)
     return ret
    
-def logit_principal_branch(Game p_game, double p_maxLambda=100000.0):
-    cdef c_List[c_LogitQREMixedStrategyProfile] solns
-    cdef LogitQREMixedStrategyProfile p
-    solns = _logit_principal_branch(p_game.game, p_maxLambda)
-    ret = [ ]
-    for i in xrange(solns.Length()):
+def logit_principal_branch(game: Game, maxlam: float = 100000.0):
+    solns = _logit_principal_branch(game.game, maxlam)
+    ret = []
+    for i in range(solns.Length()):
         p = LogitQREMixedStrategyProfile()
         p.thisptr = copyitem_list_qrem(solns, i+1)
         ret.append(p)

--- a/src/pygambit/tests/test_games/poker.efg
+++ b/src/pygambit/tests/test_games/poker.efg
@@ -1,0 +1,14 @@
+EFG 2 R "A simple Poker game" { "Fred" "Alice" }
+"This is a simple game of one-card poker from Myerson (1991)."
+
+c "" 1 "" { "Red" 1/2 "Black" 1/2 } 0
+p "" 1 1 "" { "Raise" "Fold" } 0
+p "" 2 1 "" { "Meet" "Pass" } 0
+t "" 1 "Win Big" { 2, -2 }
+t "" 2 "Win" { 1, -1 }
+t "" 2 "Win" { 1, -1 }
+p "" 1 2 "" { "Raise" "Fold" } 0
+p "" 2 1 "" { "Meet" "Pass" } 0
+t "" 3 "Lose Big" { -2, 2 }
+t "" 2 "Win" { 1, -1 }
+t "" 4 "Lose" { -1, 1 }

--- a/src/pygambit/tests/test_nash.py
+++ b/src/pygambit/tests/test_nash.py
@@ -1,0 +1,125 @@
+"""Test of calls to Nash equilibrium solvers.
+
+These tests primarily ensure that calling the solvers works and returns
+expected results on a very simple game.  This is not intended to be a
+rigorous test suite for the algorithms across all games.
+"""
+
+import pygambit as gbt
+import unittest
+
+
+class TestNash(unittest.TestCase):
+    """Test calls to Nash algorithms using Myerson poker - a game to which all algorithms apply."""
+    def setUp(self):
+        self.poker = gbt.Game.read_game("test_games/poker.efg")
+        self.mixed_rat = self.poker.mixed_strategy_profile(
+            rational=True,
+            data=[[gbt.Rational(1, 3), gbt.Rational(2, 3), gbt.Rational(0), gbt.Rational(0)],
+                  [gbt.Rational(2, 3), gbt.Rational(1, 3)]]
+        )
+        self.behav_rat = self.poker.mixed_behavior_profile(rational=True)
+        self.behav_rat[0] = gbt.Rational(1)
+        self.behav_rat[1] = gbt.Rational(0)
+        self.behav_rat[2] = gbt.Rational(1, 3)
+        self.behav_rat[3] = gbt.Rational(2, 3)
+        self.behav_rat[4] = gbt.Rational(2, 3)
+        self.behav_rat[5] = gbt.Rational(1, 3)
+
+    def tearDown(self):
+        del self.poker
+
+    def test_enumpure_strategy(self):
+        """Test calls of enumeration of pure strategies."""
+        assert len(gbt.nash.enumpure_solve(self.poker, use_strategic=True)) == 0
+
+    def test_enumpure_agent(self):
+        """Test calls of enumeration of pure agent strategies."""
+        assert len(gbt.nash.enumpure_solve(self.poker, use_strategic=False)) == 0
+
+    def test_enummixed_strategy_double(self):
+        """Test calls of enumeration of mixed strategy equilibria, floating-point."""
+        result = gbt.nash.enummixed_solve(self.poker, rational=False)
+        assert len(result) == 1
+        # For floating-point results are not exact, so we skip testing exact values for now
+
+    def test_enummixed_strategy_rational(self):
+        """Test calls of enumeration of mixed strategy equilibria, rational precision."""
+        result = gbt.nash.enummixed_solve(self.poker, rational=True)
+        assert len(result) == 1
+        assert result[0] == self.mixed_rat
+
+    def test_lcp_strategy_double(self):
+        """Test calls of LCP for mixed strategy equilibria, floating-point."""
+        result = gbt.nash.lcp_solve(self.poker, use_strategic=True, rational=False)
+        assert len(result) == 1
+        # For floating-point results are not exact, so we skip testing exact values for now
+
+    def test_lcp_strategy_rational(self):
+        """Test calls of LCP for mixed strategy equilibria, rational precision."""
+        result = gbt.nash.lcp_solve(self.poker, use_strategic=True, rational=True)
+        assert len(result) == 1
+        assert result[0] == self.mixed_rat
+
+    def test_lcp_behavior_double(self):
+        """Test calls of LCP for mixed behavior equilibria, floating-point."""
+        result = gbt.nash.lcp_solve(self.poker, use_strategic=False, rational=False)
+        assert len(result) == 1
+        # For floating-point results are not exact, so we skip testing exact values for now
+
+    def test_lcp_behavior_rational(self):
+        """Test calls of LCP for mixed behavior equilibria, rational precision."""
+        result = gbt.nash.lcp_solve(self.poker, use_strategic=False, rational=True)
+        assert len(result) == 1
+        assert result[0] == self.behav_rat
+
+    def test_lp_strategy_double(self):
+        """Test calls of LP for mixed strategy equilibria, floating-point."""
+        result = gbt.nash.lp_solve(self.poker, use_strategic=True, rational=False)
+        assert len(result) == 1
+        # For floating-point results are not exact, so we skip testing exact values for now
+
+    def test_lp_strategy_rational(self):
+        """Test calls of LP for mixed strategy equilibria, rational precision."""
+        result = gbt.nash.lp_solve(self.poker, use_strategic=True, rational=True)
+        assert len(result) == 1
+        assert result[0] == self.mixed_rat
+
+    def test_lp_behavior_double(self):
+        """Test calls of LP for mixed behavior equilibria, floating-point."""
+        result = gbt.nash.lp_solve(self.poker, use_strategic=False, rational=False)
+        assert len(result) == 1
+        # For floating-point results are not exact, so we skip testing exact values for now
+
+    def test_lp_behavior_rational(self):
+        """Test calls of LP for mixed behavior equilibria, rational precision."""
+        result = gbt.nash.lp_solve(self.poker, use_strategic=False, rational=True)
+        assert len(result) == 1
+        assert result[0] == self.behav_rat
+
+    def test_liap_strategy(self):
+        """Test calls of liap for mixed strategy equilibria."""
+        result = gbt.nash.liap_solve(self.poker, use_strategic=False)
+        # Currently default parameter liap fails to find an equilibrium
+        assert len(result) == 0
+
+    def test_liap_behavior(self):
+        """Test calls of liap for mixed behavior equilibria."""
+        result = gbt.nash.liap_solve(self.poker, use_strategic=True)
+        # Currently default parameter liap fails to find an equilibrium
+        assert len(result) == 0
+
+    def test_simpdiv_strategy(self):
+        """Test calls of simplicial subdivision for mixed strategy equilibria."""
+        result = gbt.nash.simpdiv_solve(self.poker)
+        assert len(result) == 1
+
+    def test_ipa_strategy(self):
+        """Test calls of IPA for mixed strategy equilibria."""
+        result = gbt.nash.ipa_solve(self.poker)
+        assert len(result) == 1
+
+    def test_gnm_strategy(self):
+        """Test calls of GNM for mixed strategy equilibria."""
+        result = gbt.nash.gnm_solve(self.poker)
+        assert len(result) == 1

--- a/src/pygambit/util.h
+++ b/src/pygambit/util.h
@@ -78,9 +78,13 @@ std::string WriteGame(const StrategySupportProfile &p_support)
 
 // Create a copy on the heap (via new) of the element at index p_index of 
 // container p_container.
-template <template<class> class C, class T, class X> 
+template <template<class> class C, class T, class X>
 T *copyitem(const C<T> &p_container, const X &p_index)
 { return new T(p_container[p_index]); }
+
+template <template<class> class C, class T, class X>
+std::shared_ptr<T> sharedcopyitem(const C<T> &p_container, const X &p_index)
+{ return make_shared<T>(p_container[p_index]); }
 
 // Set item p_index to value p_value in container p_container
 template <class C, class X, class T> 

--- a/src/solvers/enummixed/enummixed.h
+++ b/src/solvers/enummixed/enummixed.h
@@ -79,7 +79,17 @@ private:
   static bool EqZero(const T &x);
 };
 
- 
+
+inline List<MixedStrategyProfile<double> > EnumMixedStrategySolveDouble(const Game &p_game)
+{
+  return EnumMixedStrategySolver<double>().Solve(p_game);
+}
+
+inline List<MixedStrategyProfile<Rational> > EnumMixedStrategySolveRational(const Game &p_game)
+{
+  return EnumMixedStrategySolver<Rational>().Solve(p_game);
+}
+
 
  
 //
@@ -94,6 +104,11 @@ public:
 
   List<MixedStrategyProfile<Rational> > Solve(const Game &p_game) const override;
 };
+
+inline List<MixedStrategyProfile<Rational> > EnumMixedStrategySolveLrs(const Game &p_game)
+{
+  return EnumMixedLrsStrategySolver().Solve(p_game);
+}
 
 }  // end namespace Gambit::Nash
 }  // end namespace Gambit

--- a/src/solvers/enumpure/enumpure.h
+++ b/src/solvers/enumpure/enumpure.h
@@ -58,6 +58,11 @@ EnumPureStrategySolver::Solve(const Game &p_game) const
   return solutions;
 }
 
+inline List<MixedStrategyProfile<Rational> > EnumPureStrategySolve(const Game &p_game)
+{
+  return EnumPureStrategySolver().Solve(p_game);
+}
+
 ///
 /// Enumerate pure-strategy agent Nash equilibria of a game.  This uses
 /// the extensive representation.  Agent Nash equilibria are not necessarily
@@ -86,6 +91,11 @@ EnumPureAgentSolver::Solve(const BehaviorSupportProfile &p_support) const
     }
   }
   return solutions;
+}
+
+inline List<MixedBehaviorProfile<Rational> > EnumPureAgentSolve(const Game &p_game)
+{
+  return EnumPureAgentSolver().Solve(BehaviorSupportProfile(p_game));
 }
 
 }  // end namespace Nash

--- a/src/solvers/gnm/gnm.h
+++ b/src/solvers/gnm/gnm.h
@@ -54,6 +54,10 @@ private:
 						const gametracer::cvector &p_pert);
 };
 
+inline List<MixedStrategyProfile<double> > GNMStrategySolve(const Game &p_game) {
+  return NashGNMStrategySolver().Solve(p_game);
+}
+
 }  // end namespace Gambit::Nash
 }  // end namespace Gambit
 

--- a/src/solvers/ipa/ipa.h
+++ b/src/solvers/ipa/ipa.h
@@ -40,6 +40,11 @@ public:
 					    const Array<double> &p_pert) const;
 };
 
+inline List<MixedStrategyProfile<double> > IPAStrategySolve(const Game &p_game)
+{
+  return NashIPAStrategySolver().Solve(p_game);
+}
+
 }  // end namespace Gambit::Nash
 }  // end namespace Gambit
  

--- a/src/solvers/lcp/lcp.h
+++ b/src/solvers/lcp/lcp.h
@@ -53,7 +53,19 @@ private:
   void AllLemke(const Game &, int j, linalg::LHTableau<T> &, Solution &, int) const;
 };
 
- 
+inline List<MixedStrategyProfile<double> >
+LcpStrategySolveDouble(const Game &p_game, int p_stopAfter, int p_maxDepth)
+{
+  return NashLcpStrategySolver<double>(p_stopAfter, p_maxDepth).Solve(p_game);
+}
+
+inline List<MixedStrategyProfile<Rational> >
+LcpStrategySolveRational(const Game &p_game, int p_stopAfter, int p_maxDepth)
+{
+  return NashLcpStrategySolver<Rational>(p_stopAfter, p_maxDepth).Solve(p_game);
+}
+
+
 template <class T> class NashLcpBehaviorSolver : public BehavSolver<T> {
 public:
   NashLcpBehaviorSolver(int p_stopAfter, int p_maxDepth,
@@ -78,6 +90,18 @@ private:
 		  const GameNode &n, int, int,
 		  Solution &) const;
 };
+
+inline List<MixedBehaviorProfile<double> >
+LcpBehaviorSolveDouble(const Game &p_game, int p_stopAfter, int p_maxDepth)
+{
+  return NashLcpBehaviorSolver<double>(p_stopAfter, p_maxDepth).Solve(BehaviorSupportProfile(p_game));
+}
+
+inline List<MixedBehaviorProfile<Rational> >
+LcpBehaviorSolveRational(const Game &p_game, int p_stopAfter, int p_maxDepth)
+{
+  return NashLcpBehaviorSolver<Rational>(p_stopAfter, p_maxDepth).Solve(BehaviorSupportProfile(p_game));
+}
 
 }  // end namespace Nash
 }  // end namespace Gambit

--- a/src/solvers/liap/liap.h
+++ b/src/solvers/liap/liap.h
@@ -46,6 +46,10 @@ private:
   bool m_verbose;
 };
 
+inline List<MixedBehaviorProfile<double> > LiapBehaviorSolve(const Game &p_game, int p_maxitsN)
+{
+  return NashLiapBehaviorSolver(p_maxitsN).Solve(BehaviorSupportProfile(p_game));
+}
 
 class NashLiapStrategySolver : public StrategySolver<double> {
 public:
@@ -64,6 +68,11 @@ private:
   int m_maxitsN;
   bool m_verbose;
 };
+
+inline List<MixedStrategyProfile<double> > LiapStrategySolve(const Game &p_game, int p_maxitsN)
+{
+  return NashLiapStrategySolver(p_maxitsN).Solve(p_game);
+}
 
 
 #endif  // GAMBIT_NASH_LIAP_H

--- a/src/solvers/simpdiv/simpdiv.h
+++ b/src/solvers/simpdiv/simpdiv.h
@@ -76,6 +76,11 @@ private:
   int get_b(int j, int h, int nstrats, const PVector<int> &) const;
 };
 
+inline List<MixedStrategyProfile<Rational> > SimpdivStrategySolve(const Game &p_game)
+{
+  return NashSimpdivStrategySolver().Solve(p_game);
+}
+
 }  // end namespace Gambit::Nash
 }  // end namespace Gambit
 

--- a/src/tools/lp/efglp.h
+++ b/src/tools/lp/efglp.h
@@ -43,5 +43,15 @@ private:
 		       int, Array<T> &, Array<T> &) const;
 };
 
+inline List<MixedBehaviorProfile<double> > LpBehaviorSolveDouble(const Game &p_game)
+{
+  return NashLpBehavSolver<double>().Solve(BehaviorSupportProfile(p_game));
+}
+
+inline List<MixedBehaviorProfile<Rational> > LpBehaviorSolveRational(const Game &p_game)
+{
+  return NashLpBehavSolver<Rational>().Solve(BehaviorSupportProfile(p_game));
+}
+
 
 #endif  // LP_EFGLP_H

--- a/src/tools/lp/nfglp.h
+++ b/src/tools/lp/nfglp.h
@@ -30,7 +30,7 @@ using namespace Gambit::Nash;
 
 template <class T> class NashLpStrategySolver : public StrategySolver<T> {
 public:
-  NashLpStrategySolver(std::shared_ptr<StrategyProfileRenderer<T> > p_onEquilibrium = 0)
+  NashLpStrategySolver(std::shared_ptr<StrategyProfileRenderer<T> > p_onEquilibrium = nullptr)
     : StrategySolver<T>(p_onEquilibrium) { }
   ~NashLpStrategySolver() override = default;
 
@@ -41,5 +41,14 @@ private:
 		       int, Array<T> &, Array<T> &) const;
 };
 
+inline List<MixedStrategyProfile<double> > LpStrategySolveDouble(const Game &p_game)
+{
+  return NashLpStrategySolver<double>().Solve(p_game);
+}
+
+inline List<MixedStrategyProfile<Rational> > LpStrategySolveRational(const Game &p_game)
+{
+  return NashLpStrategySolver<Rational>().Solve(p_game);
+}
 
 #endif // LP_NFGLP_H


### PR DESCRIPTION
* In Python/Cython, this removes the cumbersome class-based algorithm interfaces in favour of simpler function-based ones.
* Simple function interfaces have been added to C++ as well.
* Memory handling for QRE results has been converted to shared_ptr.
* Adds test suite for calls to Nash-finding methods - these are intended simply to ensure that a call to the method works in principle, and are not a complete test suite for individual methods.
* Calls to the external command-line tools are now deprecated.
* The documentation has been updated to remove references to the external tools and to list the methods available in pygambit.nash.