### PR TITLE
This removes gambit-enumpoly from the default build and marks as expe…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@
 - When an action at a chance node is deleted the probabilities for the remaining actions are 
   normalized.
 
+### Changed
+- The gambit-enumpoly solver has been marked as "experimental" and is no longer built by default, nor
+  is it available via the graphical interface.
+
+
 ## [16.1.0a4] - 2023-10-13
 
 ### Changed

--- a/configure.ac
+++ b/configure.ac
@@ -37,14 +37,14 @@ AC_ARG_ENABLE(gui,
  esac], [with_gui=true])
 AM_CONDITIONAL(WITH_GUI, test x$with_gui = xtrue)
 
-dnl Disable building enumpoly -- isn't supported on 64-bit platforms
+dnl Disable building enumpoly by default -- considered experimental
 AC_ARG_ENABLE(enumpoly,
-[  --disable-enumpoly      don't build gambit-enumpoly (not supported on 64bit) ],
+[  --enable-enumpoly      build gambit-enumpoly (experimental!) ],
 [ case "${enableval}" in
   yes) with_enumpoly=true ;;
   no)  with_enumpoly=false ;;
   *)  AC_MSG_ERROR(bad value ${enableval} for --enable-enumpoly) ;;
- esac], [with_enumpoly=true])
+ esac], [with_enumpoly=false])
 AM_CONDITIONAL(WITH_ENUMPOLY, test x$with_enumpoly = xtrue)
 
 AC_DEFUN([MINGW_AC_WIN32_NATIVE_HOST],

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -39,7 +39,6 @@ documentation.
 
    tools.enumpure
    tools.enummixed
-   tools.enumpoly
    tools.lcp
    tools.lp
    tools.liap

--- a/src/gui/dlnash.cc
+++ b/src/gui/dlnash.cc
@@ -33,7 +33,7 @@
 static wxString s_recommended(wxT("with Gambit's recommended method"));
 static wxString s_enumpure(wxT("by looking for pure strategy equilibria"));
 static wxString s_enummixed(wxT("by enumerating extreme points"));
-static wxString s_enumpoly(wxT("by solving systems of polynomial equations"));
+// static wxString s_enumpoly(wxT("by solving systems of polynomial equations"));
 static wxString s_gnm(wxT("by global Newton tracing"));
 static wxString s_ipa(wxT("by iterated polymatrix approximation"));
 static wxString s_lp(wxT("by solving a linear program"));
@@ -137,7 +137,7 @@ void gbtNashChoiceDialog::OnCount(wxCommandEvent &p_event)
     m_methodChoice->Append(s_liap);
     m_methodChoice->Append(s_gnm);
     m_methodChoice->Append(s_ipa);
-    m_methodChoice->Append(s_enumpoly);
+    // m_methodChoice->Append(s_enumpoly);
   }
   else {
     if (m_doc->NumPlayers() == 2) {
@@ -206,43 +206,43 @@ gbtAnalysisOutput *gbtNashChoiceDialog::GetCommand() const
   if (method == s_recommended) {
     if (m_countChoice->GetSelection() == 0) {
       if (m_doc->NumPlayers() == 2 && m_doc->IsConstSum()) {
-	cmd = new gbtAnalysisProfileList<Rational>(m_doc, useEfg);
-	cmd->SetCommand(prefix + wxT("lp") + options);
-	cmd->SetDescription(wxT("One equilibrium by solving a linear program ")
-			    + game);
+        cmd = new gbtAnalysisProfileList<Rational>(m_doc, useEfg);
+        cmd->SetCommand(prefix + wxT("lp") + options);
+        cmd->SetDescription(wxT("One equilibrium by solving a linear program ")
+                            + game);
       }
       else {
-	cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
-	cmd->SetCommand(prefix + wxT("logit -e -d 10"));
-	cmd->SetDescription(wxT("One equilibrium by logit tracing ") + game);
+        cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
+        cmd->SetCommand(prefix + wxT("logit -e -d 10"));
+        cmd->SetDescription(wxT("One equilibrium by logit tracing ") + game);
       }
     }
     else if (m_countChoice->GetSelection() == 1) {
       if (m_doc->NumPlayers() == 2) {
-	cmd = new gbtAnalysisProfileList<Rational>(m_doc, useEfg);
-	cmd->SetCommand(prefix + wxT("lcp") + options);
-	cmd->SetDescription(wxT("Some equilibria by solving a linear ")
-			       wxT("complementarity program ") + game);
+        cmd = new gbtAnalysisProfileList<Rational>(m_doc, useEfg);
+        cmd->SetCommand(prefix + wxT("lcp") + options);
+        cmd->SetDescription(wxT("Some equilibria by solving a linear ")
+                            wxT("complementarity program ") + game);
       }
       else {
-	cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
-	cmd->SetCommand(prefix + wxT("liap -d 10") + options);
-	cmd->SetDescription(wxT("Some equilibria by function minimization ") +
-			    game);
+        cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
+        cmd->SetCommand(prefix + wxT("liap -d 10") + options);
+        cmd->SetDescription(wxT("Some equilibria by function minimization ") +
+                            game);
       }
     }
     else {
       if (m_doc->NumPlayers() == 2) {
-	cmd = new gbtAnalysisProfileList<Rational>(m_doc, false);
-	cmd->SetCommand(prefix + wxT("enummixed"));
-	cmd->SetDescription(wxT("All equilibria by enumeration of mixed ")
-			       wxT("strategies in strategic game"));
+        cmd = new gbtAnalysisProfileList<Rational>(m_doc, false);
+        cmd->SetCommand(prefix + wxT("enummixed"));
+        cmd->SetDescription(wxT("All equilibria by enumeration of mixed ")
+                            wxT("strategies in strategic game"));
       }
       else {
-	cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
-	cmd->SetCommand(prefix + wxT("enumpoly -d 10") + options);
-	cmd->SetDescription(wxT("All equilibria by solving polynomial ")
-			       wxT("systems ") + game);
+        cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
+        cmd->SetCommand(prefix + wxT("enumpoly -d 10") + options);
+        cmd->SetDescription(wxT("All equilibria by solving polynomial ")
+                            wxT("systems ") + game);
       }
     }
   }
@@ -258,12 +258,14 @@ gbtAnalysisOutput *gbtNashChoiceDialog::GetCommand() const
 			wxT(" by enumeration of mixed strategies ")
 			    wxT("in strategic game"));
   }
+  /*
   else if (method == s_enumpoly) {
     cmd = new gbtAnalysisProfileList<double>(m_doc, useEfg);
     cmd->SetCommand(prefix + wxT("enumpoly -d 10") + options);
     cmd->SetDescription(count + wxT(" by solving polynomial systems ") +
 		       game);
   }
+  */
   else if (method == s_gnm) {
     cmd = new gbtAnalysisProfileList<double>(m_doc, false);
     cmd->SetCommand(prefix + wxT("gnm -d 10") + options);


### PR DESCRIPTION
…rimental.

The implementation of gambit-enumpoly has a number of problems which have cumulated over the years, possibly related to building pelican on 64-bit systems.

The roadmap calls for this method to be refactored heavily to separate out the concept of support enumeration from solution method, and to allow for different solution backends for given candidate supports.

As such, for now, we are doing the following:

1.  This method is now marked as "experimental" and removed from the build by default.
2.  References to it in the graphical interface have been removed.  (It was never the "recommended" solver so this has little effect unless someone was selecting it explicitly.)