### PR TITLE
Issue 503. Extend `GameTreeRep` to keep track of the total number of non-terminal nodes in the game

### DIFF
--- a/src/games/game.h
+++ b/src/games/game.h
@@ -634,6 +634,8 @@ public:
   virtual GameNode GetRoot() const = 0;
   /// Returns the number of nodes in the game
   virtual size_t NumNodes() const = 0;
+  /// Returns the number of non-terminal nodes in the game
+  virtual size_t NumNonterminalNodes() const = 0;
   //@}
 
   /// @name Modification

--- a/src/games/gameagg.h
+++ b/src/games/gameagg.h
@@ -101,6 +101,8 @@ public:
   GameNode GetRoot() const override { throw UndefinedException(); }
   /// Returns the number of nodes in the game
   size_t NumNodes() const override { throw UndefinedException(); }
+  /// Returns the number of non-terminal nodes in the game
+  size_t NumNonterminalNodes() const override { throw UndefinedException(); }
   //@}
 
   /// @name General data access

--- a/src/games/gamebagg.h
+++ b/src/games/gamebagg.h
@@ -109,6 +109,8 @@ public:
   GameNode GetRoot() const override { throw UndefinedException(); }
   /// Returns the number of nodes in the game
   size_t NumNodes() const override { throw UndefinedException(); }
+  /// Returns the number of non-terminal nodes in the game
+  size_t NumNonterminalNodes() const override { throw UndefinedException(); }
   //@}
 
   /// @name General data access

--- a/src/games/gametable.h
+++ b/src/games/gametable.h
@@ -90,6 +90,8 @@ public:
   GameNode GetRoot() const override { throw UndefinedException(); }
   /// Returns the number of nodes in the game
   size_t NumNodes() const override { throw UndefinedException(); }
+  /// Returns the number of non-terminal nodes in the game
+  size_t NumNonterminalNodes() const override { throw UndefinedException(); }
   //@}
 
   /// @name Outcomes

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -138,6 +138,7 @@ void GameTreeRep::DeleteAction(GameAction p_action)
 
   for (auto member : infoset->m_members) {
     DeleteTree(member->m_children[where]);
+    m_numNodes--;
     member->m_children[where]->Invalidate();
     erase_atindex(member->m_children, where);
   }
@@ -434,6 +435,7 @@ void GameTreeRep::DeleteParent(GameNode p_node)
       std::find(oldParent->m_children.begin(), oldParent->m_children.end(), node));
   DeleteTree(oldParent);
   node->m_parent = oldParent->m_parent;
+  m_numNodes--;
   if (node->m_parent) {
     std::replace(node->m_parent->m_children.begin(), node->m_parent->m_children.end(), oldParent,
                  node);
@@ -456,6 +458,7 @@ void GameTreeRep::DeleteTree(GameNode p_node)
   IncrementVersion();
   while (!node->m_children.empty()) {
     DeleteTree(node->m_children.front());
+    m_numNodes--;
     node->m_children.front()->Invalidate();
     erase_atindex(node->m_children, 1);
   }
@@ -463,7 +466,6 @@ void GameTreeRep::DeleteTree(GameNode p_node)
     RemoveMember(node->m_infoset, node);
     node->m_infoset = nullptr;
   }
-  m_numNodes--;
   node->m_outcome = nullptr;
   node->m_label = "";
 

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -242,6 +242,7 @@ GameAction GameTreeRep::InsertAction(GameInfoset p_infoset, GameAction p_action 
   }
 
   m_numNodes += p_infoset->m_members.size();
+  // m_numNonterminalNodes stays unchanged when an action is appended to an information set
   ClearComputedValues();
   Canonicalize();
   return action;
@@ -455,6 +456,9 @@ void GameTreeRep::DeleteTree(GameNode p_node)
     throw MismatchException();
   }
   GameNodeRep *node = p_node;
+  if (!node->IsTerminal()) {
+    m_numNonterminalNodes--;
+  }
   IncrementVersion();
   while (!node->m_children.empty()) {
     DeleteTree(node->m_children.front());
@@ -633,6 +637,7 @@ GameInfoset GameTreeRep::AppendMove(GameNode p_node, GameInfoset p_infoset)
                   node->m_children.push_back(new GameNodeRep(this, node));
                   m_numNodes++;
                 });
+  m_numNonterminalNodes++;
   ClearComputedValues();
   Canonicalize();
   return node->m_infoset;
@@ -681,6 +686,7 @@ GameInfoset GameTreeRep::InsertMove(GameNode p_node, GameInfoset p_infoset)
 
   // Total nodes added = 1 (newNode) + (NumActions - 1) (new children of newNode) = NumActions
   m_numNodes += newNode->m_infoset->m_actions.size();
+  m_numNonterminalNodes++;
   ClearComputedValues();
   Canonicalize();
   return p_infoset;

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -37,6 +37,7 @@ protected:
   GameNodeRep *m_root;
   GamePlayerRep *m_chance;
   std::size_t m_numNodes = 1;
+  std::size_t m_numNonterminalNodes = 0;
 
   /// @name Private auxiliary functions
   //@{
@@ -95,6 +96,8 @@ public:
   GameNode GetRoot() const override { return m_root; }
   /// Returns the number of nodes in the game
   size_t NumNodes() const override { return m_numNodes; }
+  /// Returns the number of non-terminal nodes in the game
+  size_t NumNonterminalNodes() const override { return m_numNonterminalNodes; }
   //@}
 
   void DeleteOutcome(const GameOutcome &) override;

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -187,6 +187,7 @@ cdef extern from "games/game.h":
         void DeleteOutcome(c_GameOutcome) except +
 
         int NumNodes() except +
+        int NumNonterminalNodes() except +
         c_GameNode GetRoot() except +
 
         c_GameStrategy GetStrategy(int) except +IndexError

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -195,6 +195,41 @@ class GameNodes:
 
 
 @cython.cclass
+class GameNonterminalNodes:
+    """Represents the set of nodes in a game."""
+    game = cython.declare(c_Game)
+
+    def __init__(self, *args, **kwargs) -> None:
+        raise ValueError("Cannot create GameNonterminalNodes outside a Game.")
+
+    @staticmethod
+    @cython.cfunc
+    def wrap(game: c_Game) -> GameNonterminalNodes:
+        obj: GameNonterminalNodes = GameNonterminalNodes.__new__(GameNonterminalNodes)
+        obj.game = game
+        return obj
+
+    def __repr__(self) -> str:
+        return f"GameNonterminalNodes(game={Game.wrap(self.game)})"
+
+    def __len__(self) -> int:
+        """The number of non-terminal nodes in the game."""
+        if not self.game.deref().IsTree():
+            return 0
+        return self.game.deref().NumNonterminalNodes()
+
+    def __iter__(self) -> typing.Iterator[Node]:
+        def dfs(node):
+            if not node.is_terminal:
+                yield node
+            for child in node.children:
+                yield from dfs(child)
+        if not self.game.deref().IsTree():
+            return
+        yield from dfs(Node.wrap(self.game.deref().GetRoot()))
+
+
+@cython.cclass
 class GameOutcomes:
     """Represents the set of outcomes in a game."""
     game = cython.declare(c_Game)
@@ -712,6 +747,15 @@ class Game:
 
         """
         return GameNodes.wrap(self.game)
+
+    @property
+    def _nonterminal_nodes(self) -> GameNonterminalNodes:
+        """The set of non-terminal nodes in the game.
+
+        Iteration over this property yields the non-terminal nodes in the order of depth-first
+        search.
+        """
+        return GameNonterminalNodes.wrap(self.game)
 
     @property
     def contingencies(self) -> pygambit.gameiter.Contingencies:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -446,7 +446,7 @@ def test_len_after_delete_tree():
     list_nodes = list(game.nodes)
 
     root_of_the_deleted_subtree = list_nodes[3]
-    number_of_deleted_nodes = _count_subtree_nodes(root_of_the_deleted_subtree)
+    number_of_deleted_nodes = _count_subtree_nodes(root_of_the_deleted_subtree) - 1
 
     game.delete_tree(root_of_the_deleted_subtree)
 


### PR DESCRIPTION
Extend `GameTreeRep` to keep track of the total number of non-terminal nodes in the game

Additionally, fixes a bug in `m_numNodes` counter in operations involving delete. 

Solves #503 