### PR TITLE
except + for all functions in gambit.pxd unless it breaks compilation

### DIFF
--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -11,30 +11,30 @@ cdef extern from "gambit.h":
 
 cdef extern from "core/rational.h":
     cdef cppclass c_Rational "Rational":
-        c_Rational()
-    string rat_str "lexical_cast<std::string>"(c_Rational)
-    c_Rational str_rat "lexical_cast<Rational>"(string)
+        c_Rational() except +
+    string rat_str "lexical_cast<std::string>"(c_Rational) except +
+    c_Rational str_rat "lexical_cast<Rational>"(string) except +
 
 
 cdef extern from "games/number.h":
     cdef cppclass c_Number "Number":
-        c_Number()
-        c_Number(string)
-        string as_string "operator const string &"()
+        c_Number() except +
+        c_Number(string) except +
+        string as_string "operator const string &"() except +
 
 
 cdef extern from "core/array.h":
      cdef cppclass Array[T]:
           T getitem "operator[]"(int) except +
-          int Length()
-          Array()
-          Array(int)
+          int Length() except +
+          Array() except +
+          Array(int) except +
 
 cdef extern from "core/list.h":
      cdef cppclass c_List "List"[T]:
           T & getitem "operator[]"(int) except +
-          int Length()
-          void push_back(T)
+          int Length() except +
+          void push_back(T) except +
 
 cdef extern from "games/game.h":
      cdef cppclass c_GameRep "GameRep"
@@ -49,302 +49,302 @@ cdef extern from "games/game.h":
           c_GameRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GamePlayer "GameObjectPtr<GamePlayerRep>":
-          bool operator !=(c_GamePlayer)
+          bool operator !=(c_GamePlayer) except +
           c_GamePlayerRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GameOutcome "GameObjectPtr<GameOutcomeRep>":
-          bool operator==(c_GameOutcome)
-          bool operator !=(c_GameOutcome)
+          bool operator==(c_GameOutcome) except +
+          bool operator !=(c_GameOutcome) except +
           c_GameOutcomeRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GameNode "GameObjectPtr<GameNodeRep>":
-          bool operator !=(c_GameNode)
+          bool operator !=(c_GameNode) except +
           c_GameNodeRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GameAction "GameObjectPtr<GameActionRep>":
-          bool operator !=(c_GameAction)
+          bool operator !=(c_GameAction) except +
           c_GameActionRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GameInfoset "GameObjectPtr<GameInfosetRep>":
-          bool operator !=(c_GameInfoset)
+          bool operator !=(c_GameInfoset) except +
           c_GameInfosetRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_GameStrategy "GameObjectPtr<GameStrategyRep>":
           c_GameStrategyRep *deref "operator->"() except +RuntimeError
 
      cdef cppclass c_PureStrategyProfile "PureStrategyProfile":
-          c_PureStrategyProfileRep *deref "operator->"()
-          c_PureStrategyProfile(c_PureStrategyProfile)
+          c_PureStrategyProfileRep *deref "operator->"() except +
+          c_PureStrategyProfile(c_PureStrategyProfile) except +
 
      cdef cppclass c_PureBehaviorProfile "PureBehaviorProfile":
-          c_PureBehaviorProfile(c_Game)
+          c_PureBehaviorProfile(c_Game) except +
 
      cdef cppclass c_GameStrategyRep "GameStrategyRep":
-          int GetNumber()
-          int GetId()
-          c_GamePlayer GetPlayer()
+          int GetNumber() except +
+          int GetId() except +
+          c_GamePlayer GetPlayer() except +
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
-          void DeleteStrategy()
+          void DeleteStrategy() except +
 
      cdef cppclass c_GameActionRep "GameActionRep":
-          int GetNumber()
-          c_GameInfoset GetInfoset()
-          bint Precedes(c_GameNode)
+          int GetNumber() except +
+          c_GameInfoset GetInfoset() except +
+          bint Precedes(c_GameNode) except +
           void DeleteAction() except +ValueError
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
      cdef cppclass c_GameInfosetRep "GameInfosetRep":
-          int GetNumber()
-          c_Game GetGame()
-          c_GamePlayer GetPlayer()
+          int GetNumber() except +
+          c_Game GetGame() except +
+          c_GamePlayer GetPlayer() except +
           void SetPlayer(c_GamePlayer) except +
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
-          int NumActions()
+          int NumActions() except +
           c_GameAction GetAction(int) except +IndexError
           c_GameAction InsertAction(c_GameAction) except +ValueError
 
           c_Number GetActionProb(int) except +IndexError
           void SetActionProb(int, c_Number) except +IndexError
 
-          int NumMembers()
+          int NumMembers() except +
           c_GameNode GetMember(int) except +IndexError
 
-          void Reveal(c_GamePlayer)
-          bint IsChanceInfoset()
-          bint Precedes(c_GameNode)
+          void Reveal(c_GamePlayer) except +
+          bint IsChanceInfoset() except +
+          bint Precedes(c_GameNode) except +
 
      cdef cppclass c_GamePlayerRep "GamePlayerRep":
-          c_Game GetGame()
-          int GetNumber()
-          int IsChance()
+          c_Game GetGame() except +
+          int GetNumber() except +
+          int IsChance() except +
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
-          int NumStrategies()
+          int NumStrategies() except +
           c_GameStrategy GetStrategy(int) except +IndexError
 
-          int NumInfosets()
+          int NumInfosets() except +
           c_GameInfoset GetInfoset(int) except +IndexError
-          c_GameStrategy NewStrategy()
+          c_GameStrategy NewStrategy() except +
 
      cdef cppclass c_GameOutcomeRep "GameOutcomeRep":
-          c_Game GetGame()
-          int GetNumber()
+          c_Game GetGame() except +
+          int GetNumber() except +
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
           c_Number GetPayoff(c_GamePlayer) except +IndexError
           void SetPayoff(c_GamePlayer, c_Number) except +IndexError
 
      cdef cppclass c_GameNodeRep "GameNodeRep":
-          c_Game GetGame()
-          int GetNumber()
+          c_Game GetGame() except +
+          int GetNumber() except +
 
-          string GetLabel()
-          void SetLabel(string)
+          string GetLabel() except +
+          void SetLabel(string) except +
 
-          c_GameInfoset GetInfoset()
+          c_GameInfoset GetInfoset() except +
           void SetInfoset(c_GameInfoset) except +ValueError
-          c_GameInfoset LeaveInfoset()
-          c_GamePlayer GetPlayer()
-          c_GameNode GetParent()
-          int NumChildren()
+          c_GameInfoset LeaveInfoset() except +
+          c_GamePlayer GetPlayer() except +
+          c_GameNode GetParent() except +
+          int NumChildren() except +
           c_GameNode GetChild(int) except +IndexError
-          c_GameOutcome GetOutcome()
-          void SetOutcome(c_GameOutcome)
-          c_GameNode GetPriorSibling()
-          c_GameNode GetNextSibling()
-          bint IsTerminal()
-          bint IsSuccessorOf(c_GameNode)
-          bint IsSubgameRoot()
-          c_GameAction GetPriorAction()
+          c_GameOutcome GetOutcome() except +
+          void SetOutcome(c_GameOutcome) except +
+          c_GameNode GetPriorSibling() except +
+          c_GameNode GetNextSibling() except +
+          bint IsTerminal() except +
+          bint IsSuccessorOf(c_GameNode) except +
+          bint IsSubgameRoot() except +
+          c_GameAction GetPriorAction() except +
 
           c_GameInfoset AppendMove(c_GamePlayer, int) except +ValueError
           c_GameInfoset AppendMove(c_GameInfoset) except +ValueError
           c_GameInfoset InsertMove(c_GamePlayer, int) except +ValueError
           c_GameInfoset InsertMove(c_GameInfoset) except +ValueError
-          void DeleteParent()
-          void DeleteTree()
+          void DeleteParent() except +
+          void DeleteTree() except +
           void CopyTree(c_GameNode) except +ValueError
           void MoveTree(c_GameNode) except +ValueError
 
      cdef cppclass c_GameRep "GameRep":
-          int IsTree()
+          int IsTree() except +
 
-          string GetTitle()
-          void SetTitle(string)
+          string GetTitle() except +
+          void SetTitle(string) except +
 
-          string GetComment()
-          void SetComment(string)
+          string GetComment() except +
+          void SetComment(string) except +
 
-          int NumPlayers()
+          int NumPlayers() except +
           c_GamePlayer GetPlayer(int) except +IndexError
-          c_GamePlayer GetChance()
-          c_GamePlayer NewPlayer()
+          c_GamePlayer GetChance() except +
+          c_GamePlayer NewPlayer() except +
 
-          int NumOutcomes()
+          int NumOutcomes() except +
           c_GameOutcome GetOutcome(int) except +IndexError
-          c_GameOutcome NewOutcome()
-          void DeleteOutcome(c_GameOutcome)
+          c_GameOutcome NewOutcome() except +
+          void DeleteOutcome(c_GameOutcome) except +
 
-          int NumNodes()
-          c_GameNode GetRoot()
+          int NumNodes() except +
+          c_GameNode GetRoot() except +
 
           c_GameStrategy GetStrategy(int) except +IndexError
-          int MixedProfileLength()
+          int MixedProfileLength() except +
 
           c_GameInfoset GetInfoset(int) except +IndexError
-          Array[int] NumInfosets()
+          Array[int] NumInfosets() except +
 
           c_GameAction GetAction(int) except +IndexError
-          int BehavProfileLength()
+          int BehavProfileLength() except +
 
-          bool IsConstSum()
-          c_Rational GetMinPayoff(int)
-          c_Rational GetMaxPayoff(int)
-          bool IsPerfectRecall()
+          bool IsConstSum() except +
+          c_Rational GetMinPayoff(int) except +
+          c_Rational GetMaxPayoff(int) except +
+          bool IsPerfectRecall() except +
 
           c_Game SetChanceProbs(c_GameInfoset, Array[c_Number]) except +
 
-          c_PureStrategyProfile NewPureStrategyProfile()
-          c_MixedStrategyProfileDouble NewMixedStrategyProfile(double)
-          c_MixedStrategyProfileRational NewMixedStrategyProfile(c_Rational)
+          c_PureStrategyProfile NewPureStrategyProfile() # except + # doesn't compile
+          c_MixedStrategyProfileDouble NewMixedStrategyProfile(double) # except + doesn't compile
+          c_MixedStrategyProfileRational NewMixedStrategyProfile(c_Rational) # except + doesn't compile
 
      cdef cppclass c_PureStrategyProfileRep "PureStrategyProfileRep":
-          c_GameStrategy GetStrategy(c_GamePlayer)
-          void SetStrategy(c_GameStrategy)
+          c_GameStrategy GetStrategy(c_GamePlayer) except +
+          void SetStrategy(c_GameStrategy) except +
 
-          c_GameOutcome GetOutcome()
-          void SetOutcome(c_GameOutcome)
+          c_GameOutcome GetOutcome() except +
+          void SetOutcome(c_GameOutcome) except +
 
-          c_Rational GetPayoff(c_GamePlayer)
+          c_Rational GetPayoff(c_GamePlayer) except +
 
-     c_Game NewTree()
-     c_Game NewTable(Array[int] *)
+     c_Game NewTree() except +
+     c_Game NewTable(Array[int] *) except +
 
 
 cdef extern from "games/mixed.h":
      cdef cppclass c_MixedStrategyProfileDouble "MixedStrategyProfile<double>":
-          bool operator==(c_MixedStrategyProfileDouble)
-          bool operator!=(c_MixedStrategyProfileDouble)
-          c_Game GetGame()
-          int MixedProfileLength()
-          c_StrategySupportProfile GetSupport()
-          c_MixedStrategyProfileDouble Normalize()
+          bool operator==(c_MixedStrategyProfileDouble) except +
+          bool operator!=(c_MixedStrategyProfileDouble) except +
+          c_Game GetGame() except +
+          int MixedProfileLength() except +
+          c_StrategySupportProfile GetSupport() except +
+          c_MixedStrategyProfileDouble Normalize() # except + # doesn't compile
           void Randomize() except +TypeError
-          void Randomize(int)
+          void Randomize(int) except +
           double getitem_strategy "operator[]"(c_GameStrategy) except +IndexError
-          double GetPayoff(c_GamePlayer)
-          double GetPayoff(c_GameStrategy)
-          double GetRegret(c_GameStrategy)
-          double GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
-          double GetLiapValue()
-          c_MixedStrategyProfileDouble ToFullSupport()
-          c_MixedStrategyProfileDouble(c_MixedStrategyProfileDouble)
+          double GetPayoff(c_GamePlayer) except +
+          double GetPayoff(c_GameStrategy) except +
+          double GetRegret(c_GameStrategy) except +
+          double GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy) except +
+          double GetLiapValue() except +
+          c_MixedStrategyProfileDouble ToFullSupport() except +
+          c_MixedStrategyProfileDouble(c_MixedStrategyProfileDouble) except +
 
      cdef cppclass c_MixedStrategyProfileRational "MixedStrategyProfile<Rational>":
-          bool operator==(c_MixedStrategyProfileRational)
-          bool operator!=(c_MixedStrategyProfileRational)
-          c_Game GetGame()
-          int MixedProfileLength()
-          c_StrategySupportProfile GetSupport()
-          c_MixedStrategyProfileRational Normalize()
-          void Randomize()
-          void Randomize(int)
+          bool operator==(c_MixedStrategyProfileRational) except +
+          bool operator!=(c_MixedStrategyProfileRational) except +
+          c_Game GetGame() except +
+          int MixedProfileLength() except +
+          c_StrategySupportProfile GetSupport() except +
+          c_MixedStrategyProfileRational Normalize() # except + # doesn't compile
+          void Randomize() except +
+          void Randomize(int) except +
           c_Rational getitem_strategy "operator[]"(c_GameStrategy) except +IndexError
-          c_Rational GetPayoff(c_GamePlayer)
-          c_Rational GetPayoff(c_GameStrategy)
-          c_Rational GetRegret(c_GameStrategy)
-          c_Rational GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy)
-          c_Rational GetLiapValue()
-          c_MixedStrategyProfileRational ToFullSupport()
-          c_MixedStrategyProfileRational(c_MixedStrategyProfileRational)
+          c_Rational GetPayoff(c_GamePlayer) except +
+          c_Rational GetPayoff(c_GameStrategy) except +
+          c_Rational GetRegret(c_GameStrategy) except +
+          c_Rational GetPayoffDeriv(int, c_GameStrategy, c_GameStrategy) except +
+          c_Rational GetLiapValue() except +
+          c_MixedStrategyProfileRational ToFullSupport() except +
+          c_MixedStrategyProfileRational(c_MixedStrategyProfileRational) except +
 
 cdef extern from "games/behav.h":
      cdef cppclass c_MixedBehaviorProfileDouble "MixedBehaviorProfile<double>":
-          bool operator==(c_MixedBehaviorProfileDouble)
-          bool operator!=(c_MixedBehaviorProfileDouble)
-          c_Game GetGame()
-          int Length()
-          bool IsDefinedAt(c_GameInfoset)
-          c_MixedBehaviorProfileDouble Normalize()
+          bool operator==(c_MixedBehaviorProfileDouble) except +
+          bool operator!=(c_MixedBehaviorProfileDouble) except +
+          c_Game GetGame() except +
+          int Length() except +
+          bool IsDefinedAt(c_GameInfoset) except +
+          c_MixedBehaviorProfileDouble Normalize() # except + # doesn't compile
           void Randomize() except +TypeError
-          void Randomize(int)
+          void Randomize(int) except +
           double getitem "operator[]"(int) except +IndexError
           double getaction "operator()"(c_GameAction) except +IndexError
-          double GetPayoff(int)
-          double GetBeliefProb(c_GameNode)
-          double GetRealizProb(c_GameNode)
-          double GetInfosetProb(c_GameInfoset)
-          double GetPayoff(c_GameInfoset)
-          double GetPayoff(c_GamePlayer, c_GameNode)
-          double GetPayoff(c_GameAction)
-          double GetRegret(c_GameAction)
-          double GetLiapValue()
-          c_MixedStrategyProfileDouble ToMixedProfile()
+          double GetPayoff(int) except +
+          double GetBeliefProb(c_GameNode) except +
+          double GetRealizProb(c_GameNode) except +
+          double GetInfosetProb(c_GameInfoset) except +
+          double GetPayoff(c_GameInfoset) except +
+          double GetPayoff(c_GamePlayer, c_GameNode) except +
+          double GetPayoff(c_GameAction) except +
+          double GetRegret(c_GameAction) except +
+          double GetLiapValue() except +
+          c_MixedStrategyProfileDouble ToMixedProfile() # except + # doesn't compile
           c_MixedBehaviorProfileDouble(c_MixedStrategyProfileDouble) except +NotImplementedError
-          c_MixedBehaviorProfileDouble(c_Game)
-          c_MixedBehaviorProfileDouble(c_MixedBehaviorProfileDouble)
+          c_MixedBehaviorProfileDouble(c_Game) except +
+          c_MixedBehaviorProfileDouble(c_MixedBehaviorProfileDouble) except +
 
      cdef cppclass c_MixedBehaviorProfileRational "MixedBehaviorProfile<Rational>":
-          bool operator==(c_MixedBehaviorProfileRational)
-          bool operator!=(c_MixedBehaviorProfileRational)
-          c_Game GetGame()
-          int Length()
-          bool IsDefinedAt(c_GameInfoset)
-          c_MixedBehaviorProfileRational Normalize()
-          void Randomize()
-          void Randomize(int)
+          bool operator==(c_MixedBehaviorProfileRational) except +
+          bool operator!=(c_MixedBehaviorProfileRational) except +
+          c_Game GetGame() except +
+          int Length() except +
+          bool IsDefinedAt(c_GameInfoset) except +
+          c_MixedBehaviorProfileRational Normalize() # except + # doesn't compile
+          void Randomize() except +
+          void Randomize(int) except +
           c_Rational getitem "operator[]"(int) except +IndexError
           c_Rational getaction "operator()"(c_GameAction) except +IndexError
-          c_Rational GetPayoff(int)
-          c_Rational GetBeliefProb(c_GameNode)
-          c_Rational GetRealizProb(c_GameNode)
-          c_Rational GetInfosetProb(c_GameInfoset)
-          c_Rational GetPayoff(c_GameInfoset)
-          c_Rational GetPayoff(c_GamePlayer, c_GameNode)
-          c_Rational GetPayoff(c_GameAction)
-          c_Rational GetRegret(c_GameAction)
-          c_Rational GetLiapValue()
-          c_MixedStrategyProfileRational ToMixedProfile()
+          c_Rational GetPayoff(int) except +
+          c_Rational GetBeliefProb(c_GameNode) except +
+          c_Rational GetRealizProb(c_GameNode) except +
+          c_Rational GetInfosetProb(c_GameInfoset) except +
+          c_Rational GetPayoff(c_GameInfoset) except +
+          c_Rational GetPayoff(c_GamePlayer, c_GameNode) except +
+          c_Rational GetPayoff(c_GameAction) except +
+          c_Rational GetRegret(c_GameAction) except +
+          c_Rational GetLiapValue() except +
+          c_MixedStrategyProfileRational ToMixedProfile() # except + # doesn't compile
           c_MixedBehaviorProfileRational(c_MixedStrategyProfileRational) except +NotImplementedError
-          c_MixedBehaviorProfileRational(c_Game)
-          c_MixedBehaviorProfileRational(c_MixedBehaviorProfileRational)
+          c_MixedBehaviorProfileRational(c_Game) except +
+          c_MixedBehaviorProfileRational(c_MixedBehaviorProfileRational) except +
 
 
 cdef extern from "games/stratspt.h":
      cdef cppclass c_StrategySupportProfile "StrategySupportProfile":
-          c_StrategySupportProfile(c_Game)
-          c_StrategySupportProfile(c_StrategySupportProfile)
-          bool operator ==(c_StrategySupportProfile)
-          bool operator !=(c_StrategySupportProfile)
-          c_Game GetGame()
-          Array[int] NumStrategies()
-          int MixedProfileLength()
-          int GetIndex(c_GameStrategy)
+          c_StrategySupportProfile(c_Game) except +
+          c_StrategySupportProfile(c_StrategySupportProfile) except +
+          bool operator ==(c_StrategySupportProfile) except +
+          bool operator !=(c_StrategySupportProfile) except +
+          c_Game GetGame() except +
+          Array[int] NumStrategies() except +
+          int MixedProfileLength() except +
+          int GetIndex(c_GameStrategy) except +
           int NumStrategiesPlayer "NumStrategies"(int) except +IndexError
-          bool IsSubsetOf(c_StrategySupportProfile)
-          bool RemoveStrategy(c_GameStrategy)
+          bool IsSubsetOf(c_StrategySupportProfile) except +
+          bool RemoveStrategy(c_GameStrategy) except +
           c_GameStrategy GetStrategy(int, int) except +IndexError
-          bool Contains(c_GameStrategy)
-          c_StrategySupportProfile Undominated(bool, bool)
-          c_MixedStrategyProfileDouble NewMixedStrategyProfileDouble "NewMixedStrategyProfile<double>"()
-          c_MixedStrategyProfileRational NewMixedStrategyProfileRational "NewMixedStrategyProfile<Rational>"()
+          bool Contains(c_GameStrategy) except +
+          c_StrategySupportProfile Undominated(bool, bool) # except + # doesn't compile
+          c_MixedStrategyProfileDouble NewMixedStrategyProfileDouble "NewMixedStrategyProfile<double>"() except +
+          c_MixedStrategyProfileRational NewMixedStrategyProfileRational "NewMixedStrategyProfile<Rational>"() except +
 
 
 cdef extern from "games/behavspt.h":
      cdef cppclass c_BehaviorSupportProfile "BehaviorSupportProfile":
-          c_BehaviorSupportProfile(c_Game)
+          c_BehaviorSupportProfile(c_Game) except +
 
 
 cdef extern from "util.h":
@@ -353,30 +353,30 @@ cdef extern from "util.h":
      string WriteGame(c_Game, string) except +IOError
      string WriteGame(c_StrategySupportProfile) except +IOError
 
-     c_Rational to_rational(char *)
+     c_Rational to_rational(char *) except +
 
-     void setitem_array_int "setitem"(Array[int] *, int, int)
-     void setitem_array_number "setitem"(Array[c_Number], int, c_Number)
+     void setitem_array_int "setitem"(Array[int] *, int, int) except +
+     void setitem_array_number "setitem"(Array[c_Number], int, c_Number) except +
 
-     void setitem_mspd_int "setitem"(c_MixedStrategyProfileDouble, int, double)
+     void setitem_mspd_int "setitem"(c_MixedStrategyProfileDouble, int, double) except +
      void setitem_mspd_strategy "setitem"(c_MixedStrategyProfileDouble,
-                                          c_GameStrategy, double)
-     void setitem_mspr_int "setitem"(c_MixedStrategyProfileRational, int, c_Rational)
+                                          c_GameStrategy, double) except +
+     void setitem_mspr_int "setitem"(c_MixedStrategyProfileRational, int, c_Rational) except +
      void setitem_mspr_strategy "setitem"(c_MixedStrategyProfileRational,
-                                          c_GameStrategy, c_Rational)
+                                          c_GameStrategy, c_Rational) except +
 
-     void setitem_mbpd_int "setitem"(c_MixedBehaviorProfileDouble, int, double)
+     void setitem_mbpd_int "setitem"(c_MixedBehaviorProfileDouble, int, double) except +
      void setitem_mbpd_action "setitem"(c_MixedBehaviorProfileDouble,
-                                        c_GameAction, double)
-     void setitem_mbpr_int "setitem"(c_MixedBehaviorProfileRational, int, c_Rational)
+                                        c_GameAction, double) except +
+     void setitem_mbpr_int "setitem"(c_MixedBehaviorProfileRational, int, c_Rational) except +
      void setitem_mbpr_action "setitem"(c_MixedBehaviorProfileRational,
-                                        c_GameAction, c_Rational)
+                                        c_GameAction, c_Rational) except +
 
-     shared_ptr[c_MixedStrategyProfileDouble] copyitem_list_mspd "sharedcopyitem"(c_List[c_MixedStrategyProfileDouble], int)
-     shared_ptr[c_MixedStrategyProfileRational] copyitem_list_mspr "sharedcopyitem"(c_List[c_MixedStrategyProfileRational], int)
-     shared_ptr[c_MixedBehaviorProfileDouble] copyitem_list_mbpd "sharedcopyitem"(c_List[c_MixedBehaviorProfileDouble], int)
-     shared_ptr[c_MixedBehaviorProfileRational] copyitem_list_mbpr "sharedcopyitem"(c_List[c_MixedBehaviorProfileRational], int)
-     shared_ptr[c_LogitQREMixedStrategyProfile] copyitem_list_qrem "sharedcopyitem"(c_List[c_LogitQREMixedStrategyProfile], int)
+     shared_ptr[c_MixedStrategyProfileDouble] copyitem_list_mspd "sharedcopyitem"(c_List[c_MixedStrategyProfileDouble], int) except +
+     shared_ptr[c_MixedStrategyProfileRational] copyitem_list_mspr "sharedcopyitem"(c_List[c_MixedStrategyProfileRational], int) except +
+     shared_ptr[c_MixedBehaviorProfileDouble] copyitem_list_mbpd "sharedcopyitem"(c_List[c_MixedBehaviorProfileDouble], int) except +
+     shared_ptr[c_MixedBehaviorProfileRational] copyitem_list_mbpr "sharedcopyitem"(c_List[c_MixedBehaviorProfileRational], int) except +
+     shared_ptr[c_LogitQREMixedStrategyProfile] copyitem_list_qrem "sharedcopyitem"(c_List[c_LogitQREMixedStrategyProfile], int) except +
 
 
 cdef extern from "solvers/enumpure/enumpure.h":
@@ -425,23 +425,23 @@ cdef extern from "solvers/logit/efglogit.h":
 
 cdef extern from "solvers/logit/nfglogit.h":
      cdef cppclass c_LogitQREMixedStrategyProfile "LogitQREMixedStrategyProfile":
-          c_LogitQREMixedStrategyProfile(c_Game)
-          c_LogitQREMixedStrategyProfile(c_LogitQREMixedStrategyProfile)
-          c_Game GetGame()
-          c_MixedStrategyProfileDouble GetProfile()
-          double GetLambda()
-          double GetLogLike()
-          int MixedProfileLength()
+          c_LogitQREMixedStrategyProfile(c_Game) except +
+          c_LogitQREMixedStrategyProfile(c_LogitQREMixedStrategyProfile) except +
+          c_Game GetGame() except +
+          c_MixedStrategyProfileDouble GetProfile() # except + # doesn't compile
+          double GetLambda() except +
+          double GetLogLike() except +
+          int MixedProfileLength() except +
           double getitem "operator[]"(int) except +IndexError
 
      cdef cppclass c_StrategicQREEstimator "StrategicQREEstimator":
-          c_StrategicQREEstimator()
+          c_StrategicQREEstimator() except +
           c_LogitQREMixedStrategyProfile Estimate(c_LogitQREMixedStrategyProfile,
                                                   c_MixedStrategyProfileDouble,
                                                   double, double, double) except +RuntimeError
 
 cdef extern from "nash.h":
-    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_estimate "logit_estimate"(shared_ptr[c_MixedStrategyProfileDouble])
-    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_atlambda "logit_atlambda"(c_Game, double)
-    c_List[c_LogitQREMixedStrategyProfile] _logit_principal_branch "logit_principal_branch"(c_Game, double)
+    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_estimate "logit_estimate"(shared_ptr[c_MixedStrategyProfileDouble]) except +
+    shared_ptr[c_LogitQREMixedStrategyProfile] _logit_atlambda "logit_atlambda"(c_Game, double) except +
+    c_List[c_LogitQREMixedStrategyProfile] _logit_principal_branch "logit_principal_branch"(c_Game, double) except +
 

--- a/src/pygambit/tests/test_game.py
+++ b/src/pygambit/tests/test_game.py
@@ -77,3 +77,36 @@ def test_game_dereference_invalid():
     game.append_move(game.root, game.players[0], ["a", "b"])
     with pytest.raises(RuntimeError):
         _ = strategy.label
+
+
+def test_exceptions():
+    """Tests for certain exceptions that are caught at the cython level via 'except +'
+    The tests here are only for function calls that do not give a RuntimeError without 'except +'
+    """
+    # table
+    g = gbt.Game.new_table([2, 2])
+    p = g.mixed_strategy_profile()
+    p_rat = g.mixed_strategy_profile(rational=True)
+    g.delete_strategy(g.players[0].strategies[0])
+    with pytest.raises(RuntimeError):
+        p.payoff(g.players[0])
+    with pytest.raises(RuntimeError):
+        p.liap_value()
+    with pytest.raises(RuntimeError):
+        p_rat.payoff(g.players[0])
+    with pytest.raises(RuntimeError):
+        p_rat.liap_value()
+    # tree
+    g = gbt.Game.read_game("test_games/basic_extensive_game.efg")
+    p_behav = g.mixed_behavior_profile()
+    p_behav_rat = g.mixed_behavior_profile(rational=True)
+    iset = g.players[0].infosets[0]
+    g.delete_action(iset.actions[0])
+    with pytest.raises(RuntimeError):
+        p_behav.payoff(g.players[0])
+    with pytest.raises(RuntimeError):
+        p_behav.liap_value()
+    with pytest.raises(RuntimeError):
+        p_behav_rat.payoff(g.players[0])
+    with pytest.raises(RuntimeError):
+        p_behav_rat.liap_value()


### PR DESCRIPTION
Since it wasn't clear to me why some additions of "except +" would break compilation, I choose to try except absolutely everywhere -- the only cases now where we don't have it is where having it breaks compilation (in which case it is there but commented out, with the extra comment "doesn't compile").

The new tests are only for cases where I managed to trigger these exceptions, which are all variants of the example from 389, using payoff or liap value.

Let me know what you suggest to push, but I thought you'd want to see which ones were breaking compilation anyway.