### PR TITLE
Import a list of valid terminal node references.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@
 - `gnm_solve`/`gambit-gnm` now exposes several parameters which control the behavior of the
   path-following procedure
 - The MixedBehaviorProfile object can now be initialized on creation by a given distribution.
+- `append_move`/`append_infoset` now resolves either a singleton node reference or any
+  iterable set of node references
 
 ### Changed
 - Gambit now requires a compiler that supports C++17.

--- a/src/pygambit/gambit.pyx
+++ b/src/pygambit/gambit.pyx
@@ -79,6 +79,7 @@ StrategyReference = typing.Union[Strategy, str]
 InfosetReference = typing.Union[Infoset, str]
 ActionReference = typing.Union[Action, str]
 NodeReference = typing.Union[Node, str]
+NodeReferenceSet = typing.Iterable[NodeReference]
 
 ProfileDType = typing.Union[float, Rational]
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -11,10 +11,19 @@ class TestGambitNode(unittest.TestCase):
         self.extensive_game = (
             games.read_from_file("basic_extensive_game.efg")
         )
+        self.sample_extensive_game = (
+            games.read_from_file("sample_extensive_game.efg")
+        )
+        self.basic_game = (
+            pygambit.Game.new_tree(players=["Player 1", "Player 2", "Player 3"])
+        )
+        self.basic_game.append_move(self.basic_game.root, "Player 1", ["U", "M", "D"])
+        self.basic_game.append_move(self.basic_game.root.children[0], "Player 2", ["L", "R"])
 
     def tearDown(self):
         del self.game
         del self.extensive_game
+        del self.sample_extensive_game
 
     def test_get_infoset(self):
         "Test to ensure that we can retrieve an infoset for a given node"
@@ -215,3 +224,163 @@ class TestGambitNode(unittest.TestCase):
                           self.game.root, self.extensive_game.root)
         self.assertRaises(pygambit.MismatchError, self.game.move_tree,
                           self.extensive_game.root, self.game.root)
+
+    def test_append_move_creates_single_infoset_list_of_nodes(self):
+        """Test that appending a list of nodes creates a single infoset."""
+        self.sample_extensive_game.add_player("Player 3")
+        nodes = [self.sample_extensive_game.root.children[1].children[0],
+                 self.sample_extensive_game.root.children[0].children[0],
+                 self.sample_extensive_game.root.children[0].children[1]]
+        self.sample_extensive_game.append_move(nodes, "Player 3", ["B", "F"])
+
+        assert len(self.sample_extensive_game.players["Player 3"].infosets) == 1
+
+    def test_append_move_same_infoset_list_of_nodes(self):
+        """Test that nodes from a list of nodes are resolved in the same infoset."""
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+        nodes = [game.root.children[1].children[0],
+                 game.root.children[0].children[0]]
+        game.append_move(nodes, "Player 3", ["B", "F"])
+
+        assert nodes[0].infoset == nodes[1].infoset
+
+    def test_append_move_actions_list_of_nodes(self):
+        """Test that nodes from a list of nodes that resolved in the same infoset
+        have the same actions.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+        nodes = [game.root.children[1].children[0],
+                 game.root.children[0].children[0]]
+        game.append_move(nodes, "Player 3", ["B", "F", "S"])
+
+        action_list = list(game.players["Player 3"].infosets[0].actions)
+
+        for node in nodes:
+            assert list(node.infoset.actions) == action_list
+
+    def test_append_move_actions_list_of_node_labels(self):
+        """Test that nodes from a list of node labels are resolved correctly.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+        game.root.children[1].children[0].label = "0"
+        game.root.children[0].children[0].label = "00"
+        nodes = ["0", "00"]
+        game.append_move(nodes, "Player 3", ["B", "F", "S"])
+
+        assert game.root.children[1].children[0].children[0].parent.label == "0"
+        assert game.root.children[0].children[0].children[0].parent.label == "00"
+        assert len(game.root.children[1].children[0].children) == 3
+        assert len(game.root.children[0].children[0].children) == 3
+
+    def test_append_move_actions_list_of_mixed_node_references(self):
+        """Test that nodes from a list of nodes with either 'node' or str references
+        are resolved correctly.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+
+        game.root.children[1].children[0].label = " 000"
+        node_references = [" 000",
+                           game.root.children[0].children[0]]
+        game.append_move(node_references, "Player 3", ["B", "F", "S"])
+
+        assert game.root.children[1].children[0].children[0].parent.label == " 000"
+        assert len(game.root.children[1].children[0].children) == 3
+        assert len(game.root.children[0].children[0].children) == 3
+
+    def test_append_move_labels_list_of_nodes(self):
+        """Test that nodes from a list of nodes that resolved in the same infoset
+        have the same labels per action.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+        nodes = [game.root.children[1].children[0],
+                 game.root.children[0].children[0]]
+        game.append_move(nodes, "Player 3", ["B", "F", "S"])
+
+        action_list = game.players["Player 3"].infosets[0].actions
+        tmp1 = game.root.children[1].children[0].infoset.actions
+        tmp2 = game.root.children[0].children[0].infoset.actions
+
+        for (action, action1, action2) in zip(action_list, tmp1, tmp2):
+            assert action.label == action1.label
+            assert action.label == action2.label
+
+    def test_append_move_node_list_with_non_terminal_node(self):
+        """Test that we get an UndefinedOperationError when we import in append_move a list
+        of nodes that has a non terminal node.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+
+        self.assertRaises(pygambit.UndefinedOperationError,
+                          game.append_move,
+                          [game.root.children[1],
+                           game.root.children[0].children[1]],
+                          "Player 3", ["B", "F"])
+
+    def test_append_move_node_list_with_duplicate_node_references(self):
+        """Test that we get a ValueError when we import in append_move a list
+        nodes with non-unique node references.
+        """
+        game = games.read_from_file("sample_extensive_game.efg")
+        game.add_player("Player 3")
+        game.root.children[0].children[1].label = "00"
+
+        self.assertRaises(ValueError, game.append_move,
+                          ["00",
+                           game.root.children[1].children[0],
+                           game.root.children[0].children[1]],
+                          "Player 3", ["B", "F"])
+
+    def test_append_move_node_list_is_empty(self):
+        """Test that we get a ValueError when we import in append_move an
+        empty list of nodes.
+        """
+        game = games.read_from_file("sample_extensive_game.efg")
+        game.add_player("Player 3")
+
+        self.assertRaises(ValueError, game.append_move,
+                          [], "Player 3", ["B", "F"])
+
+    def test_append_infoset_node_list_with_non_terminal_node(self):
+        """Test that we get an UndefinedOperationError when we import in append_infoset
+        a list of nodes that has a non terminal node.
+        """
+        game = self.sample_extensive_game
+        game.add_player("Player 3")
+        game.append_move(game.root.children[0].children[0], "Player 3", ["B", "F"])
+
+        self.assertRaises(pygambit.UndefinedOperationError,
+                          game.append_infoset,
+                          [game.root.children[1],
+                           game.root.children[0].children[1]],
+                          game.root.children[0].children[0].infoset)
+
+    def test_append_infoset_node_list_with_duplicate_node(self):
+        """Test that we get a ValueError when we import in append_infoset a list
+        with non unique elements.
+        """
+        game = games.read_from_file("sample_extensive_game.efg")
+        game.add_player("Player 3")
+        game.append_move(game.root.children[0].children[0], "Player 3", ["B", "F"])
+
+        self.assertRaises(ValueError, game.append_infoset,
+                          [game.root.children[0].children[1],
+                           game.root.children[1].children[0],
+                           game.root.children[0].children[1]],
+                          game.root.children[0].children[0].infoset)
+
+    def test_append_infoset_node_list_is_empty(self):
+        """Test that we get a ValueError when we import in append_infoset an
+        empty list of nodes.
+        """
+        game = games.read_from_file("sample_extensive_game.efg")
+        game.add_player("Player 3")
+        game.append_move(game.root.children[0].children[0], "Player 3", ["B", "F"])
+
+        self.assertRaises(ValueError, game.append_infoset,
+                          [], game.root.children[0].children[0].infoset)


### PR DESCRIPTION
Import a list of valid terminal node references for  the append_move and append_infoset functions. Further, the test_node and test_infosets test function have been modified to check the newly acquired functionality.