### PR TITLE
Add static wxwidgets to mac installation in github actions

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -40,7 +40,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install automake autoconf wxwidgets
+        run: |
+            brew install automake autoconf 
+            curl -L -O https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.6/wxWidgets-3.2.6.tar.bz2
+            tar xjf wxWidgets-3.2.6.tar.bz2
+            cd wxWidgets-3.2.6
+            mkdir build-release
+            cd build-release
+            ../configure --disable-shared --disable-sys-libs
+            make -j4
+            sudo make install
       - run: aclocal
       - run: automake --add-missing
       - run: autoconf
@@ -59,7 +68,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install automake autoconf wxwidgets
+        run: |
+            brew install automake autoconf 
+            curl -L -O https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.6/wxWidgets-3.2.6.tar.bz2
+            tar xjf wxWidgets-3.2.6.tar.bz2
+            cd wxWidgets-3.2.6
+            mkdir build-release
+            cd build-release
+            ../configure --disable-shared --disable-sys-libs
+            make -j4
+            sudo make install
       - run: aclocal
       - run: automake --add-missing
       - run: autoconf

--- a/Makefile.am
+++ b/Makefile.am
@@ -599,13 +599,14 @@ gambit_SOURCES = \
 	src/gui/valnumber.cc \
 	src/gui/valnumber.h
 
+gambit_LDADD = $(RC_OBJECT_PATH) $(WX_LIBS)
 
 if IS_WIN32
-gambit_LDADD = $(RC_OBJECT_PATH) $(WX_LIBS_STATIC) -ldeflate -lzstd -llerc -lWebP
-else
-gambit_LDADD = $(RC_OBJECT_PATH) $(WX_LIBS)
+  gambit_LDADD += $(WX_LIBS_STATIC) -ldeflate -lzstd -llerc -lWebP
 endif
-
+if IS_MAC
+  gambit_LDADD += $(WX_LIBS_STATIC)
+endif
 
 osx-bundle:
 	make all

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ dnl LT_INIT
 AM_PROG_CC_C_O
 MINGW_AC_WIN32_NATIVE_HOST
 AM_CONDITIONAL(IS_WIN32, [test x$mingw_cv_win32_host = xyes])
+AM_CONDITIONAL(IS_MAC, [test x$(uname) = xDarwin])
 
 dnl Check for C++17 support
 AX_CXX_COMPILE_STDCXX(17)


### PR DESCRIPTION
This PR adds WXWidgets as a static library for the MacOS build with github actions. 

Three files are changed: 

- tools.yml : Following instructions on wxwidgets webpage, a static version of the wxwidgets is built. 
- configure.ac : Setting an IS_MAC variable ; similar to IS_WIN32
- Makefile.am : Some logic to perform to handle libraries differently depending on the OS. There may be a better way of writing this logic. . 

I've manually tested this by opening the GUI on Macos 13 (and Ted tried on Macos14). GUI opens without a previous wxwidgets installed via brew. I don't have familarity with the software to test further but it appears to work as desired. I see the same behaviour on windows. I haven't tested to linux installation. 

Hope this is helpful! :D 