### PR TITLE
Remove obsolete game restriction support in C++

### DIFF
--- a/src/games/game.cc
+++ b/src/games/game.cc
@@ -35,7 +35,7 @@ namespace Gambit {
 
 GameOutcomeRep::GameOutcomeRep(GameRep *p_game, int p_number)
   : m_game(p_game), m_number(p_number),
-    m_payoffs(m_game->NumPlayers()), m_unrestricted(nullptr)
+    m_payoffs(m_game->NumPlayers())
 { }
 
 
@@ -61,7 +61,7 @@ void GameStrategyRep::DeleteStrategy()
 //========================================================================
 
 GamePlayerRep::GamePlayerRep(GameRep *p_game, int p_id, int p_strats)
-  : m_game(p_game), m_number(p_id), m_strategies(p_strats), m_unrestricted(nullptr)
+  : m_game(p_game), m_number(p_id), m_strategies(p_strats)
 { 
   for (int j = 1; j <= p_strats; j++) {
     m_strategies[j] = new GameStrategyRep(this);
@@ -274,15 +274,6 @@ PureStrategyProfileRep::ToMixedStrategyProfile() const
     temp[GetStrategy(m_nfg->GetPlayer(pl))] = Rational(1);
   }
   return temp;
-}
-
-PureStrategyProfile PureStrategyProfileRep::Unrestrict() const
-{
-  PureStrategyProfile u = m_nfg->Unrestrict()->NewPureStrategyProfile();
-  for (auto player : this->m_nfg->GetPlayers()) {
-    u->SetStrategy(GetStrategy(player)->Unrestrict());
-  }
-  return u;
 }
 
 //========================================================================

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -243,7 +243,6 @@ private:
   int m_number;
   std::string m_label;
   Array<Number> m_payoffs;
-  GameOutcome m_unrestricted;
 
   /// @name Lifecycle
   //@{
@@ -271,9 +270,6 @@ public:
   void SetPayoff(int pl, const Number &p_value)
     { m_payoffs[pl] = p_value; }
 
-  /// Map the outcome to the corresponding outcome in the unrestricted game
-  GameOutcome Unrestrict() const 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
   //@}
 };
 
@@ -282,9 +278,7 @@ typedef GameObjectPtr<GameOutcomeRep> GameOutcome;
 /// An action at an information set in an extensive game
 class GameActionRep : public GameObject {
 protected:
-  GameAction m_unrestricted;
-
-  GameActionRep() : m_unrestricted(nullptr) { }
+  GameActionRep() = default;
   ~GameActionRep() override = default;
 
 public:
@@ -298,18 +292,12 @@ public:
 
   virtual void DeleteAction() = 0;
 
-  /// Map the action to the corresponding action in the unrestricted game
-  GameAction Unrestrict() const 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
-
 };
 
 /// An information set in an extensive game
 class GameInfosetRep : public GameObject {
 protected:
-  GameInfoset m_unrestricted;
- 
-  GameInfosetRep(): m_unrestricted(nullptr) { }
+  GameInfosetRep() = default;
   ~GameInfosetRep() override = default;
 
 public:
@@ -343,10 +331,6 @@ public:
 
   virtual const Number &GetActionProb(int i) const = 0;
   virtual void Reveal(GamePlayer) = 0;
-
-  /// Map the infoset to the corresponding infoset in the unrestricted game
-  GameInfoset Unrestrict() const 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
 };
 
 /// \brief A strategy in a game.
@@ -379,13 +363,12 @@ private:
   long m_offset;
   std::string m_label;
   Array<int> m_behav;
-  GameStrategy m_unrestricted;
 
   /// @name Lifecycle
   //@{
   /// Creates a new strategy for the given player.
   explicit GameStrategyRep(GamePlayerRep *p_player)
-    : m_number(0), m_id(0), m_player(p_player), m_offset(0L), m_unrestricted(nullptr) { }
+    : m_number(0), m_id(0), m_player(p_player), m_offset(0L) { }
   //@}
 
 public:
@@ -405,10 +388,6 @@ public:
 
   /// Remove this strategy from the game
   void DeleteStrategy();
-
-  /// Map the strategy to the corresponding strategy in the unrestricted game
-  GameStrategy Unrestrict() const
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
   //@}
 };
 
@@ -441,10 +420,9 @@ private:
   std::string m_label;
   Array<GameTreeInfosetRep *> m_infosets;
   GameStrategyArray m_strategies;
-  GamePlayer m_unrestricted;
 
   GamePlayerRep(GameRep *p_game, int p_id) 
-    : m_game(p_game), m_number(p_id), m_unrestricted(nullptr) { }
+    : m_game(p_game), m_number(p_id) { }
   GamePlayerRep(GameRep *p_game, int p_id, int m_strats);
   ~GamePlayerRep() override;
 
@@ -475,19 +453,12 @@ public:
   /// Creates a new strategy for the player
   GameStrategy NewStrategy();
   //@}
-
-  /// Map the player to the corresponding player in the unrestricted game
-  GamePlayer Unrestrict() const 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
-
 };
 
 /// A node in an extensive game
 class GameNodeRep : public GameObject {
 protected:
-  GameNode m_unrestricted;
-
-  GameNodeRep() : m_unrestricted(nullptr) { }
+  GameNodeRep() = default;
   ~GameNodeRep() override = default;
 
 public:
@@ -532,10 +503,6 @@ public:
   virtual GameInfoset AppendMove(GameInfoset p_infoset) = 0;
   virtual GameInfoset InsertMove(GamePlayer p_player, int p_actions) = 0;
   virtual GameInfoset InsertMove(GameInfoset p_infoset) = 0;
-
-  /// Map the node to the corresponding node in the unrestricted game
-  GameNode Unrestrict() const 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
 };
 
 
@@ -601,10 +568,6 @@ public:
 
   /// Convert to a mixed strategy representation
   MixedStrategyProfile<Rational> ToMixedStrategyProfile() const;
-
-  /// Map strategy profile to the unrestriction of the game
-  PureStrategyProfile Unrestrict() const;
-
   //@}
 };
 
@@ -771,11 +734,6 @@ public:
 
   /// Returns true if the game has a action-graph game representation
   virtual bool IsAgg() const { return false; }
-
-  /// Returns true if the game is a restriction of a more general game
-  virtual bool IsRestriction() const { return false; }
-  /// Returns the unrestricted version of the game
-  virtual Game Unrestrict() const { throw UndefinedException(); }
 
   /// Get the text label associated with the game
   virtual const std::string &GetTitle() const { return m_title; }

--- a/src/games/gametable.h
+++ b/src/games/gametable.h
@@ -36,7 +36,6 @@ class GameTableRep : public GameExplicitRep {
   template <class T> friend class TableMixedStrategyProfileRep;
 private:
   Array<GameOutcomeRep *> m_results;
-  Game m_unrestricted;
 
   /// @name Private auxiliary functions
   //@{
@@ -59,13 +58,6 @@ public:
   bool IsConstSum() const override;
   bool IsPerfectRecall(GameInfoset &, GameInfoset &) const override
   { return true; }
-  //@}
-
-  /// @name Interface with restricted game mechanism
-  //@{
-  bool IsRestriction() const override { return (m_unrestricted != nullptr); }
-  Game Unrestrict() const override 
-  { if (m_unrestricted) return m_unrestricted; else throw UndefinedException(); }
   //@}
 
   /// @name Dimensions of the game

--- a/src/games/mixed.h
+++ b/src/games/mixed.h
@@ -224,9 +224,6 @@ public:
 
   /// Converts the profile to one on the full support of the game
   MixedStrategyProfile<T> ToFullSupport() const;
-
-  /// Converts the profile to one on the unrestricted parent of the game
-  MixedStrategyProfile<T> Unrestrict() const;
   //@}
 
   /// @name Computation of interesting quantities

--- a/src/games/mixed.imp
+++ b/src/games/mixed.imp
@@ -566,20 +566,6 @@ MixedStrategyProfile<T> MixedStrategyProfile<T>::ToFullSupport() const
   return full;
 }
 
-template <class T> MixedStrategyProfile<T> MixedStrategyProfile<T>::Unrestrict() const
-{
-  MixedStrategyProfile<T> full(m_rep->m_support.GetGame()->Unrestrict()->NewMixedStrategyProfile((T) 0));
-  static_cast<Vector<T> &>(full) = (T) 0;
-
-  for (auto player : GetGame()->GetPlayers()) {
-    for (GameStrategyArray::const_iterator strategy = player->Strategies().begin();
-	 strategy != player->Strategies().end(); ++strategy) {
-      full[strategy->Unrestrict()] = (*this)[*strategy];
-    }
-  }
-  return full;	
-}
-
 //========================================================================
 //    MixedStrategyProfile<T>: Computation of interesting quantities
 //========================================================================

--- a/src/games/stratspt.cc
+++ b/src/games/stratspt.cc
@@ -390,25 +390,6 @@ bool StrategySupportProfile::Overwhelms(const GameStrategy &s,
   return true;
 }
 
-Game StrategySupportProfile::Restrict() const
-{
-  std::ostringstream os;
-  WriteNfgFile(os);
-  std::istringstream is(os.str());
-  Game restricted = ReadGame(is);
-  for (int pl = 1; pl <= restricted->NumPlayers(); pl++) {
-    GamePlayerRep *player = restricted->GetPlayer(pl);
-    player->m_unrestricted = m_nfg->GetPlayer(pl);
-    for (int st = 1; st <= player->NumStrategies(); st++) {
-      GameStrategyRep *strategy = player->m_strategies[st];
-      strategy->m_unrestricted = m_nfg->GetPlayer(pl)->Strategies()[st];
-    }
-  }
-  dynamic_cast<GameTableRep &>(*restricted).m_unrestricted = m_nfg;
-  return restricted;
-}
-
-
 //===========================================================================
 //                     class StrategySupportProfile::iterator
 //===========================================================================

--- a/src/games/stratspt.h
+++ b/src/games/stratspt.h
@@ -148,9 +148,6 @@ public:
                   bool p_strict) const;
   //@}
 
-  Game Restrict() const;
-
-
   class iterator {
   public:
     /// @name Lifecycle


### PR DESCRIPTION
This removes obsolete and unused code in the C++ game library for representing the concept of a "restriction" of a game.  We have decided there are much better ways of accomplishing what the concept aimed to do.