### PR TITLE
Implement regret for mixed strategy and behavior profiles.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,11 @@
 - ValueErrors raised for mixed behavior profiles when payoff, action_value, or infoset_value are
   called with the chance player.
 - Implemented Game.delete_strategy to remove a strategy from a strategic game.
+- Implemented regret for mixed strategy profiles.
+
+### Fixed
+- Regret on mixed behavior profiles now implements the standard definition of regret
+  (loss in expected payoff relative to best response conditional on reaching the information set).
 
 
 ## [16.1.0a3] - 2023-09-29

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -194,6 +194,7 @@ Probability distributions over strategies
    MixedStrategyProfile.__getitem__
    MixedStrategyProfile.__setitem__
    MixedStrategyProfile.payoff
+   MixedStrategyProfile.regret
    MixedStrategyProfile.strategy_value
    MixedStrategyProfile.strategy_value_deriv
    MixedStrategyProfileDouble.game

--- a/src/games/behav.h
+++ b/src/games/behav.h
@@ -46,7 +46,7 @@ protected:
 
   // structures for storing cached data: actions
   mutable DVector<T> m_actionValues;   // aka conditional payoffs
-  mutable DVector<T> m_gripe;
+  mutable DVector<T> m_regret;
 
   const T &ActionValue(const GameAction &act) const 
     { return m_actionValues(act->GetInfoset()->GetPlayer()->GetNumber(),

--- a/src/games/behav.imp
+++ b/src/games/behav.imp
@@ -41,61 +41,61 @@ MixedBehaviorProfile<T>::MixedBehaviorProfile(const MixedBehaviorProfile<T> &p_p
     m_nodeValues(p_profile.m_nodeValues),
     m_infosetValues(p_profile.m_infosetValues),
     m_actionValues(p_profile.m_actionValues),
-    m_gripe(p_profile.m_gripe)
+    m_regret(p_profile.m_regret)
 {
   m_realizProbs = (T) 0.0;
   m_beliefs = (T) 0.0;
   m_nodeValues = (T) 0.0;
   m_infosetValues = (T) 0.0;
   m_actionValues = (T) 0.0;
-  m_gripe = (T) 0.0;
+  m_regret = (T) 0.0;
 }
 
 template <class T> 
 MixedBehaviorProfile<T>::MixedBehaviorProfile(const Game &p_game)
-  : DVector<T>(p_game->NumActions()), 
+  : DVector<T>(p_game->NumActions()),
     m_support(BehaviorSupportProfile(p_game)),
     m_cacheValid(false),
     m_realizProbs(p_game->NumNodes()),
     m_beliefs(p_game->NumNodes()),
-    m_nvals(p_game->NumNodes()), 
+    m_nvals(p_game->NumNodes()),
     m_bvals(p_game->NumNodes()),
     m_nodeValues(p_game->NumNodes(),
 		 p_game->NumPlayers()),
     m_infosetValues(p_game->NumInfosets()),
     m_actionValues(p_game->NumActions()),
-    m_gripe(p_game->NumActions())
+    m_regret(p_game->NumActions())
 {
   m_realizProbs = (T) 0.0;
   m_beliefs = (T) 0.0;
   m_nodeValues = (T) 0.0;
   m_infosetValues = (T) 0.0;
   m_actionValues = (T) 0.0;
-  m_gripe = (T) 0.0;
+  m_regret = (T) 0.0;
   SetCentroid();
 }
 
 template <class T> 
 MixedBehaviorProfile<T>::MixedBehaviorProfile(const BehaviorSupportProfile &p_support) 
-  : DVector<T>(p_support.NumActions()), 
+  : DVector<T>(p_support.NumActions()),
     m_support(p_support),
     m_cacheValid(false),
     m_realizProbs(p_support.GetGame()->NumNodes()),
     m_beliefs(p_support.GetGame()->NumNodes()),
-    m_nvals(p_support.GetGame()->NumNodes()), 
+    m_nvals(p_support.GetGame()->NumNodes()),
     m_bvals(p_support.GetGame()->NumNodes()),
     m_nodeValues(p_support.GetGame()->NumNodes(),
 		 p_support.GetGame()->NumPlayers()),
     m_infosetValues(p_support.GetGame()->NumInfosets()),
     m_actionValues(p_support.GetGame()->NumActions()),
-    m_gripe(p_support.GetGame()->NumActions())
+    m_regret(p_support.GetGame()->NumActions())
 {
   m_realizProbs = (T) 0.0;
   m_beliefs = (T) 0.0;
   m_nodeValues = (T) 0.0;
   m_infosetValues = (T) 0.0;
   m_actionValues = (T) 0.0;
-  m_gripe = (T) 0.0;
+  m_regret = (T) 0.0;
   SetCentroid();
 }
 
@@ -155,7 +155,7 @@ void MixedBehaviorProfile<T>::RealizationProbs(const MixedStrategyProfile<T> &mp
 
 template <class T>
 MixedBehaviorProfile<T>::MixedBehaviorProfile(const MixedStrategyProfile<T> &p_profile)
-  : DVector<T>(p_profile.GetGame()->NumActions()), 
+  : DVector<T>(p_profile.GetGame()->NumActions()),
     m_support(p_profile.GetGame()),
     m_cacheValid(false),
     m_realizProbs(m_support.GetGame()->NumNodes()),
@@ -166,14 +166,14 @@ MixedBehaviorProfile<T>::MixedBehaviorProfile(const MixedStrategyProfile<T> &p_p
 		 m_support.GetGame()->NumPlayers()),
     m_infosetValues(m_support.GetGame()->NumInfosets()),
     m_actionValues(m_support.GetGame()->NumActions()),
-    m_gripe(m_support.GetGame()->NumActions())
+    m_regret(m_support.GetGame()->NumActions())
 {
   m_realizProbs = (T) 0.0;
   m_beliefs = (T) 0.0;
   m_nodeValues = (T) 0.0;
   m_infosetValues = (T) 0.0;
   m_actionValues = (T) 0.0;
-  m_gripe = (T) 0.0;
+  m_regret = (T) 0.0;
 
   ((Vector<T> &) *this).operator=((T)0); 
 
@@ -477,8 +477,8 @@ template <class T>
 const T &MixedBehaviorProfile<T>::GetRegret(const GameAction &act) const
 { 
   ComputeSolutionData();
-  return m_gripe(act->GetInfoset()->GetPlayer()->GetNumber(),
-		 act->GetInfoset()->GetNumber(), act->GetNumber());
+  return m_regret(act->GetInfoset()->GetPlayer()->GetNumber(),
+                  act->GetInfoset()->GetNumber(), act->GetNumber());
 }
 
 template <class T>
@@ -688,36 +688,40 @@ void MixedBehaviorProfile<T>::ComputeSolutionDataPass1(const GameNode &node) con
 template <class T>
 void MixedBehaviorProfile<T>::ComputeSolutionData() const
 {
-  if (!m_cacheValid) {
-    m_actionValues = (T) 0;
-    m_nodeValues = (T) 0;
-    m_infosetValues = (T) 0;
-    m_gripe = (T) 0;
-    ComputeSolutionDataPass1(m_support.GetGame()->GetRoot());
-    ComputeSolutionDataPass2(m_support.GetGame()->GetRoot());
+  if (m_cacheValid) {
+    return;
+  }
+  m_actionValues = (T) 0;
+  m_nodeValues = (T) 0;
+  m_infosetValues = (T) 0;
+  m_regret = (T) 0;
+  ComputeSolutionDataPass1(m_support.GetGame()->GetRoot());
+  ComputeSolutionDataPass2(m_support.GetGame()->GetRoot());
 
-    // At this point, mark the cache as value, so calls to GetPayoff()
-    // don't create a loop.
-    m_cacheValid = true;
+  // At this point, mark the cache as value, so calls to GetPayoff()
+  // don't create a loop.
+  m_cacheValid = true;
 
-    for (int pl = 1; pl <= m_support.GetGame()->NumPlayers(); pl++) {
-      for (int iset = 1; iset <= m_support.GetGame()->NumInfosets()[pl]; iset++) {
-	GameInfoset infoset = m_support.GetGame()->GetPlayer(pl)->GetInfoset(iset);
+  for (int pl = 1; pl <= m_support.GetGame()->NumPlayers(); pl++) {
+    for (int iset = 1; iset <= m_support.GetGame()->NumInfosets()[pl]; iset++) {
+      GameInfoset infoset = m_support.GetGame()->GetPlayer(pl)->GetInfoset(iset);
 
-	m_infosetValues(infoset->GetPlayer()->GetNumber(), infoset->GetNumber()) = (T) 0;
-	for (int act = 1; act <= infoset->NumActions(); act++) {
-	  GameAction action = infoset->GetAction(act);
-	  m_infosetValues(infoset->GetPlayer()->GetNumber(),
-			  infoset->GetNumber()) += GetActionProb(action) * ActionValue(action);
-	}
+      m_infosetValues(infoset->GetPlayer()->GetNumber(), infoset->GetNumber()) = (T) 0;
+      for (int act = 1; act <= infoset->NumActions(); act++) {
+        GameAction action = infoset->GetAction(act);
+        m_infosetValues(infoset->GetPlayer()->GetNumber(),
+                        infoset->GetNumber()) += GetActionProb(action) * ActionValue(action);
+      }
 
-	for (int act = 1; act <= infoset->NumActions(); act++) {
-	  GameAction action = infoset->GetAction(act);
-	  m_gripe(action->GetInfoset()->GetPlayer()->GetNumber(),
-		  action->GetInfoset()->GetNumber(),
-                  action->GetNumber()) = 
-	    (ActionValue(action) - GetPayoff(infoset)) * GetRealizProb(infoset);
-	}
+      T brpayoff = ActionValue(infoset->GetAction(1));
+      for (int act = 1; act <= infoset->NumActions(); act++) {
+        brpayoff = std::max(brpayoff, ActionValue(infoset->GetAction(act)));
+      }
+      for (int act = 1; act <= infoset->NumActions(); act++) {
+        GameAction action = infoset->GetAction(act);
+        m_regret(action->GetInfoset()->GetPlayer()->GetNumber(),
+                 action->GetInfoset()->GetNumber(),
+                 act) = brpayoff - ActionValue(action);
       }
     }
   }

--- a/src/games/mixed.h
+++ b/src/games/mixed.h
@@ -52,6 +52,8 @@ public:
   virtual T GetPayoff(int pl) const = 0;
   virtual T GetPayoffDeriv(int pl, const GameStrategy &) const = 0;
   virtual T GetPayoffDeriv(int pl, const GameStrategy &, const GameStrategy &) const = 0;
+
+  T GetRegret(const GameStrategy &) const;
 };
 
 template <class T> class TreeMixedStrategyProfileRep 
@@ -252,6 +254,11 @@ public:
   /// Computes the payoff to playing the pure strategy against the profile
   T GetPayoff(const GameStrategy &p_strategy) const
   { return GetPayoffDeriv(p_strategy->GetPlayer()->GetNumber(), p_strategy); }
+
+  /// Computes the regret to playing the pure strategy compared to the payoff
+  /// of the best response
+  T GetRegret(const GameStrategy &p_strategy) const
+  { return m_rep->GetRegret(p_strategy); }
 
   /// \brief Computes the Lyapunov value of the profile
   ///

--- a/src/games/mixed.imp
+++ b/src/games/mixed.imp
@@ -120,6 +120,22 @@ template <class T> void MixedStrategyProfileRep<T>::Randomize(int p_denom)
   }
 }
 
+template <class T>
+T MixedStrategyProfileRep<T>::GetRegret(const GameStrategy &p_strategy) const
+{
+  GamePlayer player = p_strategy->GetPlayer();
+  T payoff = GetPayoffDeriv(player->GetNumber(), p_strategy);
+  T brpayoff = payoff;
+  for (int st = 1; st <= player->NumStrategies(); st++) {
+    if (st != p_strategy->GetNumber()) {
+      brpayoff = std::max(brpayoff,
+                          GetPayoffDeriv(player->GetNumber(), player->GetStrategy(st)));
+    }
+  }
+  return brpayoff - payoff;
+}
+
+
 //========================================================================
 //                   TreeMixedStrategyProfileRep<T>
 //========================================================================

--- a/src/pygambit/behav.pxi
+++ b/src/pygambit/behav.pxi
@@ -359,8 +359,13 @@ class MixedBehaviorProfile:
         return self._infoset_prob(self.game._resolve_infoset(infoset, 'infoset_prob'))
 
     def regret(self, action: typing.Union[Action, str]):
-        """Returns the regret associated with `action`.  The regret is the loss of
-        payoff relative to the best response to the profile.
+        """Returns the regret to playing `action`, if all other
+        players play according to the profile.
+
+        The regret is defined as the difference between the payoff of the
+        best-response action and the payoff of `action`.  Payoffs are computed
+        conditional on reaching the information set.  By convention, the
+        regret is always non-negative.
 
         Parameters
         ----------

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -246,6 +246,7 @@ cdef extern from "games/mixed.h":
           double getitem_strategy "operator[]"(c_GameStrategy) except +IndexError
           double GetPayoff(c_GamePlayer)
           double GetPayoff(c_GameStrategy)
+          double GetRegret(c_GameStrategy)
           double GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
           double GetLiapValue()
           c_MixedStrategyProfileDouble ToFullSupport()
@@ -263,6 +264,7 @@ cdef extern from "games/mixed.h":
           c_Rational getitem_strategy "operator[]"(c_GameStrategy) except +IndexError
           c_Rational GetPayoff(c_GamePlayer)
           c_Rational GetPayoff(c_GameStrategy)
+          c_Rational GetRegret(c_GameStrategy)
           c_Rational GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
           c_Rational GetLiapValue()
           c_MixedStrategyProfileRational ToFullSupport()

--- a/src/pygambit/mixed.pxi
+++ b/src/pygambit/mixed.pxi
@@ -191,6 +191,29 @@ class MixedStrategyProfile:
         """
         return self._strategy_value(self.game._resolve_strategy(strategy, 'strategy_value'))
 
+    def regret(self, strategy: typing.Union[Strategy, str]):
+        """Returns the regret to playing `strategy`, if all other
+        players play according to the profile.
+
+        The regret is defined as the difference between the payoff of the
+        best-response strategy and the payoff of `strategy`.  By convention, the
+        regret is always non-negative.
+
+        Parameters
+        ----------
+        strategy : Strategy or str
+            The strategy to get the regret for.  If a string is passed, the
+            strategy is determined by finding the strategy with that label, if any.
+
+        Raises
+        ------
+        MismatchError
+            If `strategy` is a `Strategy` from a different game.
+        KeyError
+            If `strategy` is a string and no strategy in the game has that label.
+        """
+        return self._regret(self.game._resolve_strategy(strategy, 'regret'))
+
     def strategy_value_deriv(self, strategy: typing.Union[Strategy, str], other: typing.Union[Strategy, str]):
         """Returns the derivative of the payoff to playing `strategy`, with respect to the probability
         that `other` is played.
@@ -226,6 +249,9 @@ class MixedStrategyProfileDouble(MixedStrategyProfile):
 
     def _strategy_value(self, strategy: Strategy) -> float:
         return deref(self.profile).GetPayoff(strategy.strategy)
+
+    def _regret(self, strategy: Strategy) -> float:
+        return deref(self.profile).GetRegret(strategy.strategy)
 
     def _strategy_value_deriv(self, strategy: Strategy, other: Strategy) -> float:
         return deref(self.profile).GetPayoffDeriv(
@@ -324,6 +350,9 @@ class MixedStrategyProfileRational(MixedStrategyProfile):
 
     def _strategy_value(self, strategy: Strategy) -> Rational:
         return rat_to_py(deref(self.profile).GetPayoff(strategy.strategy))
+
+    def _regret(self, strategy: Strategy) -> Rational:
+        return rat_to_py(deref(self.profile).GetRegret(strategy.strategy))
 
     def _strategy_value_deriv(self, strategy: Strategy, other: Strategy) -> Rational:
         return rat_to_py(deref(self.profile).GetPayoffDeriv(

--- a/src/pygambit/tests/test_behav.py
+++ b/src/pygambit/tests/test_behav.py
@@ -540,85 +540,15 @@ class TestGambitMixedBehavGame(unittest.TestCase):
         assert self.profile_rational.action_value("D3") == gbt.Rational("3/1")
 
     def test_regret(self):
-        "Test to retrieve regret value associated to an action"
-        assert (
-            self.profile_double.regret(
-                self.game.players[0].infosets[0].actions[0]
-            ) == 0.0
-        )
-        assert (
-            self.profile_double.regret(
-                self.game.players[0].infosets[0].actions[1]
-            ) == 0.0
-        )
-        assert (
-            self.profile_double.regret(
-                self.game.players[1].infosets[0].actions[0]
-            ) == 0.0
-        )
-        assert (
-            self.profile_double.regret(
-                self.game.players[1].infosets[0].actions[1]
-            ) == 0.0
-        )
-        assert (
-            self.profile_double.regret(
-                self.game.players[2].infosets[0].actions[0]
-            ) == 0.25
-        )
-        assert (
-            self.profile_double.regret(
-                self.game.players[2].infosets[0].actions[1]
-            ) == -0.25
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[0].infosets[0].actions[0]
-            ) == gbt.Rational("0/1")
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[0].infosets[0].actions[1]
-            ) == gbt.Rational("0/1")
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[1].infosets[0].actions[0]
-            ) == gbt.Rational("0/1")
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[1].infosets[0].actions[1]
-            ) == gbt.Rational("0/1")
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[2].infosets[0].actions[0]
-            ) == gbt.Rational("1/4")
-        )
-        assert (
-            self.profile_rational.regret(
-                self.game.players[2].infosets[0].actions[1]
-            ) == gbt.Rational(-1, 4)
-        )
-
-    def test_regret_by_string(self):
-        """Test to retrieve regret value associated to an action
-        by string values
-        """
-        assert self.profile_double.regret("U1") == 0.0
-        assert self.profile_double.regret("D1") == 0.0
-        assert self.profile_double.regret("U2") == 0.0
-        assert self.profile_double.regret("D2") == 0.0
-        assert self.profile_double.regret("U3") == 0.25
-        assert self.profile_double.regret("D3") == -0.25
-
-        assert self.profile_rational.regret("U1") == gbt.Rational("0/1")
-        assert self.profile_rational.regret("D1") == gbt.Rational("0/1")
-        assert self.profile_rational.regret("U2") == gbt.Rational("0/1")
-        assert self.profile_rational.regret("D2") == gbt.Rational("0/1")
-        assert self.profile_rational.regret("U3") == gbt.Rational(1, 4)
-        assert self.profile_rational.regret("D3") == gbt.Rational(-1, 4)
+        for profile in [self.profile_double, self.profile_rational]:
+            for player in self.game.players:
+                for infoset in player.infosets:
+                    for action in infoset.actions:
+                        assert (
+                            profile.regret(action) ==
+                            max(profile.action_value(a) for a in infoset.actions) -
+                            profile.action_value(action)
+                        )
 
     def test_liap_values(self):
         "Test to retrieve Lyapunov values"

--- a/src/pygambit/tests/test_mixed.py
+++ b/src/pygambit/tests/test_mixed.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 
 import pygambit
 import pygambit as gbt
@@ -68,6 +69,19 @@ def test_strategy_value():
     strategy = game.players[0].strategies[1]
     assert game.mixed_strategy_profile(rational=False).strategy_value(strategy) == 0
     assert game.mixed_strategy_profile(rational=True).strategy_value(strategy) == 0
+
+
+def test_strategy_regret():
+    m = np.array([[8, 2], [10, 5]])
+    game = gbt.Game.from_arrays(m, np.transpose(m))
+    profile = game.mixed_strategy_profile(rational=False)
+    for player in game.players:
+        for strategy in player.strategies:
+            assert (
+                profile.regret(strategy) ==
+                max(profile.strategy_value(s) for s in player.strategies) -
+                profile.strategy_value(strategy)
+            )
 
 
 def test_strategy_value_by_label():


### PR DESCRIPTION
* Implement regret calculation for mixed strategy profiles; this had been omitted previously in both C++ and Python.
* Correct implementation of regret for mixed behavior profiles; this was computing something non-standard (a non-conditional expected payoff loss relative to the actual agent strategy, and not the best response)

Closes #352.