### PR TITLE
Fix bug with from_dict()

### DIFF
--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -301,10 +301,10 @@ class Game:
         for (player, label) in zip(g.players, payoffs):
             player.label = label
         for profile in itertools.product(
-                *(range(shape[i]) for i in range(len(g.players)))
+                *(range(arrays[0].shape[i]) for i in range(len(g.players)))
         ):
-            for (pl, _) in enumerate(arrays):
-                g[profile][pl] = arrays[pl][profile]
+            for pl, player in enumerate(g.players):
+                g[profile][player] = arrays[pl][profile]
         g.title = title
         return g
 

--- a/src/pygambit/tests/test_game.py
+++ b/src/pygambit/tests/test_game.py
@@ -12,6 +12,16 @@ def test_from_arrays():
     assert len(game.players[1].strategies) == 2
 
 
+def test_from_dict():
+    m = np.array([[8, 2], [10, 5]])
+    game = gbt.Game.from_dict({"a": m, "b": m.transpose()})
+    assert len(game.players) == 2
+    assert len(game.players[0].strategies) == 2
+    assert len(game.players[1].strategies) == 2
+    assert game.players[0].label == "a"
+    assert game.players[1].label == "b"
+
+
 def test_game_get_outcome_by_index():
     game = gbt.Game.new_table([2, 2])
     assert game[0, 0] == game.outcomes[0]


### PR DESCRIPTION
Replaced the (incorrect) snippet to populate player outcomes with that from the `from_arrays()` method and add test.

The original code for doing this was as follows -

```python
for profile in itertools.product(
                *(range(shape[i]) for i in range(len(g.players)))
        ):
            for (pl, _) in enumerate(arrays):
                g[profile][pl] = arrays[pl][profile]
```

Since we're iterating over the indices and using that as the player index, pygambit throws the following error -

```bash
  File "src/pygambit/game.pxi", line 307, in pygambit.gambit.Game.from_dict
    g[profile][pl] = arrays[pl][profile]
  File "src/pygambit/outcome.pxi", line 119, in pygambit.gambit.Outcome.__setitem__
    self.game._resolve_player(player, 'Outcome.__setitem__'))
  File "src/pygambit/game.pxi", line 815, in pygambit.gambit.Game._resolve_player
    raise TypeError(f"{funcname}(): {argname} must be Player or str, not {player.__class__.__name__}")
TypeError: Outcome.__setitem__(): player must be Player or str, not int
```

This PR replaces the offending snippet in `from_dict()` with the correct one from `from_arrays()` and adds a test for the same in `tests/test_game.test_from_dicts`. The test fails prior to the fix, and passes with it.