### PR TITLE
In pygambit, access outcome payoffs only by player reference.

### DIFF
--- a/doc/pygambit.user.rst
+++ b/doc/pygambit.user.rst
@@ -145,21 +145,26 @@ an existing information set (represented in `pygambit` as an :py:class:`.Infoset
 Building a strategic game
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Games in strategic form are created using :py:meth:`.Game.new_table`, which
-takes a list of integers specifying the number of strategies for
-each player::
+Games in strategic form, also referred to as normal form, are represented solely
+by a collection of payoff tables, one per player.  The most direct way to create
+a strategic game is via :py:meth:`.Game.from_arrays`.  This function takes one
+n-dimensional array per player, where n is the number of players in the game.
+The arrays can be any object that can be indexed like an n-times-nested Python list;
+so, for example, NumPy arrays can be used directly.
 
-  In [1]: g = gbt.Game.new_table([2,2])
+For example, to create a standard prisoner's dilemma game in which the cooperative
+payoff is 8, the betrayal payoff is 10, the sucker payoff is 2, and the noncooperative
+payoff is 5::
 
-  In [2]: g.title = "A prisoner's dilemma game"
+  In [1]: import numpy as np
 
-  In [3]: g.players[0].label = "Alphonse"
+  In [2]: m = np.array([[8, 2], [10, 5]])
 
-  In [4]: g.players[1].label = "Gaston"
+  In [3]: g = gbt.Game.from_arrays(m, np.transpose(m))
 
-  In [5]: g
-  Out[5]:
-  NFG 1 R "A prisoner's dilemma game" { "Alphonse" "Gaston" }
+  In [4]: g
+  Out[4]:
+  NFG 1 R "Untitled strategic game" { "1" "2" }
 
   { { "1" "2" }
   { "1" "2" }
@@ -167,65 +172,17 @@ each player::
   ""
 
   {
+  { "" 8, 8 }
+  { "" 10, 2 }
+  { "" 2, 10 }
+  { "" 5, 5 }
   }
-  0 0 0 0
+  1 2 3 4
 
-The :py:attr:`.Player.strategies` collection for a
-:py:class:`.Player` lists all the
-strategies available for that player::
-
-  In [6]: g.players[0].strategies
-  Out[6]: [<Strategy [0] '1' for player 'Alphonse' in game 'A
-  prisoner's dilemma game'>,
-           <Strategy [1] '2' for player 'Alphonse' in game 'A prisoner's dilemma game'>]
-
-  In [7]: len(g.players[0].strategies)
-  Out[7]: 2
-
-  In [8]: g.players[0].strategies[0].label = "Cooperate"
-
-  In [9]: g.players[0].strategies[1].label = "Defect"
-
-  In [10]: g.players[0].strategies
-  Out[10]: [<Strategy [0] 'Cooperate' for player 'Alphonse' in game 'A
-  prisoner's dilemma game'>,
-            <Strategy [1] 'Defect' for player 'Alphonse' in game 'A prisoner's dilemma game'>]
-
-The outcome associated with a particular combination of strategies is
-accessed by treating the game like an array. For a game :literal:`g`,
-:literal:`g[i,j]` is the outcome where the first player plays his
-:literal:`i` th strategy, and the second player plays his
-:literal:`j` th strategy.  Payoffs associated with an outcome are set
-or obtained by indexing the outcome by the player number.  For a
-prisoner's dilemma game where the cooperative payoff is 8, the
-betrayal payoff is 10, the sucker payoff is 2, and the noncooperative
-(equilibrium) payoff is 5::
-
-  In [11]: g[0,0][0] = 8
-
-  In [12]: g[0,0][1] = 8
-
-  In [13]: g[0,1][0] = 2
-
-  In [14]: g[0,1][1] = 10
-
-  In [15]: g[1,0][0] = 10
-
-  In [16]: g[1,1][1] = 2
-
-  In [17]: g[1,0][1] = 2
-
-  In [18]: g[1,1][0] = 5
-
-  In [19]: g[1,1][1] = 5
-
-Alternatively, one can use :py:meth:`.Game.from_arrays` in conjunction
-with numpy arrays to construct a game with desired payoff matrices
-more directly, as in::
-
-  In [20]: m = numpy.array([[8, 2], [10, 5]])
-
-  In [21]: g = gbt.Game.from_arrays(m, numpy.transpose(m))
+The arrays passed to :py:meth:`.Game.from_arrays` are all indexed in the same sense, that is,
+the top level index is the choice of the first player, the second level index of the second player,
+and so on.  Therefore, to create a two-player symmetric game, as in this example, the payoff matrix
+for the second player is transposed before passing to :py:meth:`.Game.from_arrays`.
 
 
 Representation of numerical data of a game
@@ -356,33 +313,6 @@ formats can be loaded using :meth:`.Game.read_game`::
   { "" 2, 0 }
   }
   1 2 3 4 5 6
-
-Iterating the pure strategy profiles in a game
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Each entry in a strategic game corresponds to the outcome arising from
-a particular combination fo pure strategies played by the players.
-The property :py:attr:`.Game.contingencies` is the collection of
-all such combinations.  Iterating over the contingencies collection
-visits each pure strategy profile possible in the game::
-
-   In [1]: g = gbt.Game.read_game("e02.nfg")
-
-   In [2]: list(g.contingencies)
-   Out[2]: [[0, 0], [0, 1], [1, 0], [1, 1], [2, 0], [2, 1]]
-
-Each pure strategy profile can then be used to access individual
-outcomes and payoffs in the game::
-
-   In [3]: for profile in g.contingencies:
-      ...:     print(profile, g[profile][0], g[profile][1])
-      ...:
-   [0, 0] 1 1
-   [0, 1] 1 1
-   [1, 0] 0 2
-   [1, 1] 0 3
-   [2, 0] 0 2
-   [2, 1] 2 0
 
 
 Mixed strategy and behavior profiles

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -267,9 +267,13 @@ public:
 
   /// Gets the payoff associated with the outcome to player 'pl'
   const Number &GetPayoff(int pl) const { return m_payoffs[pl]; }
+  /// Gets the payoff associated with the outcome to the player
+  const Number &GetPayoff(const GamePlayer &p_player) const;
   /// Sets the payoff to player 'pl'
   void SetPayoff(int pl, const Number &p_value)
     { m_payoffs[pl] = p_value; }
+  /// Sets the payoff to the player
+  void SetPayoff(const GamePlayer &p_player, const Number &p_value);
 
   /// Map the outcome to the corresponding outcome in the unrestricted game
   GameOutcome Unrestrict() const 
@@ -903,6 +907,20 @@ Game NewTable(const Array<int> &p_dim, bool p_sparseOutcomes = false);
 // all classes to be defined.
 
 inline Game GameOutcomeRep::GetGame() const { return m_game; }
+inline const Number &GameOutcomeRep::GetPayoff(const GamePlayer &p_player) const
+{
+  if (p_player->GetGame() != GetGame()) {
+    throw MismatchException();
+  }
+  return m_payoffs[p_player->GetNumber()];
+}
+inline void GameOutcomeRep::SetPayoff(const GamePlayer &p_player, const Number &p_value)
+{
+  if (p_player->GetGame() != GetGame()) {
+    throw MismatchException();
+  }
+  m_payoffs[p_player->GetNumber()] = p_value;
+}
 
 inline GamePlayer GameStrategyRep::GetPlayer() const { return m_player; }
 

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -141,8 +141,8 @@ cdef extern from "games/game.h":
           string GetLabel()
           void SetLabel(string)
 
-          c_Number GetPayoff(int) except +IndexError
-          void SetPayoff(int, c_Number) except +IndexError
+          c_Number GetPayoff(c_GamePlayer) except +IndexError
+          void SetPayoff(c_GamePlayer, c_Number) except +IndexError
 
      cdef cppclass c_GameNodeRep "GameNodeRep":
           c_Game GetGame()
@@ -225,7 +225,7 @@ cdef extern from "games/game.h":
           c_GameOutcome GetOutcome()
           void SetOutcome(c_GameOutcome)
 
-          c_Rational GetPayoff(int)
+          c_Rational GetPayoff(c_GamePlayer)
 
      c_Game NewTree()
      c_Game NewTable(Array[int] *)

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -259,8 +259,8 @@ class Game:
         for profile in itertools.product(
                 *(range(arrays[0].shape[i]) for i in range(len(g.players)))
         ):
-            for pl in range(len(g.players)):
-                g[profile][pl] = arrays[pl][profile]
+            for pl, player in enumerate(g.players):
+                g[profile][player] = arrays[pl][profile]
         g.title = title
         return g
 
@@ -1318,7 +1318,7 @@ class Game:
         if str(label) != "":
             c.label = str(label)
         for player, payoff in zip(self.players, payoffs):
-            c[player.number] = payoff
+            c[player] = payoff
         return c
 
     def delete_outcome(self, outcome: typing.Union[Outcome, str]) -> None:

--- a/src/pygambit/outcome.pxi
+++ b/src/pygambit/outcome.pxi
@@ -22,6 +22,8 @@
 from cython.operator cimport dereference as deref
 from libcpp.memory cimport shared_ptr
 
+import typing
+
 from deprecated import deprecated
 
 @cython.cclass
@@ -36,7 +38,7 @@ class Outcome:
         )
     
     def __eq__(self, other: typing.Any) -> bool:
-        return isinstance(other, Outcome) and self.outcome.deref() == (<Outcome> other).outcome.deref()
+        return isinstance(other, Outcome) and self.outcome.deref() == cython.cast(Outcome, other).outcome.deref()
 
     def __hash__(self) -> int:
         return cython.cast(cython.long, self.outcome.deref())
@@ -73,45 +75,49 @@ class Outcome:
             warnings.warn("Another outcome with an identical label exists")
         self.outcome.deref().SetLabel(value.encode('ascii'))
 
-    def __getitem__(self, player):
-        """Returns the payoff to ``player`` at the outcome.  ``player``
-        may be a `Player`, a string, or an integer.
-        If a string, returns the payoff to the player with that string
-        as its label.  If an integer, returns the payoff to player
-        number ``player``.
-        """
-        py_string = cython.declare(bytes)
-        if isinstance(player, Player):
-            py_string = self.outcome.deref().GetPayoff(player.number+1).as_string().c_str()
-        elif isinstance(player, str):
-            number = self.game.players[player].number
-            py_string = self.outcome.deref().GetPayoff(number+1).as_string().c_str()
-        elif isinstance(player, int):
-            py_string = self.outcome.deref().GetPayoff(player+1).as_string().c_str()
-        if "." in py_string.decode(b'ascii'):
-            return decimal.Decimal(py_string.decode(b'ascii'))
-        else:
-            return Rational(py_string.decode(b'ascii'))
-
-    def __setitem__(self, pl: int, value: typing.Any) -> None:
-        """
-        Set the payoff value to a specified player for the outcome.
-
-        Parameters
-        ----------
-        pl : int
-            The player number for which to set the payoff
-        value : Any
-            The value of the payoff.  This can be any numeric type, or any object that
-            has a string representation which can be interpreted as an integer,
-            decimal, or rational number.
+    def __getitem__(
+            self, player: typing.Union[Player, str]
+    ) -> typing.Union[decimal.Decimal, Rational]:
+        """The payoff to `player` at the outcome.
 
         Raises
         ------
-        ValueError
-              If ``payoff`` cannot be interpreted as a decimal or rational number.
+        MismatchError
+            If `player` is a ``Player`` from a different game than the outcome.
         """
-        self.outcome.deref().SetPayoff(pl+1, _to_number(value))
+        resolved_player = cython.cast(Player,
+                                      self.game._resolve_player(player, 'Outcome.__getitem__'))
+        payoff = (
+            cython.cast(bytes,
+                        self.outcome.deref().GetPayoff(resolved_player.player).as_string())
+            .decode('ascii')
+        )
+        if "." in payoff:
+            return decimal.Decimal(payoff)
+        else:
+            return Rational(payoff)
+
+    def __setitem__(self, player: typing.Union[Player, str], value: typing.Any) -> None:
+        """Set the payoff to `player` at the outcome.
+
+        Parameters
+        ----------
+        player : Player or str
+            A reference to the player for which to set the payoff.
+        value : Any
+            The value of the payoff.  This can be any numeric type, or any object that
+            has a string representation which can be interpreted as a number.
+
+        Raises
+        ------
+        MismatchError
+            If `player` is a ``Player`` from a different game than the outcome.
+        ValueError
+            If `value` cannot be interpreted as a number.
+        """
+        resolved_player = cython.cast(Player,
+                                      self.game._resolve_player(player, 'Outcome.__setitem__'))
+        self.outcome.deref().SetPayoff(resolved_player.player, _to_number(value))
 
 
 @cython.cclass
@@ -136,24 +142,32 @@ class TreeGameOutcome:
             deref(self.psp).deref() == deref(cython.cast(TreeGameOutcome, other).psp).deref()
         )
 
-    def __getitem__(self, player):
-        if isinstance(player, Player):
-            return rat_to_py(deref(self.psp).deref().GetPayoff(player.number+1))
-        elif isinstance(player, str):
-            number = self.game.players[player].number
-            return rat_to_py(deref(self.psp).deref().GetPayoff(number+1))
-        elif isinstance(player, int):
-            if player < 0 or player >= self.c_game.deref().NumPlayers():
-                raise IndexError("Index out of range")
-            return rat_to_py(deref(self.psp).deref().GetPayoff(player+1))
-        raise TypeError("player index should be a Player, int or str instance; {} passed"
-                        .format(player.__class__.__name__))
+    def __getitem__(self, player: typing.Union[Player, str]) -> Rational:
+        """The payoff to `player` at the outcome.
 
-    def __setitem__(self, pl, value):
-        raise NotImplementedError("Cannot modify outcomes in a derived strategic game.")
+        Parameters
+        ----------
+        player : Player or str
+            A reference to the player to get the payoff for
+
+        Returns
+        -------
+        Rational
+            The expected payoff to the player.  Because this is calculated in a derived
+            strategic game, it will always be represented as a ``Rational`` even if
+            game data are represented as ``Decimal``.
+
+        Raises
+        ------
+        MismatchError
+            If `player` is a ``Player`` from a different game than the outcome.
+        """
+        resolved_player = cython.cast(Player,
+                                      self.game._resolve_player(player, 'Outcome.__getitem__'))
+        return rat_to_py(deref(self.psp).deref().GetPayoff(resolved_player.player))
 
     def delete(self):
-        raise NotImplementedError("Cannot modify outcomes in a derived strategic game.")
+        raise UndefinedOperationError("Cannot modify outcomes in a derived strategic game.")
 
     @property
     def label(self) -> str:

--- a/src/pygambit/tests/test_extensive_outcomes.py
+++ b/src/pygambit/tests/test_extensive_outcomes.py
@@ -13,16 +13,16 @@ class TestGambitOutcomes(unittest.TestCase):
         del self.game
 
     def test_player1_outcomes(self):
-        assert self.game[[0, 0]][0] == 2
-        assert self.game[[0, 1]][0] == 2
-        assert self.game[[1, 0]][0] == 4
-        assert self.game[[1, 1]][0] == 6
+        assert self.game[[0, 0]]["Player 1"] == 2
+        assert self.game[[0, 1]]["Player 1"] == 2
+        assert self.game[[1, 0]]["Player 1"] == 4
+        assert self.game[[1, 1]]["Player 1"] == 6
 
     def test_player2_outcomes(self):
-        assert self.game[[0, 0]][1] == 3
-        assert self.game[[0, 1]][1] == 3
-        assert self.game[[1, 0]][1] == 5
-        assert self.game[[1, 1]][1] == 7
+        assert self.game[[0, 0]]["Player 2"] == 3
+        assert self.game[[0, 1]]["Player 2"] == 3
+        assert self.game[[1, 0]]["Player 2"] == 5
+        assert self.game[[1, 1]]["Player 2"] == 7
 
     def test_getting_payoff_by_label_string(self):
         assert self.game[[0, 0]]['Player 1'] == 2
@@ -47,4 +47,4 @@ class TestGambitOutcomes(unittest.TestCase):
         assert self.game[[1, 1]][player2] == 7
 
     def test_outcome_index_exception_int(self):
-        self.assertRaises(IndexError, self.game[[0, 0]].__getitem__, 3)
+        self.assertRaises(KeyError, self.game[[0, 0]].__getitem__, "Not a player")

--- a/src/pygambit/tests/test_game.py
+++ b/src/pygambit/tests/test_game.py
@@ -1,19 +1,27 @@
 import fractions
 import unittest
 
-import pygambit
+import numpy as np
+
+import pygambit as gbt
 
 
 class TestGambitGame(unittest.TestCase):
     def setUp(self):
-        self.game = pygambit.Game.new_table([2, 2])
-        self.extensive_game = pygambit.Game.read_game(
-            "test_games/basic_extensive_game.efg"
-        )
+        self.game = gbt.Game.new_table([2, 2])
+        self.extensive_game = gbt.Game.read_game("test_games/basic_extensive_game.efg")
 
     def tearDown(self):
         del self.game
         del self.extensive_game
+
+    def test_from_arrays(self):
+        """Test creating a two-player game from numpy arrays."""
+        m = np.array([[8, 2], [10, 5]])
+        g = gbt.Game.from_arrays(m, m.transpose())
+        assert len(g.players) == 2
+        assert len(g.players[0].strategies) == 2
+        assert len(g.players[1].strategies) == 2
 
     def test_game_get_outcome_with_ints(self):
         "To test getting the first outcome"
@@ -66,32 +74,32 @@ class TestGambitGame(unittest.TestCase):
 
     def test_game_is_const_sum(self):
         "To test checking if the game is constant sum"
-        game = pygambit.Game.read_game("test_games/const_sum_game.nfg")
+        game = gbt.Game.read_game("test_games/const_sum_game.nfg")
         assert game.is_const_sum
 
     def test_game_is_not_const_sum(self):
         "To test checking if the game is not constant sum"
-        game = pygambit.Game.read_game("test_games/non_const_sum_game.nfg")
+        game = gbt.Game.read_game("test_games/non_const_sum_game.nfg")
         assert not game.is_const_sum
 
     def test_game_get_min_payoff(self):
         "To test getting the minimum payoff of the game"
-        game = pygambit.Game.read_game("test_games/payoff_game.nfg")
+        game = gbt.Game.read_game("test_games/payoff_game.nfg")
         assert game.min_payoff == fractions.Fraction(1, 1)
 
     def test_game_get_max_payoff(self):
         "To test getting the maximum payoff of the game"
-        game = pygambit.Game.read_game("test_games/payoff_game.nfg")
+        game = gbt.Game.read_game("test_games/payoff_game.nfg")
         assert game.max_payoff == fractions.Fraction(10, 1)
 
     def test_game_is_perfect_recall(self):
         "To test checking if the game is of perfect recall"
-        game = pygambit.Game.read_game("test_games/perfect_recall.efg")
+        game = gbt.Game.read_game("test_games/perfect_recall.efg")
         assert game.is_perfect_recall
 
     def test_game_is_not_perfect_recall(self):
         "To test checking if the game is not of perfect recall"
-        game = pygambit.Game.read_game("test_games/not_perfect_recall.efg")
+        game = gbt.Game.read_game("test_games/not_perfect_recall.efg")
         assert not game.is_perfect_recall
 
     def test_game_behav_profile_error(self):
@@ -99,7 +107,7 @@ class TestGambitGame(unittest.TestCase):
         MixedBehavProfile from a game without a tree representation
         """
         self.assertRaises(
-            pygambit.UndefinedOperationError, self.game.mixed_behavior_profile, True
+            gbt.UndefinedOperationError, self.game.mixed_behavior_profile, True
         )
 
     def test_game_title(self):
@@ -142,7 +150,7 @@ class TestGambitGame(unittest.TestCase):
         """Test to ensure an error is raised when trying to access actions
         of a game without a tree representation
         """
-        self.assertRaises(pygambit.UndefinedOperationError, lambda: self.game.actions)
+        self.assertRaises(gbt.UndefinedOperationError, lambda: self.game.actions)
 
     def test_game_infosets(self):
         assert (
@@ -162,7 +170,7 @@ class TestGambitGame(unittest.TestCase):
         """Test to ensure an error is raised when trying to access infosets
         of a game without a tree representation
         """
-        self.assertRaises(pygambit.UndefinedOperationError, lambda: self.game.infosets)
+        self.assertRaises(gbt.UndefinedOperationError, lambda: self.game.infosets)
 
     def test_game_strategies(self):
         assert self.game.strategies[0] == self.game.players[0].strategies[0]
@@ -180,7 +188,7 @@ class TestGambitGame(unittest.TestCase):
         """Test to ensure an error is raised when trying to get the root
         node of a game without a tree representation
         """
-        self.assertRaises(pygambit.UndefinedOperationError, lambda: self.game.root)
+        self.assertRaises(gbt.UndefinedOperationError, lambda: self.game.root)
 
     def test_game_num_nodes(self):
         "Test retrieving the number of nodes of a game"
@@ -190,7 +198,7 @@ class TestGambitGame(unittest.TestCase):
     def test_game_dereference_invalid(self):
         "Test referencing an invalid game member object"
         def foo():
-            g = pygambit.Game.new_tree()
+            g = gbt.Game.new_tree()
             g.add_player("One")
             s = g.players[0].strategies[0]
             g.append_move(g.root, g.players[0], ["a", "b"])

--- a/src/pygambit/tests/test_outcomes.py
+++ b/src/pygambit/tests/test_outcomes.py
@@ -9,10 +9,10 @@ class TestGambitOutcomes(unittest.TestCase):
         self.game = pygambit.Game.new_table([2, 2])
         self.game.players[0].label = "joe"
         self.game.players[1].label = "dan"
-        self.game.outcomes[0][0] = 1
-        self.game.outcomes[0][1] = 2
-        self.game.outcomes[1][0] = 3
-        self.game.outcomes[1][1] = 4
+        self.game.outcomes[0]["joe"] = 1
+        self.game.outcomes[0]["dan"] = 2
+        self.game.outcomes[1]["joe"] = 3
+        self.game.outcomes[1]["dan"] = 4
 
     def tearDown(self):
         del self.game


### PR DESCRIPTION
This changes the method for accessing outcome payoffs in pygambit from integer indices to player references (either instances of Player, or label strings). This aligns with the conventions used elsewhere in the package.

Alongside this, the user guide has been revised to focus on .from_arrays as the most natural quick-start way to create a new game in strategic form.