### PR TITLE
Fix invalid pointer access in `GameTreeRep::Reveal`.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 # Changelog
 
+## [16.5.1] - unreleased
+
+### Fixed
+- `Game.reveal` raised a null pointer access exception or dumped core in some cases (#749)
+
+
 ## [16.5.0] - 2026-01-05
 
 ### Fixed

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -259,16 +259,14 @@ void GameTreeRep::RemoveMember(GameInfosetRep *p_infoset, GameNodeRep *p_node)
 void GameTreeRep::Reveal(GameInfoset p_atInfoset, GamePlayer p_player)
 {
   IncrementVersion();
-  for (auto action : p_atInfoset->GetActions()) {
-    for (auto infoset : p_player->m_infosets) {
-      // make copy of members to iterate correctly
-      // (since the information set may be changed in the process)
+  for (const auto &action : p_atInfoset->m_actions) {
+    auto infosets = p_player->m_infosets;
+    for (const auto &infoset : infosets) {
       auto members = infoset->m_members;
-
       // This information set holds all members of information set
       // which follow 'action'.
       GameInfoset newiset = nullptr;
-      for (auto &member : members) {
+      for (const auto &member : members) {
         if (action->Precedes(member)) {
           if (!newiset) {
             newiset = LeaveInfoset(member);


### PR DESCRIPTION
Fixes #749.