### PR TITLE
doc: Add tutorial on congestion games (#663)

### DIFF
--- a/doc/pygambit.rst
+++ b/doc/pygambit.rst
@@ -42,6 +42,7 @@ Advanced tutorials:
 
    tutorials/advanced_tutorials/starting_points
    tutorials/advanced_tutorials/quantal_response
+   tutorials/advanced_tutorials/congestion_games
    .. pygambit.external_programs
 
 Interoperability tutorials

--- a/doc/tutorials/advanced_tutorials/congestion_games.ipynb
+++ b/doc/tutorials/advanced_tutorials/congestion_games.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Congestion Games and Weighted Congestion Games\n",
+    "\n",
+    "In this tutorial, we will explore **congestion games**, a fundamental class of games in algorithmic game theory. Congestion games model scenarios where multiple self-interested players share a common set of resources (such as routes in a network), and the cost incurred by each player depends only on the number of players choosing the same resources.\n",
+    "\n",
+    "An important theoretical result is that all **unweighted congestion games** are exact potential games, which guarantees the existence of at least one pure Nash equilibrium. However, this property does not generally hold for **weighted congestion games**, where players have different weights (demands) affecting the resources. In the weighted case, pure Nash equilibria are not guaranteed, but mixed Nash equilibria still exist.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Defining the Network and Cost Functions\n",
+    "\n",
+    "Consider a simple network with a source node $s$, an intermediate node $v$, and a sink node $t$. The setup is as follows:\n",
+    "- Two edges from $s$ to $v$: $e_1$ with cost $c_1(x) = x + 33$, and $e_2$ with cost $c_2(x) = 3x^2$\n",
+    "- Two edges from $v$ to $t$: $e_3$ with cost $c_3(x) = 13x$, and $e_4$ with cost $c_4(x) = x^2 + 44$\n",
+    "- One direct edge from $s$ to $t$: $e_5$ with cost $c_5(x) = 47x$\n",
+    "\n",
+    "Players choose a path from $s$ to $t$. There are five possible paths:\n",
+    "1. $P_1 = (e_1, e_3)$\n",
+    "2. $P_2 = (e_1, e_4)$\n",
+    "3. $P_3 = (e_2, e_3)$\n",
+    "4. $P_4 = (e_2, e_4)$\n",
+    "5. $P_5 = (e_5)$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pygambit as g\n",
+    "\n",
+    "# Edge cost functions\n",
+    "def c1(x): return x + 33\n",
+    "def c2(x): return 3 * (x ** 2)\n",
+    "def c3(x): return 13 * x\n",
+    "def c4(x): return (x ** 2) + 44\n",
+    "def c5(x): return 47 * x\n",
+    "\n",
+    "cost_funcs = {'e1': c1, 'e2': c2, 'e3': c3, 'e4': c4, 'e5': c5}\n",
+    "\n",
+    "# The 5 possible paths from s to t\n",
+    "paths = {\n",
+    "    'P1': ['e1', 'e3'],\n",
+    "    'P2': ['e1', 'e4'],\n",
+    "    'P3': ['e2', 'e3'],\n",
+    "    'P4': ['e2', 'e4'],\n",
+    "    'P5': ['e5']\n",
+    "}\n",
+    "\n",
+    "def compute_costs(path_p1, path_p2, w1, w2):\n",
+    "    \"\"\"Compute the costs for player 1 and player 2 given their chosen paths and weights.\"\"\"\n",
+    "    # Calculate load (x) on each edge\n",
+    "    load = {e: 0 for e in cost_funcs.keys()}\n",
+    "    for edge in paths[path_p1]: load[edge] += w1\n",
+    "    for edge in paths[path_p2]: load[edge] += w2\n",
+    "    \n",
+    "    # Calculate total cost for player 1\n",
+    "    cost1 = sum(cost_funcs[edge](load[edge]) for edge in paths[path_p1])\n",
+    "    \n",
+    "    # Calculate total cost for player 2\n",
+    "    cost2 = sum(cost_funcs[edge](load[edge]) for edge in paths[path_p2])\n",
+    "    \n",
+    "    return cost1, cost2\n",
+    "\n",
+    "def build_congestion_game(w1, w2):\n",
+    "    \"\"\"Generates the PyGambit bimatrix representation of the congestion game.\"\"\"\n",
+    "    game = g.Game.new_table([len(paths), len(paths)])\n",
+    "    game.title = f\"Congestion Game (w1={w1}, w2={w2})\"\n",
+    "    game.players[0].label = f\"Player 1 (w={w1})\"\n",
+    "    game.players[1].label = f\"Player 2 (w={w2})\"\n",
+    "    \n",
+    "    path_names = list(paths.keys())\n",
+    "    for i, name in enumerate(path_names):\n",
+    "        game.players[0].strategies[i].label = name\n",
+    "        game.players[1].strategies[i].label = name\n",
+    "\n",
+    "    # Fill the payoff matrix (payoffs are negative costs)\n",
+    "    for i, p1 in enumerate(path_names):\n",
+    "        for j, p2 in enumerate(path_names):\n",
+    "            c1, c2 = compute_costs(p1, p2, w1, w2)\n",
+    "            game[i, j][0] = -c1\n",
+    "            game[i, j][1] = -c2\n",
+    "            \n",
+    "    return game\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Unweighted Case (Always has a Pure Equilibrium)\n",
+    "\n",
+    "Let's consider the unweighted scenario where both Player 1 and Player 2 share a weight of 1 ($w_1 = w_2 = 1$). A well-known theoretical result establishes that every unweighted congestion game induces an exact potential game, meaning there is guaranteed to be at least one pure Nash equilibrium.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unweighted Game: Player 1 has weight 1, Player 2 has weight 1\n",
+    "g_unweighted = build_congestion_game(w1=1, w2=1)\n",
+    "\n",
+    "# Solve for pure strategy Nash equilibria\n",
+    "pure_eqs = g.nash.enumpure_solve(g_unweighted)\n",
+    "\n",
+    "print(f\"Found {len(pure_eqs)} pure Nash equilibrium/equilibria:\")\n",
+    "for eq in pure_eqs:\n",
+    "    p1_strat = next(s.label for s in g_unweighted.players[0].strategies if eq[s] == 1)\n",
+    "    p2_strat = next(s.label for s in g_unweighted.players[1].strategies if eq[s] == 1)\n",
+    "    print(f\"- Player 1 plays {p1_strat}, Player 2 plays {p2_strat}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Weighted Case (No Pure Equilibrium)\n",
+    "\n",
+    "Now, we introduce asymmetry. Suppose Player 1 has a weight of 1 ($w_1 = 1$), but Player 2 represents a larger group or higher-demand agent with a weight of 2 ($w_2 = 2$). \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Weighted Game: Player 1 has weight 1, Player 2 has weight 2\n",
+    "g_weighted = build_congestion_game(w1=1, w2=2)\n",
+    "\n",
+    "pure_eqs_w = g.nash.enumpure_solve(g_weighted)\n",
+    "print(f\"Found {len(pure_eqs_w)} pure Nash equilibria.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As predicted by algorithmic game theory, this weighted formulation lacks a pure Nash equilibrium. However, Nash's existence theorem guarantees that a mixed equilibrium will exist.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Solve for mixed strategy Nash equilibria\n",
+    "mixed_eqs = g.nash.enummixed_solve(g_weighted)\n",
+    "\n",
+    "print(f\"Found {len(mixed_eqs)} mixed Nash equilibrium/equilibria:\\n\")\n",
+    "for eq in mixed_eqs:\n",
+    "    print(\"Player 1 mixed strategy:\")\n",
+    "    for strat in g_weighted.players[0].strategies:\n",
+    "        prob = eq[strat]\n",
+    "        if prob > 0:\n",
+    "            print(f\"  {strat.label}: {prob:.3f}\")\n",
+    "            \n",
+    "    print(\"\\nPlayer 2 mixed strategy:\")\n",
+    "    for strat in g_weighted.players[1].strategies:\n",
+    "        prob = eq[strat]\n",
+    "        if prob > 0:\n",
+    "            print(f\"  {strat.label}: {prob:.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Iterated Elimination of Strictly Dominated Strategies\n",
+    "\n",
+    "One interesting property of finding equilibria is examining whether the game can be simplified. A rational player will never play a strictly dominated strategy. We can demonstrate **Iterated Elimination of Strictly Dominated Strategies (IESDS)** using PyGambit.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "\n",
+    "# Create a copy so we don't mutate our original weighted game\n",
+    "g_weighted_reduced = copy.copy(g_weighted)\n",
+    "\n",
+    "# Apply iterated elimination\n",
+    "g_weighted_reduced = g.game.simplify(g_weighted_reduced)\n",
+    "\n",
+    "print(\"Original game size (strategies per player):\")\n",
+    "print([len(p.strategies) for p in g_weighted.players])\n",
+    "\n",
+    "print(\"\\nReduced game size after elimination of strictly dominated strategies:\")\n",
+    "print([len(p.strategies) for p in g_weighted_reduced.players])\n",
+    "\n",
+    "# Let's inspect which strategies survived for each player\n",
+    "print(\"\\nSurviving Strategies:\")\n",
+    "for player in g_weighted_reduced.players:\n",
+    "    strategies = [s.label for s in player.strategies]\n",
+    "    print(f\"- {player.label}: {', '.join(strategies)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a new Jupyter notebook tutorial exploring the difference between unweighted and weighted congestion games. It demonstrates:
- How unweighted games inherently have pure Nash equilibria (potential games).
- How weighted games might only have mixed equilibria.
- Iterated elimination of strictly dominated strategies on congestion games.
- Specifically recreates the 2-player network example requested in issue #663.

_Thanks for contributing to Gambit! Before you submitting or reviewing a pull request, check out our [guidelines for contributing](https://gambitproject.readthedocs.io/en/latest/developer.contributing.html)._

_The person submitting the PR should ensure it has an informative title and update the headers below, before marking the PR as ready for review and assigning reviewers._

### Issues closed by this PR

- Closes #663

### Description of the changes in this PR

This PR adds `congestion_games.ipynb` to the `doc/tutorials/advanced_tutorials` directory and registers it in the [doc/pygambit.rst](cci:7://file:///Users/khushchaudhari/Desktop/Gsoc_orgs_2026/GAMBIT/doc/pygambit.rst:0:0-0:0) index. The tutorial walks students through the theoretical difference between unweighted and weighted congestion games, providing a practical demonstration using `pygambit`. It leverages `enumpure_solve` for pure equilibria, `enummixed_solve` for the weighted case, and `g.game.simplify()` to demonstrate the collapse of the strategy space.

### How to review this PR

- Review the code changes and explanations within `doc/tutorials/advanced_tutorials/congestion_games.ipynb` for pedagogical clarity and mathematical accuracy.
- Ensure the tutorial renders correctly when building the documentation locally.
- Run the notebook to verify that the PyGambit outputs match the expected theoretical results.
