### PR TITLE
Document quantal response estimation in pygambit.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 # Changelog
 
+## [16.1.1] - unreleased
+
+### Fixed
+- Corrected outdated code in `fit_fixedpoint` and `fit_empirical`, and added extended documentation
+  of both methods.
+
+
 ## [16.1.0] - 2023-11-09
 
 ### Fixed

--- a/doc/biblio.rst
+++ b/doc/biblio.rst
@@ -5,6 +5,10 @@ Bibliography
 Articles on computation of Nash equilibria
 ------------------------------------------
 
+.. [BlaTur23] Bland, J. R. and Turocy, T. L., 2023.  Quantal response equilibrium
+   as a structural model for estimation: The missing manual.
+   SSRN working paper 4425515.
+
 .. [Eav71] B. C. Eaves, "The linear complementarity problem", 612-634,
    Management Science , 17, 1971.
 
@@ -98,6 +102,9 @@ General game theory articles and texts
 
 .. [Nas50] John Nash, "Equilibrium points in n-person games", 48-49,
    Proceedings of the National Academy of Sciences , 36, 1950.
+
+.. [Och95] Jack Ochs, "Games with unique, mixed strategy equilibria:
+   An experimental study", Games and Economic Behavior 10: 202-217, 1995.
 
 .. [Sel75] Reinhard Selten, Reexamination of the perfectness concept for
    equilibrium points in extensive games , 25-55, International Journal

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -272,3 +272,4 @@ Computation of quantal response equilibria
 
    fit_empirical
    fit_fixedpoint
+   LogitQREMixedStrategyFitResult

--- a/doc/pygambit.user.rst
+++ b/doc/pygambit.user.rst
@@ -469,3 +469,46 @@ using :py:meth:`.MixedStrategyProfile.as_behavior` and :py:meth:`.MixedBehaviorP
 
    eqa[0].as_behavior()
    eqa[0].as_behavior().as_strategy()
+
+
+Estimating quantal response equilibria
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alongside computing quantal response equilibria, Gambit can also perform maximum likelihood
+estimation, computing the QRE which best fits an empirical distribution of play.
+
+As an example we consider an asymmetric matching pennies game studied in [Och95]_,
+analysed in [McKPal95]_ using QRE.
+
+.. ipython:: python
+
+   g = gbt.Game.from_arrays(
+         [[1.1141, 0], [0, 0.2785]],
+         [[0, 1.1141], [1.1141, 0]],
+         title="Ochs (1995) asymmetric matching pennies as transformed in McKelvey-Palfrey (1995)"
+   )
+   data = g.mixed_strategy_profile([[128*0.527, 128*(1-0.527)], [128*0.366, 128*(1-0.366)]])
+
+Estimation of QRE is done using :py:func:`.fit_fixedpoint`.
+
+.. ipython:: python
+
+   fit = gbt.qre.fit_fixedpoint(data)
+
+The returned :py:class:`.LogitQREMixedStrategyFitResult` object contains the results of the
+estimation.
+The results replicate those reported in [McKPal95]_, including the estimated value of lambda,
+the QRE profile probabilities, and the log-likelihood.
+Because `data` contains the empirical counts of play, and not just frequencies, the resulting
+log-likelihood is correct for use in likelihoood-ratio tests. [#f1]_
+
+.. ipython:: python
+
+   print(fit.lam)
+   print(fit.profile)
+   print(fit.log_like)
+
+.. rubric:: Footnotes
+
+.. [#f1] The log-likelihoods quoted in [McKPal95]_ are exactly a factor of 10 larger than
+         those obtained by replicating the calculation.


### PR DESCRIPTION
QRE estimation was (quietly) added in 16.1.0.  This does the following:
1.  Updates the implementation of both fixed-point and empirical methods to fix bugs in accessing mixed strategy profiles.
2.  Adds improved docstrings to the methods (and the result class), and a user guide section to the documentation with a very brief exposition of their use.