### PR TITLE
Update example game playthrough with OpenSpiel of a Gambit extensive form game

### DIFF
--- a/doc/tutorials/interoperability_tutorials/openspiel.ipynb
+++ b/doc/tutorials/interoperability_tutorials/openspiel.ipynb
@@ -816,124 +816,7 @@
    "source": [
     "Games loaded from EFG in OpenSpiel do not take advantage of the full functionality of the package, for example, it is not possible to carry out training with RL algorithms on these games, as in the example above with Tiny Hanabi. The OpenSpiel documentation explains [how to submit new games to the library](https://openspiel.readthedocs.io/en/latest/developer_guide.html#adding-a-game) if you wish to add your own games.\n",
     "\n",
-    "We can however use the state representation and play through the game step by step:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c01c4d6f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ops_one_card_poker.num_distinct_actions()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9986860c",
-   "metadata": {},
-   "source": [
-    "The one-card poker game has 4 distinct actions, 2 are for the first player (Alice in the example game): \"Bet\" and \"Fold\", and 2 for the second player (Bob): \"Call\" and \"Fold\".\n",
-    "\n",
-    "Initialising the game state, we can see the current player at the start is the chance player, who deals the cards:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3b9cc43b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state = ops_one_card_poker.new_initial_state()\n",
-    "state"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e23df723",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state.legal_actions()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7b0959f9",
-   "metadata": {},
-   "source": [
-    "Let's make the chance player's action dealing a King (action 0):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4dd5d504",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state.apply_action(0)\n",
-    "state"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be557706",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state.legal_actions()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b4291f07",
-   "metadata": {},
-   "source": [
-    "As expected, it's now the first player's (Alice's) turn.\n",
-    "Let's have Alice choose to \"Bet\" (action 0):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bd15369f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state.apply_action(0)\n",
-    "state"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd63f7d7",
-   "metadata": {},
-   "source": [
-    "As expected, the current player is now player 2 (Bob), let's check the legal actions available to Bob:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d81ff6b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "state.legal_actions()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fdb5194f",
-   "metadata": {},
-   "source": [
-    "Player 2 (Bob) now has the option to \"Call\" (action 1) or \"Fold\" (action 2).\n",
-    "Let's have Bob choose to \"Fold\":"
+    "We can however use the state representation to simulate a playthrough of the game:"
    ]
   },
   {
@@ -943,8 +826,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state.apply_action(2)\n",
-    "state"
+    "players = {0: \"Alice\", 1: \"Bob\", -1: \"Chance\"}\n",
+    "\n",
+    "# Create an initial game state, then play through to completion\n",
+    "state = ops_one_card_poker.new_initial_state()\n",
+    "while not state.is_terminal():\n",
+    "\n",
+    "  # Store legal actions of current player in a dict\n",
+    "  legal_actions = {}\n",
+    "  for action in state.legal_actions():\n",
+    "    legal_actions[action] = state.action_to_string(state.current_player(), action)\n",
+    "\n",
+    "  # If player is chance, choose an action according to probability\n",
+    "  if state.is_chance_node():\n",
+    "    outcomes_with_probs = state.chance_outcomes()\n",
+    "    action_list, prob_list = zip(*outcomes_with_probs, strict=True)\n",
+    "    action = np.random.choice(action_list, p=prob_list)\n",
+    "    print(\"Dealt card: \", legal_actions[action])\n",
+    "    state.apply_action(action)\n",
+    "\n",
+    "  # Regular players pick a random legal action.\n",
+    "  else:\n",
+    "    action = np.random.choice(state.legal_actions())\n",
+    "    print(players[state.current_player()], \" action: \", legal_actions[action])\n",
+    "    state.apply_action(action)\n",
+    "  print()\n",
+    "\n",
+    "print(\"Alice receives: \", state.player_return(0), \", Bob receives: \", state.player_return(1))"
    ]
   },
   {
@@ -952,7 +860,7 @@
    "id": "1bf09576",
    "metadata": {},
    "source": [
-    "Since Bob Folded, Alice takes the small win and we reach a terminal state."
+    "Run the code cell above to simulate different possible playthroughs of the game."
    ]
   }
  ],


### PR DESCRIPTION
### Description of the changes in this PR

This PR updates the end of the OpenSpiel tutorial notebook to clarify playing through an extensive form game generated with Gambit - it was previously a bit confusing because OpenSpiel does not handle action labels in the same way as gambit:
When loading the one card poker example, which now has 2 different actions labeled "Fold" (one for each player), from Gambit, this actually confuses the OpenSpiel game in thinking there are fewer distinct actions than there are. 

The updated code doesn't run `ops_one_card_poker.num_distinct_actions()` - this difference may be of relevance we revisit OpenSpiel<=>Gambit importer/exporter code - I have made a note of this.

### How to review this PR

I'm going to merge this without review provided the notebook renders correctly.
