### PR TITLE
Refactor apis of mixed profiles to be products of distributions (#763)

### DIFF
--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -909,8 +909,7 @@ class Game:
                 raise ValueError(
                     f"Number of elements does not match number of strategies for {p}"
                 )
-            for (s, v) in zip(p.strategies, d, strict=True):
-                profile[s] = typefunc(v)
+            profile[p] = [typefunc(v) for v in d]
         return profile
 
     def mixed_strategy_profile(self, data=None, rational=False) -> MixedStrategyProfile:
@@ -986,15 +985,11 @@ class Game:
         if denom is None:
             profile = self.mixed_strategy_profile()
             for player in self.players:
-                for strategy, prob in zip(
-                        player.strategies,
-                        scipy.stats.dirichlet(
-                            alpha=[1 for strategy in player.strategies],
-                            seed=gen
-                        ).rvs(size=1)[0],
-                        strict=True
-                        ):
-                    profile[strategy] = prob
+                probs = scipy.stats.dirichlet(
+                    alpha=[1 for _ in player.strategies],
+                    seed=gen
+                ).rvs(size=1)[0]
+                profile[player] = list(probs)
             return profile
         elif denom < 1:
             raise ValueError("random_strategy_profile(): denom must be positive")
@@ -1009,16 +1004,11 @@ class Game:
                     ) +
                     [denom + k]
                 )
-                for strategy, (hi, lo) in zip(
-                    player.strategies,
-                    zip(
-                        sample[1:],
-                        sample[:-1],
-                        strict=True
-                    ),
-                    strict=True
-                ):
-                    profile[strategy] = Rational(hi - lo - 1, denom)
+                probs = [
+                    Rational(hi - lo - 1, denom)
+                    for (hi, lo) in zip(sample[1:], sample[:-1], strict=True)
+                ]
+                profile[player] = probs
             return profile
 
     def _fill_behavior_profile(self,
@@ -1039,8 +1029,7 @@ class Game:
                         f"Number of elements does not match number of "
                         f"actions for infoset {i} for {p}"
                     )
-                for (a, u) in zip(i.actions, v, strict=True):
-                    profile[a] = typefunc(u)
+                profile[i] = [typefunc(u) for u in v]
         return profile
 
     def mixed_behavior_profile(self, data=None, rational=False) -> MixedBehaviorProfile:
@@ -1119,13 +1108,11 @@ class Game:
         if denom is None:
             profile = self.mixed_behavior_profile()
             for infoset in self.infosets:
-                for action, prob in zip(
-                        infoset.actions,
-                        scipy.stats.dirichlet(alpha=[1 for action in infoset.actions],
-                                              seed=gen).rvs(size=1)[0],
-                        strict=True
-                ):
-                    profile[action] = prob
+                probs = scipy.stats.dirichlet(
+                    alpha=[1 for _ in infoset.actions],
+                    seed=gen
+                ).rvs(size=1)[0]
+                profile[infoset] = list(probs)
             return profile
         elif denom < 1:
             raise ValueError("random_behavior_profile(): denom must be positive")
@@ -1140,15 +1127,11 @@ class Game:
                     ) +
                     [denom + k]
                 )
-                for action, (hi, lo) in zip(
-                    infoset.actions,
-                    zip(
-                        sample[1:], sample[:-1],
-                        strict=True
-                    ),
-                    strict=True
-                ):
-                    profile[action] = Rational(hi - lo - 1, denom)
+                probs = [
+                    Rational(hi - lo - 1, denom)
+                    for (hi, lo) in zip(sample[1:], sample[:-1], strict=True)
+                ]
+                profile[infoset] = probs
             return profile
 
     def strategy_support_profile(

--- a/src/pygambit/qre.py
+++ b/src/pygambit/qre.py
@@ -219,10 +219,14 @@ def _estimate_strategy_empirical(
         bounds=((0.0, None),)
     )
     profile = data.game.mixed_strategy_profile()
-    for strategy, log_prob in zip(data.game.strategies,
-                                  _empirical_log_logit_probs(res.x[0], regrets),
-                                  strict=True):
-        profile[strategy] = math.exp(log_prob)
+    log_probs = _empirical_log_logit_probs(res.x[0], regrets)
+    idx = 0
+    for player in data.game.players:
+        player_probs = []
+        for strategy in player.strategies:
+            player_probs.append(math.exp(log_probs[idx]))
+            idx += 1
+        profile[player] = player_probs
     return LogitQREMixedStrategyFitResult(
         data, "empirical", res.x[0], profile, -res.fun
     )
@@ -241,9 +245,15 @@ def _estimate_behavior_empirical(
         bounds=((0.0, None),)
     )
     profile = data.game.mixed_behavior_profile()
-    for action, log_prob in zip(data.game.actions, _empirical_log_logit_probs(res.x[0], regrets),
-                                strict=True):
-        profile[action] = math.exp(log_prob)
+    log_probs = _empirical_log_logit_probs(res.x[0], regrets)
+    idx = 0
+    for player in data.game.players:
+        for infoset in player.infosets:
+            infoset_probs = []
+            for action in infoset.actions:
+                infoset_probs.append(math.exp(log_probs[idx]))
+                idx += 1
+            profile[infoset] = infoset_probs
     return LogitQREMixedBehaviorFitResult(
         data, "empirical", res.x[0], profile, -res.fun
     )

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -18,9 +18,17 @@ def _set_action_probs(profile: gbt.MixedStrategyProfile, probs: list, rational_f
     """Set the action probabilities in a strategy profile called ```profile``` according to a
     list with probabilities in the order of ```profile.game.strategies```
     """
-    for i, p in enumerate(probs):
-        # assumes rationals given as strings
-        profile[profile.game.strategies[i]] = gbt.Rational(p) if rational_flag else p
+    idx = 0
+    for player in profile.game.players:
+        player_probs = []
+        for strategy in player.strategies:
+            if idx < len(probs):
+                p = probs[idx]
+                player_probs.append(gbt.Rational(p) if rational_flag else p)
+                idx += 1
+            else:
+                player_probs.append(profile[strategy])
+        profile[player] = player_probs
 
 
 @pytest.mark.parametrize(
@@ -116,13 +124,13 @@ def test_normalize(game, profile_data, expected_data, rational_flag):
      (games.create_stripped_down_poker_efg(), "21", "7/9", True),
     ],
 )
-def test_set_and_get_probability_by_strategy_label(game: gbt.Game, strategy_label: str,
-                                                   rational_flag: bool,
-                                                   prob: float | str):
+def test_set_individual_strategy_by_label_raises_error(game: gbt.Game, strategy_label: str,
+                                                            rational_flag: bool,
+                                                            prob: float | str):
     profile = game.mixed_strategy_profile(rational=rational_flag)
     prob = gbt.Rational(prob) if rational_flag else prob
-    profile[strategy_label] = prob
-    assert profile[strategy_label] == prob
+    with pytest.raises((TypeError, KeyError)):
+        profile[strategy_label] = prob
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Closes #763

### Description of the changes in this PR

- refactored python apis for MixedStrategyProfile and MixedBehaviorProfile to correctly reflect their structure as products of distributions.

- before, the api allowed setting the probability of individual strategies or actions. i have removed those individual setters and enforced distribution-level setting per player or per information set.


