### PR TITLE
Fix bug in formulating LP tableau for sequence form.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@
   uniform across nodes (#63)
 - Corrected outdated code in `fit_fixedpoint` and `fit_empirical`, and added extended documentation
   of both methods (#1)
+- Fixed bug in gambit-lp which would return non-Nash output on extensive games if the game had chance nodes
+  other than the root node (#134)
 
 
 

--- a/src/solvers/lp/efglp.cc
+++ b/src/solvers/lp/efglp.cc
@@ -85,8 +85,7 @@ NashLpBehavSolver<T>::GameData::BuildConstraintMatrix(const BehaviorSupportProfi
 {
   GameOutcome outcome = n->GetOutcome();
   if (outcome) {
-    A(s1,s2) += 
-      (T) (Rational(prob) * static_cast<Rational>(outcome->GetPayoff(1)) - minpay);
+    A(s1,s2) += Rational(prob) * (static_cast<Rational>(outcome->GetPayoff(1)) - minpay);
   }
 
   if (n->NumChildren() == 0) {


### PR DESCRIPTION
This corrects a bug in formulating the LP tableau for the sequence form. Specifically, there was a missing parenthesis in setting tableau entries; the effect of this is that the tableau was incorrect in the case of a game which had a chance node that was not the root node.

This closes #134