### PR TITLE
Revises methods to change strategies for a player:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 - Migrated to pytest for testing of pygambit.
 - ValueErrors raised for mixed behavior profiles when payoff, action_value, or infoset_value are
   called with the chance player.
+- Implemented Game.delete_strategy to remove a strategy from a strategic game.
 
 
 ## [16.1.0a3] - 2023-09-29

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -76,6 +76,8 @@ Transforming game components
    Game.add_outcome
    Game.delete_outcome
    Game.set_outcome
+   Game.add_strategy
+   Game.delete_strategy
 
 
 Information about the game

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -87,6 +87,8 @@ cdef extern from "games/game.h":
           string GetLabel()
           void SetLabel(string)
 
+          void DeleteStrategy()
+
      cdef cppclass c_GameActionRep "GameActionRep":
           int GetNumber()
           c_GameInfoset GetInfoset()

--- a/src/pygambit/player.pxi
+++ b/src/pygambit/player.pxi
@@ -19,6 +19,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
+from deprecated import deprecated
 
 @cython.cclass
 class Infosets(Collection):
@@ -42,6 +43,9 @@ class Strategies(Collection):
     """The set of strategies available to a player."""
     player = cython.declare(c_GamePlayer)
 
+    @deprecated(version='16.1.0',
+                reason='Use Game.add_strategy() instead of Player.strategies.add()',
+                category=FutureWarning)
     def add(self, label="") -> Strategy:
         """Add a new strategy to the set of the player's strategies.
 

--- a/src/pygambit/tests/test_players.py
+++ b/src/pygambit/tests/test_players.py
@@ -70,15 +70,33 @@ def test_extensive_game_add_player():
 
 def test_strategic_game_add_strategy():
     game = gbt.Game.new_table([2, 2])
-    game.players[0].strategies.add("new strategy")
+    game.add_strategy(game.players[0], "new strategy")
     assert len(game.players[0].strategies) == 3
 
 
 def test_extensive_game_add_strategy():
     game = gbt.Game.new_tree(["Alice"])
     assert len(game.players["Alice"].strategies) == 1
-    with pytest.raises(TypeError):
-        game.players["Alice"].strategies.add("new strategy")
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.add_strategy(game.players["Alice"], "new strategy")
+
+
+def test_strategic_game_delete_strategy():
+    game = gbt.Game.new_table([2, 2])
+    game.delete_strategy(game.players[0].strategies[0])
+    assert len(game.players[0].strategies) == 1
+
+
+def test_strategic_game_delete_last_strategy():
+    game = gbt.Game.new_table([1, 2])
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.delete_strategy(game.players[0].strategies[0])
+
+
+def test_extensive_game_delete_strategy():
+    game = gbt.Game.new_tree(["Alice"])
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.delete_strategy(game.players["Alice"].strategies[0])
 
 
 def test_player_strategy_by_label():


### PR DESCRIPTION
* Moves `Player.strategies.add()` to `Game.add_strategy()`, with the old call deprecated, to be removed in 16.2.
* Implements `Game.delete_strategy()` to remove a strategy from a strategic game.