### PR TITLE
Fix notebook discovery to exclude Jupyter checkpoint files

### DIFF
--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -23,7 +23,11 @@ def _find_tutorial_notebooks():
         pytest.skip(f"Tutorials folder not found: {root}")
 
     # Collect all notebooks under doc/tutorials (including any subfolders).
-    notebooks = sorted(set(root.rglob("*.ipynb")))
+    # Exclude Jupyter checkpoint files
+    notebooks = sorted(
+        p for p in root.rglob("*.ipynb")
+        if ".ipynb_checkpoints" not in p.parts
+    )
 
     if not notebooks:
         pytest.skip(f"No tutorial notebooks found in: {root}")


### PR DESCRIPTION
Closes #650 

### Reviewers

If you have any `.ipynb_checkpoints` on your machine which previously caused the test that runs the tutorials to fail, check out this branch and run the following to check that those checkpoints are now ignored:

```
pytest tests/test_tutorials.py
```