### PR TITLE
fix: restrict enumpoly search space to strictly interior (#756)

### DIFF
--- a/src/solvers/enumpoly/efgpoly.cc
+++ b/src/solvers/enumpoly/efgpoly.cc
@@ -161,8 +161,8 @@ std::list<MixedBehaviorProfile<double>> SolveSupport(const BehaviorSupportProfil
 
   // set up the rectangle of search
   Vector<double> bottoms(data.space->GetDimension()), tops(data.space->GetDimension());
-  bottoms = 0;
-  tops = 1;
+  bottoms = 1e-12;
+  tops = 1 - 1e-12;
 
   PolynomialSystemSolver solver(equations);
   std::list<Vector<double>> roots;

--- a/src/solvers/enumpoly/nfgpoly.cc
+++ b/src/solvers/enumpoly/nfgpoly.cc
@@ -111,8 +111,8 @@ EnumPolyStrategySupportSolve(const StrategySupportProfile &support, bool &is_sin
   const PolynomialSystem<double> equations = ConstructEquations(space, support, strategy_poly);
 
   Vector<double> bottoms(space->GetDimension()), tops(space->GetDimension());
-  bottoms = 0;
-  tops = 1;
+  bottoms = 1e-12;
+  tops = 1 - 1e-12;
   PolynomialSystemSolver solver(equations);
   is_singular = false;
   std::list<Vector<double>> roots;

--- a/src/solvers/enumpoly/poly.h
+++ b/src/solvers/enumpoly/poly.h
@@ -375,7 +375,11 @@ public:
     });
   }
   [[nodiscard]] const std::vector<Monomial<T>> &GetTerms() const noexcept { return m_terms; }
-  bool IsZero() const noexcept { return m_terms.empty(); }
+  bool IsZero() const noexcept
+  {
+    return m_terms.empty() || std::all_of(m_terms.begin(), m_terms.end(),
+                                          [](const auto &mono) { return mono.IsZero(); });
+  }
   bool IsConstant() const noexcept
   {
     return m_terms.size() == 1 && m_terms.front().TotalDegree() == 0;


### PR DESCRIPTION
Newton's method in enumpoly_solve behaves poorly when solutions lie on the boundary of the probability simplex (i.e. probability = 0 or 1). The branch-and-bound approach would keep shrinking search areas toward the boundary indefinitely.

Since any boundary solution on a given support is an interior solution on a strictly smaller support, restrict the search rectangle to (1e-12, 1 - 1e-12) instead of (0, 1).

Also fix Polynomial::IsZero() to handle the case where a polynomial has terms but all coefficients are zero.

Fixes #756

_Thanks for contributing to Gambit! Before you submitting or reviewing a pull request, check out our [guidelines for contributing](https://gambitproject.readthedocs.io/en/latest/developer.contributing.html)._

_The person submitting the PR should ensure it has an informative title and update the headers below, before marking the PR as ready for review and assigning reviewers._

### Issues closed by this PR

_Add any issues that are being closed by this PR to the list. Use "Closes" or [another keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) followed by the issue number._

- Closes #756 

### Description of the changes in this PR

_Update the description of the changes made in this PR. You can delete this section if the changes are already fully described in the linked issues._

This PR ...

### How to review this PR

_The gambit repository contains source code and documentation for several different components. Explain how a reviewer should approach reviewing the specific changes made in this PR._

_For example, you might include instructions like:_
- _"Review code changes and ensure tests cover edge cases"_
- _"Rebuild the GUI from this branch, then test features X, Y, Z work as expected"_
- _"Click the link to the documentation page and sense check by reading"_
