### PR TITLE
Disable View->Strategic game if game is in strategic form

### DIFF
--- a/src/gui/gameframe.cc
+++ b/src/gui/gameframe.cc
@@ -489,6 +489,10 @@ void gbtGameFrame::MakeMenus()
 
   viewMenu->Append(GBT_MENU_VIEW_STRATEGIC, _("&Strategic game"),
                    wxT("Display the reduced strategic representation ") wxT("of the game"), true);
+  if (!m_doc->GetGame()->IsTree()) {
+    viewMenu->Check(GBT_MENU_VIEW_STRATEGIC, true);
+    viewMenu->Enable(GBT_MENU_VIEW_STRATEGIC, false);
+  }
 
   auto *formatMenu = new wxMenu;
   AppendBitmapItem(formatMenu, GBT_MENU_FORMAT_LAYOUT, _("&Layout"),


### PR DESCRIPTION
On a strategic game the View->Strategic game menu option was (a) available and (b) unchecked.

Selecting it would result in program termination.

This corrects the situation: It is now (a) disabled but (b) checked.