### PR TITLE
Add tests for MixedBehaviorProfile.as_strategy

### DIFF
--- a/tests/test_behav_as_strategy.py
+++ b/tests/test_behav_as_strategy.py
@@ -3,10 +3,8 @@ import pygambit as gbt
 
 @pytest.fixture
 def small_efg():
-    """Fixture providing a minimal 2-player perfect-info sequential game."""
     g = gbt.Game.new_tree(players=["Alice", "Bob"], title="Small Sequential")
     g.append_move(g.root, "Alice", ["L", "R"])
-    # Note: append_move to individual node gives Bob two distinct information sets
     g.append_move(g.root.children[0], "Bob", ["u", "d"])
     g.append_move(g.root.children[1], "Bob", ["u", "d"])
     
@@ -17,55 +15,27 @@ def small_efg():
     return g
 
 def test_as_strategy_payoff_consistency(small_efg):
-    """
-    Test that the expected payoffs match between computing with the original 
-    behavior profile and the converted mixed strategy profile.
-    """
     g = small_efg
     profile = g.mixed_behavior_profile(rational=True)
-    
-    # Assign some arbitrary probabilities
     profile["L"] = gbt.Rational(1, 4)
     profile["R"] = gbt.Rational(3, 4)
     profile[g.players["Bob"].infosets[0]] = [gbt.Rational(1, 2), gbt.Rational(1, 2)]
     profile[g.players["Bob"].infosets[1]] = [gbt.Rational(1, 4), gbt.Rational(3, 4)]
-    
     strat_profile = profile.as_strategy()
-    
-    # Check consistency of payoffs across both profile structures
     assert profile.payoff("Alice") == strat_profile.payoff("Alice")
     assert profile.payoff("Bob") == strat_profile.payoff("Bob")
 
 def test_as_strategy_kuhn_manual_reference(small_efg):
-    """
-    Test that the mixed strategy representation calculated by as_strategy() 
-    matches manual calculation using Kuhn's Theorem (multiplying 
-    action probabilities structurally along each pure strategy's execution path).
-    """
     g = small_efg
     profile = g.mixed_behavior_profile(rational=True)
-    
-    # Let Pr(L) = 1/4, Pr(R) = 3/4
     profile["L"] = gbt.Rational(1, 4)
     profile["R"] = gbt.Rational(3, 4)
-    
-    # Let Bob play u with prob=1/2 after L; Bob play u with prob=1/4 after R
     profile[g.players["Bob"].infosets[0]] = [gbt.Rational(1, 2), gbt.Rational(1, 2)]
     profile[g.players["Bob"].infosets[1]] = [gbt.Rational(1, 4), gbt.Rational(3, 4)]
-    
     strat_profile = profile.as_strategy()
-    
-    # Alice has 1 information set with 2 actions -> 2 pure strategies in the NFG: L, R
+   
     assert strat_profile[g.players["Alice"].strategies[0]] == gbt.Rational(1, 4) # Pr(L)
     assert strat_profile[g.players["Alice"].strategies[1]] == gbt.Rational(3, 4) # Pr(R)
-    
-    # Bob has 2 information sets, each taking 2 actions -> 4 pure strategies
-    # For Bob, strategy order conceptually maps to combinations of the two infoset distributions.
-    # We verify the correct probabilities using the mathematical product:
-    # 0 = u at 0, u at 1 -> (1/2) * (1/4) = 1/8
-    # 1 = u at 0, d at 1 -> (1/2) * (3/4) = 3/8
-    # 2 = d at 0, u at 1 -> (1/2) * (1/4) = 1/8
-    # 3 = d at 0, d at 1 -> (1/2) * (3/4) = 3/8
     assert strat_profile[g.players["Bob"].strategies[0]] == gbt.Rational(1, 8)
     assert strat_profile[g.players["Bob"].strategies[1]] == gbt.Rational(3, 8)
     assert strat_profile[g.players["Bob"].strategies[2]] == gbt.Rational(1, 8)


### PR DESCRIPTION
Closes #432 

This PR adds tests for MixedBehaviorProfile.as_strategy, which converts a behavior profile into a MixedStrategyProfile.

Two tests are added:
Payoff consistency test
Checks that the expected payoffs from the original mixed behavior profile match the expected payoffs from the mixed strategy profile returned by as_strategy().

Reference test (manual product calculation)
Uses a small two-player perfect-information game and manually computes the mixed strategy probabilities by multiplying behavior probabilities across information sets. These values are then compared with the probabilities returned by as_strategy().
The full test suite passes locally.

How to review this PR
Review the new test file for correctness and clarity.
Confirm that:
The payoff consistency test checks equality of expected payoffs.
The reference test correctly verifies the manually computed probabilities.
Run the full test suite to ensure no regressions.
This PR only adds tests and does not modify any implementation code.