### PR TITLE
Fix bug in TreeGameOutcome.label

### DIFF
--- a/src/pygambit/outcome.pxi
+++ b/src/pygambit/outcome.pxi
@@ -179,7 +179,7 @@ class TreeGameOutcome:
         return "(%s)" % (
             ",".join(
                 [deref(deref(self.psp).deref()).GetStrategy(cython.cast(Player, player).player)
-                 .deref().GetLabel().c_str()
+                 .deref().GetLabel().c_str().decode()
                  for player in self.game.players]
             )
         )


### PR DESCRIPTION
Decode bytes before joining with the string in `TreeGameOutcome.label`