### PR TITLE
Remove draw_tree from optional dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,7 @@ jobs:
           cd dist
           sdist=$(ls pygambit-*.tar.gz)
           pip install -v "${sdist}[test,doc]"
+          pip install "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.1"
       - name: Run tests
         run: pytest --run-tutorials
 
@@ -52,6 +53,7 @@ jobs:
       - name: Build extension
         run: |
           python -m pip install -v .[test,doc]
+          pip install "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.1"
       - name: Run tests
         run: pytest --run-tutorials
 
@@ -74,6 +76,7 @@ jobs:
       - name: Build extension
         run: |
           python -m pip install -v .[test,doc]
+          pip install "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.1"
       - name: Run tests
         run: pytest --run-tutorials
 
@@ -96,5 +99,6 @@ jobs:
       - name: Build extension
         run: |
           python -m pip install -v .[test,doc]
+          pip install "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.1"
       - name: Run tests
         run: pytest --run-tutorials

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,9 @@ build:
     - pandoc
     - texlive-full
   jobs:
-    # Create CSV for catalog table in docs
     post_install:
+      - pip install "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.1"
+      # Create RST for catalog table in docs
       - $READTHEDOCS_VIRTUALENV_PATH/bin/python build_support/catalog/update.py
 
 python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ doc = [
     "pickleshare",
     "jupyter",
     "open_spiel; sys_platform != 'win32'",
-    "draw-tree @ git+https://github.com/gambitproject/draw_tree.git@v0.4.0"
 ]
 
 [project.urls]


### PR DESCRIPTION

### Description of the changes in this PR

- Remove draw_tree from optional dependencies and install manually in actions and rtd
- Having a GitHub repo optional dependency was preventing us releasing to PyPI

### How to review this PR

Just need tests to pass