### PR TITLE
Get the action prescribed by a strategy at an information set

### DIFF
--- a/src/games/game.cc
+++ b/src/games/game.cc
@@ -47,6 +47,26 @@ GameOutcomeRep::GameOutcomeRep(GameRep *p_game, int p_number) : m_game(p_game), 
 }
 
 //========================================================================
+//                      class GameStrategyRep
+//========================================================================
+
+GameAction GameStrategyRep::GetAction(const GameInfoset &p_infoset) const
+{
+  if (p_infoset->GetPlayer() != m_player) {
+    throw MismatchException();
+  }
+  int action = m_behav[p_infoset->GetNumber()];
+  return (action) ? *std::next(p_infoset->GetActions().cbegin(), action - 1) : nullptr;
+}
+
+void GameStrategyRep::DeleteStrategy()
+{
+  if (m_player->GetGame()->IsTree()) {
+    throw UndefinedException();
+  }
+}
+
+//========================================================================
 //                       class GamePlayerRep
 //========================================================================
 

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -358,6 +358,12 @@ public:
   GamePlayer GetPlayer() const;
   /// Returns the index of the strategy for its player
   int GetNumber() const { return m_number; }
+
+  /// Returns the action specified by the strategy at the information set
+  GameAction GetAction(const GameInfoset &) const;
+
+  /// Remove this strategy from the game
+  void DeleteStrategy();
   //@}
 };
 

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -97,6 +97,8 @@ cdef extern from "games/game.h":
         c_GamePlayer GetPlayer() except +
         string GetLabel() except +
         void SetLabel(string) except +
+        c_GameAction GetAction(c_GameInfoset) except +
+        void DeleteStrategy() except +
 
     cdef cppclass c_GameActionRep "GameActionRep":
         int GetNumber() except +

--- a/src/pygambit/strategy.pxi
+++ b/src/pygambit/strategy.pxi
@@ -73,3 +73,6 @@ class Strategy:
     def number(self) -> int:
         """The number of the strategy."""
         return self.strategy.deref().GetNumber() - 1
+
+    def action(self, infoset: Infoset) -> Action:
+        return Action.wrap(self.strategy.deref().GetAction(infoset.infoset))


### PR DESCRIPTION
This provides an interface `GameStrategyRep::GetAction` to the mapping from infoset to action as part of a strategy for an extensive game.

A function `.action()` has been added in Python as well.
