### PR TITLE
Fix printing normal form games

### DIFF
--- a/src/games/stratspt.h
+++ b/src/games/stratspt.h
@@ -156,6 +156,7 @@ public:
     const int digit = p_strategy->GetNumber() - 1;
     StrategySupportProfile restricted(*this);
     restricted.m_strategyDigits.m_allowedDigits[player_index].assign(1, digit);
+    restricted.m_support.at(player) = {p_strategy};
     return restricted;
   }
   //@}

--- a/src/games/writer.cc
+++ b/src/games/writer.cc
@@ -91,7 +91,6 @@ std::string WriteHTMLFile(const Game &p_game, const GamePlayer &p_rowPlayer,
     }
 
     theHtml += "</table>";
-    break;
   }
   theHtml += "\n";
   return theHtml;


### PR DESCRIPTION
### Description of the changes in this PR

@tturocy I noticed that after recent changes when you view a normal form game in jupyter the printed html is duplicated:

<img width="816" height="502" alt="Screenshot 2026-02-05 at 09 45 57" src="https://github.com/user-attachments/assets/e1dc3419-a8cf-4b8a-9bbd-19a0a124edf6" />

I've made a temporary fix with out looking properly into how the code works and now we get the game printed just once:
<img width="851" height="217" alt="Screenshot 2026-02-05 at 09 48 07" src="https://github.com/user-attachments/assets/5747f771-51c4-4a71-8a8b-3b3f585046e5" />


### How to review this PR

@tturocy I can take more of a look into this but you may know a quick fix