### PR TITLE
Add generated build support files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ doc/tutorials/*.png
 Gambit.app/*
 *.ipynb_checkpoints
 *.ef
+build_support/msw/gambit.wxs
+build_support/osx/Info.plist


### PR DESCRIPTION

### Description of the changes in this PR

Updates `.gitignore` with build support files that get generated

### How to review this PR

Check it makes sense that these files should not be committed to the repo
