### PR TITLE
Use wxString::Format only for true formatting

### DIFF
--- a/src/gui/dleditmove.cc
+++ b/src/gui/dleditmove.cc
@@ -158,10 +158,11 @@ wxBEGIN_EVENT_TABLE(EditMoveDialog, wxDialog) EVT_BUTTON(wxID_OK, EditMoveDialog
   labelSizer->Add(m_infosetName, 1, wxALL | wxEXPAND, 5);
   topSizer->Add(labelSizer, 0, wxALL | wxEXPAND, 0);
 
-  topSizer->Add(new wxStaticText(
-                    this, wxID_STATIC,
-                    wxString::Format(_("Number of members: %d"), p_infoset->GetMembers().size())),
-                0, wxALL | wxALIGN_CENTER, 5);
+  {
+    wxString label;
+    label << _("Number of members: ") << p_infoset->GetMembers().size();
+    topSizer->Add(new wxStaticText(this, wxID_STATIC, label), 0, wxALL | wxALIGN_CENTER, 5);
+  }
 
   auto *playerSizer = new wxBoxSizer(wxHORIZONTAL);
   playerSizer->Add(new wxStaticText(this, wxID_STATIC, _("Belongs to player")), 0,
@@ -173,8 +174,9 @@ wxBEGIN_EVENT_TABLE(EditMoveDialog, wxDialog) EVT_BUTTON(wxID_OK, EditMoveDialog
   }
   else {
     for (const auto &player : p_infoset->GetGame()->GetPlayers()) {
-      m_player->Append(wxString::Format(_T("%d: "), player->GetNumber()) +
-                       wxString(player->GetLabel().c_str(), *wxConvCurrent));
+      wxString label;
+      label << player->GetNumber() << ": " << player->GetLabel();
+      m_player->Append(label);
     }
     m_player->SetSelection(p_infoset->GetPlayer()->GetNumber() - 1);
   }

--- a/src/gui/dleditnode.cc
+++ b/src/gui/dleditnode.cc
@@ -55,7 +55,9 @@ EditNodeDialog::EditNodeDialog(wxWindow *p_parent, const GameNode &p_node)
       for (const auto &infoset : p_node->GetGame()->GetChance()->GetInfosets()) {
         if (infoset->GetActions().size() == p_node->GetChildren().size()) {
           m_infosetList.push_back(infoset);
-          m_infoset->Append(wxString::Format(_("Chance infoset %d"), infoset->GetNumber()));
+          wxString label;
+          label << _("Chance infoset ") << infoset->GetNumber();
+          m_infoset->Append(label);
           if (infoset == p_node->GetInfoset()) {
             selection = m_infosetList.size();
           }
@@ -69,8 +71,10 @@ EditNodeDialog::EditNodeDialog(wxWindow *p_parent, const GameNode &p_node)
         for (const auto &infoset : player->GetInfosets()) {
           if (infoset->GetActions().size() == p_node->GetChildren().size()) {
             m_infosetList.push_back(infoset);
-            m_infoset->Append(wxString::Format(_("Player %d, Infoset %d"), player->GetNumber(),
-                                               infoset->GetNumber()));
+            wxString label;
+            label << _("Player ") << player->GetNumber() << _(", Infoset ")
+                  << infoset->GetNumber();
+            m_infoset->Append(label);
             if (infoset == p_node->GetInfoset()) {
               selection = m_infosetList.size();
             }

--- a/src/gui/dlefglayout.cc
+++ b/src/gui/dlefglayout.cc
@@ -100,24 +100,28 @@ LayoutNodesPanel::LayoutNodesPanel(wxWindow *p_parent, const TreeRenderConfig &p
   gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Horizontal size of nodes")), 0,
                  wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  constexpr int NODE_LENGTH_MIN = 5;
-  constexpr int NODE_LENGTH_MAX = 100;
-
-  m_nodeSize = new wxSpinCtrl(this, wxID_ANY, wxString::Format(_T("%d"), p_settings.GetNodeSize()),
-                              wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, NODE_LENGTH_MIN,
-                              NODE_LENGTH_MAX);
-  gridSizer->Add(m_nodeSize, 1, wxEXPAND | wxALL, 5);
+  {
+    constexpr int NODE_LENGTH_MIN = 5;
+    constexpr int NODE_LENGTH_MAX = 100;
+    wxString label;
+    label << p_settings.GetNodeSize();
+    m_nodeSize = new wxSpinCtrl(this, wxID_ANY, label, wxDefaultPosition, wxDefaultSize,
+                                wxSP_ARROW_KEYS, NODE_LENGTH_MIN, NODE_LENGTH_MAX);
+    gridSizer->Add(m_nodeSize, 1, wxEXPAND | wxALL, 5);
+  }
 
   gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Vertical spacing between terminal nodes")), 0,
                  wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  constexpr int Y_SPACING_MIN = 15;
-  constexpr int Y_SPACING_MAX = 60;
-
-  m_terminalSpacing = new wxSpinCtrl(
-      this, wxID_ANY, wxString::Format(_T("%d"), p_settings.GetTerminalSpacing()),
-      wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, Y_SPACING_MIN, Y_SPACING_MAX);
-  gridSizer->Add(m_terminalSpacing, 1, wxEXPAND | wxALL, 5);
+  {
+    constexpr int Y_SPACING_MIN = 15;
+    constexpr int Y_SPACING_MAX = 60;
+    wxString label;
+    label << p_settings.GetTerminalSpacing();
+    m_terminalSpacing = new wxSpinCtrl(this, wxID_ANY, label, wxDefaultPosition, wxDefaultSize,
+                                       wxSP_ARROW_KEYS, Y_SPACING_MIN, Y_SPACING_MAX);
+    gridSizer->Add(m_terminalSpacing, 1, wxEXPAND | wxALL, 5);
+  }
 
   sizeSizer->Add(gridSizer, 1, wxALL | wxEXPAND, 5);
   topSizer->Add(sizeSizer, 0, wxALL | wxALIGN_CENTER, 5);
@@ -151,12 +155,6 @@ public:
 LayoutBranchesPanel::LayoutBranchesPanel(wxWindow *p_parent, const TreeRenderConfig &p_settings)
   : wxPanel(p_parent, wxID_ANY)
 {
-  constexpr int BRANCH_LENGTH_MIN = 0;
-  constexpr int BRANCH_LENGTH_MAX = 100;
-
-  constexpr int TINE_LENGTH_MIN = 20;
-  constexpr int TINE_LENGTH_MAX = 100;
-
   auto *topSizer = new wxBoxSizer(wxVERTICAL);
 
   auto *styleBoxSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Drawing branches"));
@@ -186,19 +184,29 @@ LayoutBranchesPanel::LayoutBranchesPanel(wxWindow *p_parent, const TreeRenderCon
   auto *gridSizer = new wxFlexGridSizer(2);
   gridSizer->AddGrowableCol(1);
 
-  gridSizer->Add(new wxStaticText(this, wxID_ANY, _("size of branch fork")), 0,
-                 wxALIGN_CENTER_VERTICAL | wxALL, 5);
-  m_branchLength = new wxSpinCtrl(
-      this, wxID_ANY, wxString::Format(_T("%d"), p_settings.GetBranchLength()), wxDefaultPosition,
-      wxDefaultSize, wxSP_ARROW_KEYS, BRANCH_LENGTH_MIN, BRANCH_LENGTH_MAX);
-  gridSizer->Add(m_branchLength, 1, wxALL | wxEXPAND, 5);
+  {
+    constexpr int BRANCH_LENGTH_MIN = 0;
+    constexpr int BRANCH_LENGTH_MAX = 100;
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("size of branch fork")), 0,
+                   wxALIGN_CENTER_VERTICAL | wxALL, 5);
+    wxString label;
+    label << p_settings.GetBranchLength();
+    m_branchLength = new wxSpinCtrl(this, wxID_ANY, label, wxDefaultPosition, wxDefaultSize,
+                                    wxSP_ARROW_KEYS, BRANCH_LENGTH_MIN, BRANCH_LENGTH_MAX);
+    gridSizer->Add(m_branchLength, 1, wxALL | wxEXPAND, 5);
+  }
 
-  gridSizer->Add(new wxStaticText(this, wxID_ANY, _("size of branch tine")), 1,
-                 wxALIGN_CENTER_VERTICAL | wxALL, 5);
-  m_tineLength = new wxSpinCtrl(
-      this, wxID_ANY, wxString::Format(_T("%d"), p_settings.GetTineLength()), wxDefaultPosition,
-      wxDefaultSize, wxSP_ARROW_KEYS, TINE_LENGTH_MIN, TINE_LENGTH_MAX);
-  gridSizer->Add(m_tineLength, 1, wxALL | wxEXPAND, 5);
+  {
+    constexpr int TINE_LENGTH_MIN = 20;
+    constexpr int TINE_LENGTH_MAX = 100;
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("size of branch tine")), 1,
+                   wxALIGN_CENTER_VERTICAL | wxALL, 5);
+    wxString label;
+    label << p_settings.GetTineLength();
+    m_tineLength = new wxSpinCtrl(this, wxID_ANY, label, wxDefaultPosition, wxDefaultSize,
+                                  wxSP_ARROW_KEYS, TINE_LENGTH_MIN, TINE_LENGTH_MAX);
+    gridSizer->Add(m_tineLength, 1, wxALL | wxEXPAND, 5);
+  }
 
   lengthSizer->Add(gridSizer, 1, wxALL | wxEXPAND, 5);
   topSizer->Add(lengthSizer, 0, wxALL | wxALIGN_CENTER, 5);

--- a/src/gui/dlefglogit.cc
+++ b/src/gui/dlefglogit.cc
@@ -74,15 +74,18 @@ LogitBehavList::LogitBehavList(wxWindow *p_parent, GameDocument *p_doc)
 wxString LogitBehavList::GetCellValue(const wxSheetCoords &p_coords)
 {
   if (IsRowLabelCell(p_coords)) {
-    return wxString::Format(wxT("%d"), p_coords.GetRow() + 1);
+    wxString label;
+    label << (p_coords.GetRow() + 1);
+    return label;
   }
   if (IsColLabelCell(p_coords)) {
     if (p_coords.GetCol() == 0) {
       return wxT("Lambda");
     }
     const GameAction action = m_doc->GetAction(p_coords.GetCol());
-    return (wxString::Format(wxT("%d: "), action->GetInfoset()->GetNumber()) +
-            wxString(action->GetLabel().c_str(), *wxConvCurrent));
+    wxString label;
+    label << action->GetInfoset()->GetNumber() << ": " << action->GetLabel();
+    return label;
   }
   if (IsCornerLabelCell(p_coords)) {
     return wxT("#");

--- a/src/gui/dlefgreveal.cc
+++ b/src/gui/dlefgreveal.cc
@@ -71,10 +71,10 @@ RevealMoveDialog::RevealMoveDialog(wxWindow *p_parent, const Game &p_game)
   for (const auto &player : players) {
     wxString label;
     if (!player->GetLabel().empty()) {
-      label = wxString::FromUTF8(player->GetLabel());
+      label << player->GetLabel();
     }
     else {
-      label = wxString::Format("Player %u", player->GetNumber());
+      label << "Player " << player->GetNumber();
     }
     auto *cb = new wxCheckBox(this, wxID_ANY, label);
     cb->SetValue(true);

--- a/src/gui/dlgameprop.cc
+++ b/src/gui/dlgameprop.cc
@@ -63,9 +63,11 @@ GamePropertiesDialog::GamePropertiesDialog(wxWindow *p_parent, GameDocument *p_d
       wxALL, 5);
 
   const Game game = m_doc->GetGame();
-  boxSizer->Add(new wxStaticText(this, wxID_STATIC,
-                                 wxString::Format(_("Number of players: %d"), game->NumPlayers())),
-                0, wxALL, 5);
+  {
+    wxString label;
+    label << _("Number of players: ") << game->NumPlayers();
+    boxSizer->Add(new wxStaticText(this, wxID_STATIC, label), 0, wxALL, 5);
+  }
   if (game->IsConstSum()) {
     boxSizer->Add(new wxStaticText(this, wxID_STATIC, _("This is a constant-sum game")), 0, wxALL,
                   5);

--- a/src/gui/dlinsertmove.cc
+++ b/src/gui/dlinsertmove.cc
@@ -40,10 +40,10 @@ InsertMoveDialog::InsertMoveDialog(wxWindow *p_parent, GameDocument *p_doc)
   for (const auto &player : m_doc->GetGame()->GetPlayers()) {
     wxString s = _("Insert move for ");
     if (player->GetLabel() != "") {
-      s += wxString(player->GetLabel().c_str(), *wxConvCurrent);
+      s << player->GetLabel();
     }
     else {
-      s += wxString::Format(_("player %d"), player->GetNumber());
+      s << _("player ") << player->GetNumber();
     }
     m_playerItem->Append(s);
   }
@@ -58,18 +58,18 @@ InsertMoveDialog::InsertMoveDialog(wxWindow *p_parent, GameDocument *p_doc)
   for (const auto &infoset : player->GetInfosets()) {
     wxString s = _("at information set ");
     if (infoset->GetLabel() != "") {
-      s += wxString(infoset->GetLabel().c_str(), *wxConvCurrent);
+      s << infoset->GetLabel();
     }
     else {
-      s += wxString::Format(wxT("%d"), infoset->GetNumber());
+      s << infoset->GetNumber();
     }
 
-    s += wxString::Format(wxT(" (%d action"), infoset->GetActions().size());
+    s << " (" << infoset->GetActions().size() << " action";
     if (infoset->GetActions().size() > 1) {
       s += wxT("s");
     }
 
-    s += wxString::Format(wxT(", %d member node"), infoset->GetMembers().size());
+    s << ", " << infoset->GetMembers().size() << " member node";
     if (infoset->GetMembers().size() > 1) {
       s += wxT("s)");
     }
@@ -134,18 +134,18 @@ void InsertMoveDialog::OnPlayer(wxCommandEvent &)
   for (const auto &infoset : player->GetInfosets()) {
     wxString s = _("at information set ");
     if (infoset->GetLabel() != "") {
-      s += wxString(infoset->GetLabel().c_str(), *wxConvCurrent);
+      s << infoset->GetLabel();
     }
     else {
-      s += wxString::Format(wxT("%d"), infoset->GetNumber());
+      s << infoset->GetNumber();
     }
 
-    s += wxString::Format(wxT(" (%d action"), infoset->GetActions().size());
+    s << " (" << infoset->GetActions().size() << " action";
     if (infoset->GetActions().size() > 1) {
       s += wxT("s");
     }
 
-    s += wxString::Format(wxT(", %d member node"), infoset->GetMembers().size());
+    s << ", " << infoset->GetMembers().size() << " member node";
     if (infoset->GetMembers().size() > 1) {
       s += wxT("s)");
     }

--- a/src/gui/dlnashmon.cc
+++ b/src/gui/dlnashmon.cc
@@ -154,9 +154,9 @@ void NashMonitorDialog::OnIdle(wxIdleEvent &p_event)
     msg << tis.ReadLine();
 
     m_doc->DoAddOutput(*m_output, msg);
-    m_countText->SetLabel(
-        wxString::Format(wxT("Number of equilibria found so far: %d"), m_output->NumProfiles()));
-
+    wxString label;
+    label << wxT("Number of equilibria found so far: ") << m_output->NumProfiles();
+    m_countText->SetLabel(label);
     p_event.RequestMore();
   }
   else {
@@ -179,8 +179,9 @@ void NashMonitorDialog::OnEndProcess(wxProcessEvent &p_event)
 
     if (!msg.empty()) {
       m_doc->DoAddOutput(*m_output, msg);
-      m_countText->SetLabel(
-          wxString::Format(wxT("Number of equilibria found so far: %d"), m_output->NumProfiles()));
+      wxString label;
+      label << wxT("Number of equilibria found so far: ") << m_output->NumProfiles();
+      m_countText->SetLabel(label);
     }
   }
 

--- a/src/gui/dlnfglogit.cc
+++ b/src/gui/dlnfglogit.cc
@@ -136,7 +136,9 @@ wxString LogitMixedSheet::GetCellValue(const wxSheetCoords &p_coords)
   }
 
   if (IsRowLabelCell(p_coords)) {
-    return wxString::Format(wxT("%d"), p_coords.GetRow() + 1);
+    wxString label;
+    label << (p_coords.GetRow() + 1);
+    return label;
   }
   if (IsColLabelCell(p_coords)) {
     if (p_coords.GetCol() == 0) {
@@ -146,8 +148,9 @@ wxString LogitMixedSheet::GetCellValue(const wxSheetCoords &p_coords)
     for (const auto &player : m_doc->GetGame()->GetPlayers()) {
       for (const auto &strategy : player->GetStrategies()) {
         if (index++ == p_coords.GetCol()) {
-          return (wxString::Format(wxT("%d: "), player->GetNumber()) +
-                  wxString(strategy->GetLabel().c_str(), *wxConvCurrent));
+          wxString label;
+          label << player->GetNumber() << ": " << strategy->GetLabel();
+          return label;
         }
       }
       return wxT("");

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -847,7 +847,9 @@ void EfgDisplay::OnMouseMotion(wxMouseEvent &p_event)
         image.CopyFromBitmap(bitmap);
 #endif // _WXMSW__
 
-        wxTextDataObject textData(wxString::Format(wxT("C%d"), node->GetNumber()));
+        wxString label;
+        label << "C" << node->GetNumber();
+        wxTextDataObject textData(label);
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(true);
       }
@@ -862,7 +864,9 @@ void EfgDisplay::OnMouseMotion(wxMouseEvent &p_event)
         image.CopyFromBitmap(bitmap);
 #endif // _WXMSW__
 
-        wxTextDataObject textData(wxString::Format(wxT("I%d"), node->GetNumber()));
+        wxString label;
+        label << "I" << node->GetNumber();
+        wxTextDataObject textData(label);
 
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(wxDrag_DefaultMove);
@@ -877,7 +881,9 @@ void EfgDisplay::OnMouseMotion(wxMouseEvent &p_event)
         image.CopyFromBitmap(bitmap);
 #endif // _WXMSW__
 
-        wxTextDataObject textData(wxString::Format(wxT("M%d"), node->GetNumber()));
+        wxString label;
+        label << "M" << node->GetNumber();
+        wxTextDataObject textData(label);
 
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(wxDrag_DefaultMove);
@@ -897,17 +903,23 @@ void EfgDisplay::OnMouseMotion(wxMouseEvent &p_event)
 #endif // _WXMSW__
 
       if (p_event.ControlDown()) {
-        wxTextDataObject textData(wxString::Format(wxT("O%d"), node->GetNumber()));
+        wxString label;
+        label << "O" << node->GetNumber();
+        wxTextDataObject textData(label);
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(true);
       }
       else if (p_event.ShiftDown()) {
-        wxTextDataObject textData(wxString::Format(wxT("p%d"), node->GetNumber()));
+        wxString label;
+        label << "p" << node->GetNumber();
+        wxTextDataObject textData(label);
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(true);
       }
       else {
-        wxTextDataObject textData(wxString::Format(wxT("o%d"), node->GetNumber()));
+        wxString label;
+        label << "o" << node->GetNumber();
+        wxTextDataObject textData(label);
         wxDropSource source(textData, this, image, image, image);
         /*wxDragResult result =*/source.DoDragDrop(wxDrag_DefaultMove);
       }

--- a/src/gui/efglayout.cc
+++ b/src/gui/efglayout.cc
@@ -428,11 +428,14 @@ wxString TreeLayout::CreateNodeLabel(const std::shared_ptr<NodeEntry> &p_entry, 
     case GBT_NODE_LABEL_ISETID:
       if (n->GetInfoset()) {
         if (n->GetInfoset()->IsChanceInfoset()) {
-          return wxString::Format(wxT("C:%d"), n->GetInfoset()->GetNumber());
+          wxString label;
+          label << "C:" << n->GetInfoset()->GetNumber();
+          return label;
         }
         else {
-          return wxString::Format(wxT("%d:%d"), n->GetPlayer()->GetNumber(),
-                                  n->GetInfoset()->GetNumber());
+          wxString label;
+          label << n->GetPlayer()->GetNumber() << ":" << n->GetInfoset()->GetNumber();
+          return label;
         }
       }
       else {

--- a/src/gui/efgpanel.cc
+++ b/src/gui/efgpanel.cc
@@ -73,7 +73,9 @@ void gbtTreePlayerIcon::OnLeftClick(wxMouseEvent &)
   image.CopyFromBitmap(bitmap);
 #endif // _WXMSW__
 
-  wxTextDataObject textData(wxString::Format(wxT("P%d"), m_player));
+  wxString label;
+  label << "P" << m_player;
+  wxTextDataObject textData(label);
   wxDropSource source(textData, this, image, image, image);
   source.DoDragDrop(wxDrag_DefaultMove);
 }
@@ -268,7 +270,9 @@ void gbtTreePlayerPanel::OnSetColor(wxCommandEvent &)
   wxColourData data;
   data.SetColour(m_doc->GetStyle().GetPlayerColor(m_doc->GetGame()->GetPlayer(m_player)));
   wxColourDialog dialog(this, &data);
-  dialog.SetTitle(wxString::Format(_("Choose color for player %d"), m_player));
+  wxString label;
+  label << _("Choose color for player ") << m_player;
+  dialog.SetTitle(label);
 
   if (dialog.ShowModal() == wxID_OK) {
     const wxColour color = dialog.GetColourData().GetColour();

--- a/src/gui/efgprofile.cc
+++ b/src/gui/efgprofile.cc
@@ -74,12 +74,15 @@ void BehaviorProfileList::OnCellClick(wxSheetEvent &p_event)
 wxString BehaviorProfileList::GetCellValue(const wxSheetCoords &p_coords)
 {
   if (IsRowLabelCell(p_coords)) {
-    return wxString::Format(wxT("%d"), p_coords.GetRow() + 1);
+    wxString label;
+    label << (p_coords.GetRow() + 1);
+    return label;
   }
   if (IsColLabelCell(p_coords)) {
     const GameAction action = m_doc->GetAction(p_coords.GetCol() + 1);
-    return (wxString::Format(wxT("%d: "), action->GetInfoset()->GetNumber()) +
-            wxString(action->GetLabel().c_str(), *wxConvCurrent));
+    wxString label;
+    label << action->GetInfoset()->GetNumber() << ": " << action->GetLabel();
+    return label;
   }
   if (IsCornerLabelCell(p_coords)) {
     return wxT("#");

--- a/src/gui/gameframe.cc
+++ b/src/gui/gameframe.cc
@@ -165,7 +165,9 @@ void AnalysisNotebook::OnUpdate()
 {
   m_choices->Clear();
   for (int i = 1; i <= m_doc->NumProfileLists(); i++) {
-    m_choices->Append(wxString::Format(wxT("Profiles %d"), i));
+    wxString label;
+    label << wxT("Profiles ") << i;
+    m_choices->Append(label);
   }
   m_choices->SetSelection(m_doc->GetCurrentProfileList() - 1);
 
@@ -1115,12 +1117,13 @@ void GameFrame::OnViewStrategic(wxCommandEvent &p_event)
 
     if (const size_t contingencies = m_doc->GetGame()->GetStrategies().extent_product();
         !m_nfgPanel && contingencies >= 50000) {
-      if (wxMessageBox(wxString::Format(wxT("This game has %d contingencies in strategic form.\n"),
-                                        contingencies) +
-                           wxT("Performance in browsing strategic form will be poor,\n") +
-                           wxT("and may render the program nonresponsive.\n") +
-                           wxT("Do you wish to continue?"),
-                       _("Large strategic game warning"), wxOK | wxCANCEL | wxALIGN_CENTER,
+      wxString msg;
+      msg << "This game has " << contingencies << " contingencies in strategic form.\n"
+          << "Performance in browsing strategic form will be poor,\n"
+          << "and may render the program nonresponsive.\n"
+          << "Do you wish to continue?";
+
+      if (wxMessageBox(msg, _("Large strategic game warning"), wxOK | wxCANCEL | wxICON_WARNING,
                        this) != wxOK) {
         return;
       }
@@ -1247,14 +1250,14 @@ void GameFrame::OnToolsEquilibrium(wxCommandEvent &)
     if (dialog.UseStrategic()) {
       if (const int contingencies = m_doc->GetGame()->GetStrategies().extent_product();
           contingencies >= 50000) {
-        if (wxMessageBox(
-                wxString::Format(wxT("This game has %d contingencies in strategic form.\n"),
-                                 contingencies) +
-                    wxT("Performance in solving strategic form will be poor,\n") +
-                    wxT("and may render the program nonresponsive.\n") +
-                    wxT("Do you wish to continue?"),
-                _("Large strategic game warning"), wxOK | wxCANCEL | wxALIGN_CENTER,
-                this) != wxOK) {
+        wxString msg;
+        msg << "This game has " << contingencies << " contingencies in strategic form.\n"
+            << "Performance in solving strategic form will be poor,\n"
+            << "and may render the program nonresponsive.\n"
+            << "Do you wish to continue?";
+
+        if (wxMessageBox(msg, _("Large strategic game warning"), wxOK | wxCANCEL | wxALIGN_CENTER,
+                         this) != wxOK) {
           return;
         }
       }

--- a/src/gui/nfgpanel.cc
+++ b/src/gui/nfgpanel.cc
@@ -71,7 +71,9 @@ void TablePlayerIcon::OnLeftClick(wxMouseEvent &)
   image.CopyFromBitmap(bitmap);
 #endif // _WXMSW__
 
-  wxTextDataObject textData(wxString::Format(wxT("P%d"), m_player));
+  wxString label;
+  label << "P" << m_player;
+  wxTextDataObject textData(label);
   wxDropSource source(textData, this, image, image, image);
   source.DoDragDrop(wxDrag_DefaultMove);
 }
@@ -207,7 +209,9 @@ void TablePlayerPanel::OnSetColor(wxCommandEvent &)
   wxColourData data;
   data.SetColour(m_doc->GetStyle().GetPlayerColor(m_doc->GetGame()->GetPlayer(m_player)));
   wxColourDialog dialog(this, &data);
-  dialog.SetTitle(wxString::Format(_("Choose color for player %d"), m_player));
+  wxString label;
+  label << _("Choose color for player ") << m_player;
+  dialog.SetTitle(label);
 
   if (dialog.ShowModal() == wxID_OK) {
     const wxColour color = dialog.GetColourData().GetColour();
@@ -407,8 +411,9 @@ void StrategyDominanceToolbar::OnUpdate()
     m_level->SetLabel(wxT("Eliminated 1 level"));
   }
   else {
-    m_level->SetLabel(
-        wxString::Format(wxT("Eliminated %d levels"), m_doc->GetStrategyElimLevel() - 1));
+    wxString label;
+    label << "Eliminated " << (m_doc->GetStrategyElimLevel() - 1) << " levels";
+    m_level->SetLabel(label);
   }
   GetSizer()->Layout();
 }

--- a/src/gui/nfgprofile.cc
+++ b/src/gui/nfgprofile.cc
@@ -84,21 +84,24 @@ static Gambit::GameStrategy GetStrategy(GameDocument *p_doc, int p_index)
 wxString MixedProfileList::GetCellValue(const wxSheetCoords &p_coords)
 {
   if (IsRowLabelCell(p_coords)) {
-    return wxString::Format(wxT("%d"), RowToProfile(p_coords.GetRow()));
+    wxString label;
+    label << RowToProfile(p_coords.GetRow());
+    return label;
   }
-  else if (IsColLabelCell(p_coords)) {
+  if (IsColLabelCell(p_coords)) {
     int index = 0;
     for (const auto &player : m_doc->GetGame()->GetPlayers()) {
       for (const auto &strategy : player->GetStrategies()) {
         if (index++ == p_coords.GetCol()) {
-          return (wxString::Format(wxT("%d: "), player->GetNumber()) +
-                  wxString(strategy->GetLabel().c_str(), *wxConvCurrent));
+          wxString label;
+          label << player->GetNumber() << ": " << strategy->GetLabel();
+          return label;
         }
       }
     }
     return wxT("");
   }
-  else if (IsCornerLabelCell(p_coords)) {
+  if (IsCornerLabelCell(p_coords)) {
     return wxT("#");
   }
 


### PR DESCRIPTION
This removes usages of wxString::Format which were simply instances of converting or inserting numbers into strings. The re-written versions allow for type checking/selection at compile time, eliminating a source of runtime warning dialogs.

