### PR TITLE
fix-issue: logit_estimate

### DIFF
--- a/src/pygambit/qre.py
+++ b/src/pygambit/qre.py
@@ -305,6 +305,20 @@ def logit_estimate(
         as a structural model for estimation: The missing manual.
         SSRN working paper 4425515.
     """
+    def convert_to_float_precision(profile):
+        """Convert a rational precision profile to float precision."""
+        if isinstance(profile, libgbt.MixedStrategyProfile):
+            return libgbt.MixedStrategyProfile(
+                {strategy: float(prob) for strategy, prob in profile.items()}
+            )
+        elif isinstance(profile, libgbt.MixedBehaviorProfile):
+            return libgbt.MixedBehaviorProfile(
+                {action: float(prob) for action, prob in profile.items()}
+            )
+        else:
+            raise TypeError("Unsupported profile type for conversion")
+    # Convert to float precision if necessary
+    data = convert_to_float_precision(data)
     if isinstance(data, libgbt.MixedStrategyProfile):
         if use_empirical:
             return _estimate_strategy_empirical(data)


### PR DESCRIPTION
This update allows the logit_estimate function to handle rational numbers (like fractions) by converting them to floats internally. This means you can now use profiles with rational precision without any issues, making it easier to work with count data directly.

this fixes issue- #458 