### PR TITLE
Refine implementation of label indexing on game collection objects.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,13 @@
   of both methods (#1)
 - Fixed bug in gambit-lp which would return non-Nash output on extensive games if the game had chance nodes
   other than the root node (#134)
+- In pygambit, fixed indexing in mixed behavior and mixed strategy profiles, which could result
+  in strategies or actions belonging to other players or information sets being referenced when
+  indexing by string label
 
+### Changed
+- In pygambit, resolving game objects with ambiguous or duplicated labels results in a ValueError,
+  instead of silently returning the first matching object found.
 
 
 ## [16.1.0] - 2023-11-09

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -108,7 +108,9 @@ Information about the game
    Player.label
    Player.number
    Player.game
+   Player.strategies
    Player.infosets
+   Player.actions
    Player.is_chance
    Player.min_payoff
    Player.max_payoff

--- a/doc/pygambit.user.rst
+++ b/doc/pygambit.user.rst
@@ -165,7 +165,7 @@ by a collection of payoff tables, one per player.  The most direct way to create
 a strategic game is via :py:meth:`.Game.from_arrays`.  This function takes one
 n-dimensional array per player, where n is the number of players in the game.
 The arrays can be any object that can be indexed like an n-times-nested Python list;
-so, for example, NumPy arrays can be used directly.
+so, for example, `numpy` arrays can be used directly.
 
 For example, to create a standard prisoner's dilemma game in which the cooperative
 payoff is 8, the betrayal payoff is 10, the sucker payoff is 2, and the noncooperative
@@ -349,11 +349,11 @@ the extensive representation.  Assuming that ``g`` refers to the game
    len(eqa)
 
 The result of the calculation is a list of :py:class:`~pygambit.gambit.MixedBehaviorProfile`.
-A mixed behavior profile specifies, for each information set, the probability distribution over
-actions at that information set.
+A mixed behavior profile is a ``dict``-like object which specifies, for each information set,
+the probability distribution over actions at that information set, conditional on the
+information set being reached.
 Indexing a :py:class:`.MixedBehaviorProfile` by a player gives the probability distributions
 over each of that player's information sets:
-
 
 .. ipython:: python
 
@@ -361,13 +361,44 @@ over each of that player's information sets:
 
 In this case, at Alice's first information set, the one at which she has the King, she always raises.
 At her second information set, where she has the Queen, she sometimes bluffs, raising with
-probability one-third.  Looking at Bob's strategy,
+probability one-third:
+
+.. ipython:: python
+
+   [eqa[0]["Alice"][infoset]["Raise"] for infoset in g.players["Alice"].infosets]
+
+In larger games, labels may not always be the most convenient way to refer to specific
+actions.  We can also index profiles directly with :py:class:`.Action` objects.
+So an alternative way to extract the probabilities of playing "Raise" would be by
+iterating Alice's list of actions:
+
+.. ipython:: python
+
+   [eqa[0][action] for action in g.players["Alice"].actions if action.label == "Raise"]
+
+
+Looking at Bob's strategy,
 
 .. ipython:: python
 
    eqa[0]["Bob"]
 
-Bob meets Alice's raise two-thirds of the time.
+Bob meets Alice's raise two-thirds of the time.  The label "Raise" is used in more than one
+information set for Alice, so in the above we had to specify information sets when indexing.
+When there is no ambiguity, we can specify action labels directly.  So for example, because
+Bob has only one action named "Meet" in the game, we can extract the probability that Bob plays
+"Meet" by:
+
+.. ipython:: python
+
+   eqa[0]["Bob"]["Meet"]
+
+Moreover, this is the only action with that label in the game, so we can index the
+profile directly using the action label without any ambiguity:
+
+.. ipython:: python
+
+   eqa[0]["Meet"]
 
 Because this is an equilibrium, the fact that Bob randomizes at his information set must mean he
 is indifferent between the two actions at his information set.  :py:meth:`.MixedBehaviorProfile.action_value`

--- a/src/pygambit/gambit.pyx
+++ b/src/pygambit/gambit.pyx
@@ -76,22 +76,6 @@ def _to_number(value: typing.Any) -> c_Number:
     return c_Number(value.encode('ascii'))
 
 
-@cython.cclass
-class Collection:
-    """Represents a collection of related objects in a game."""
-    def __repr__(self):
-        return str(list(self))
-
-    def __getitem__(self, i):
-        if isinstance(i, str):
-            try:
-                return self[[x.label for x in self].index(i)]
-            except ValueError:
-                raise IndexError(f"no object with label '{i}'")
-        else:
-            raise TypeError(f"collection indexes must be int or str, not {i.__class__.__name__}")
-
-
 ######################
 # Includes
 ######################

--- a/src/pygambit/stratspt.pxi
+++ b/src/pygambit/stratspt.pxi
@@ -26,7 +26,7 @@ from libcpp.memory cimport unique_ptr
 from deprecated import deprecated
 
 @cython.cclass
-class StrategySupportProfile(Collection):
+class StrategySupportProfile:
     """A set-like object representing a subset of the strategies in game.
     A StrategySupportProfile always contains at least one strategy for each player
     in the game.
@@ -92,7 +92,6 @@ class StrategySupportProfile(Collection):
         return deref(self.support).Contains(strategy.strategy)
 
     def __iter__(self) -> typing.Generator[Strategy, None, None]:
-        cdef Strategy s
         for pl in range(len(self.game.players)):
             for st in range(deref(self.support).NumStrategiesPlayer(pl+1)):
                 s = Strategy()

--- a/src/pygambit/tests/test_game_resolve_functions.py
+++ b/src/pygambit/tests/test_game_resolve_functions.py
@@ -66,8 +66,8 @@ class TestGambitResolveFunctions(unittest.TestCase):
         assert self.game1._resolve_strategy(strategy='11', funcname='test')
         assert self.game1._resolve_strategy(strategy='12', funcname='test')
         self.assertRaises(KeyError, self.game1._resolve_strategy, strategy='13', funcname='test')
-        assert self.game2._resolve_strategy(strategy='1', funcname='test')
-        assert self.game2._resolve_strategy(strategy='2', funcname='test')
+        self.assertRaises(ValueError, self.game2._resolve_strategy, strategy='1', funcname='test')
+        self.assertRaises(ValueError, self.game2._resolve_strategy, strategy='2', funcname='test')
         self.assertRaises(KeyError, self.game2._resolve_strategy, strategy='3', funcname='test')
 
     def test_resolve_node_empty_strings(self):
@@ -107,8 +107,8 @@ class TestGambitResolveFunctions(unittest.TestCase):
 
     def test_resolve_action_nonempty_strings(self):
         """Test _resolve_action with non-empty strings, some that resolve some that don't"""
-        assert self.game1._resolve_action(action='1', funcname='test')
-        assert self.game1._resolve_action(action='2', funcname='test')
+        self.assertRaises(ValueError, self.game1._resolve_action, action='1', funcname='test')
+        self.assertRaises(ValueError, self.game1._resolve_action, action='2', funcname='test')
         self.assertRaises(KeyError, self.game1._resolve_action, action='3', funcname='test')
         assert self.game2._resolve_action(action='U1', funcname='test')
         assert self.game2._resolve_action(action='D1', funcname='test')

--- a/src/pygambit/tests/test_outcomes.py
+++ b/src/pygambit/tests/test_outcomes.py
@@ -52,7 +52,7 @@ def test_outcome_index_int_range(game: gbt.Game):
     "game", [gbt.Game.new_table([2, 2])]
 )
 def test_outcome_index_label_range(game: gbt.Game):
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         _ = game.outcomes["not an outcome"]
 
 

--- a/src/pygambit/tests/test_players.py
+++ b/src/pygambit/tests/test_players.py
@@ -49,7 +49,7 @@ def test_player_index_invalid():
 
 def test_player_label_invalid():
     game = gbt.Game.new_table([2, 2])
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         _ = game.players["Not a player"]
 
 
@@ -113,7 +113,7 @@ def test_player_strategy_bad_index():
 
 def test_player_strategy_bad_label():
     game = gbt.Game.new_table([2, 2])
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         _ = game.players[0].strategies["Cooperate"]
 
 


### PR DESCRIPTION
* In the case where multiple game objects in the same scope (actions, strategies, etc.) had the same label, indexing on collections by label was silently returning the first match. This changes indexing to match conventions used elsewhere in label resolution, and further raises an exception on multiple matches.
* Failing to match on a string index raises a KeyError instead of an IndexError; this is more Pythonic.