### PR TITLE
Fix caching in MixedStrategyProfile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@
   adding a move via drag-and-drop of a player icon (#618)
 - Fixed a regression generating null pointer dereference errors when setting the outcome of
   a node to the null outcome (#625, #647)
+- Fixed a regression in calculating payoff quantities for mixed strategy profiles derived from
+  mixed behavior profiles (#616)
 
 
 ## [16.3.2] - unreleased

--- a/src/games/stratmixed.h
+++ b/src/games/stratmixed.h
@@ -49,7 +49,11 @@ public:
     return m_probs[m_profileIndex.at(p_strategy)];
   }
   /// Returns the probability the strategy is played
-  T &operator[](const GameStrategy &p_strategy) { return m_probs[m_profileIndex.at(p_strategy)]; }
+  T &operator[](const GameStrategy &p_strategy)
+  {
+    InvalidateCache();
+    return m_probs[m_profileIndex.at(p_strategy)];
+  }
   /// Set the strategy of the corresponding player to a pure strategy
   void SetStrategy(const GameStrategy &p_strategy)
   {


### PR DESCRIPTION
For mixed strategy profiles which are defined on trees, a behavior strategy profile is computed and cached.  This was not correctly being cleared when changing the strategy probabilities,
resulting in incorrect output.

Closes #616.