### PR TITLE
Repeated games generator

### DIFF
--- a/tests/games.py
+++ b/tests/games.py
@@ -38,6 +38,65 @@ def create_efg_corresponding_to_bimatrix_game(
     return g
 
 
+def create_repeated_game_efg(
+    A: np.ndarray, B: np.ndarray, T: int, title: str
+) -> gbt.Game:
+    """Create a T-period repeated game from a simultaneous m*n stage game.
+
+    Each round is a proper subgame difference.  Within a round, Player 1
+    moves first and Player 2 moves without observing Player 1's action.
+    Terminal payoffs are the sum of stage-game payoffs along the path.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Payoff matrix for Player 1 (m*n).
+    B : np.ndarray
+        Payoff matrix for Player 2 (m*n).
+    T : int
+        Number of repetitions (>= 1).
+    title : str
+        Title for the game.
+
+    Returns
+    -------
+    Game
+        The extensive-form repeated game with:
+        - (m*n)^T terminal nodes
+        - (1 + m) · ((m*n)^T - 1) / (m*n - 1) non-terminal nodes
+        - 2 · ((m*n)^T - 1) / (m*n - 1) information sets
+        - ((m*n)^T - 1) / (m*n - 1) subgame roots
+    """
+    assert A.shape == B.shape
+    assert T >= 1
+
+    m, n = A.shape
+    g = gbt.Game.new_tree(players=["1", "2"], title=title)
+    actions1 = [str(i) for i in range(m)]
+    actions2 = [str(i) for i in range(n)]
+
+    payoffs_to_outcomes = {}
+    frontier = [(g.root, 0, 0)]
+    for t in range(1, T + 1):
+        next_frontier = []
+        for node, acc_payoff_a, acc_payoff_b in frontier:
+            g.append_move(node, "1", actions1)
+            g.append_move(node.children, "2", actions2)
+            for i, j in itertools.product(range(m), range(n)):
+                child = node.children[i].children[j]
+                new_payoff_a = acc_payoff_a + A[i, j]
+                new_payoff_b = acc_payoff_b + B[i, j]
+                if t == T:
+                    key = (new_payoff_a, new_payoff_b)
+                    if key not in payoffs_to_outcomes:
+                        payoffs_to_outcomes[key] = g.add_outcome(list(key))
+                    g.set_outcome(child, payoffs_to_outcomes[key])
+                else:
+                    next_frontier.append((child, new_payoff_a, new_payoff_b))
+        frontier = next_frontier
+    return g
+
+
 ################################################################################################
 # Extensive-form games (efg)
 

--- a/tests/games.py
+++ b/tests/games.py
@@ -43,9 +43,8 @@ def create_repeated_game_efg(
 ) -> gbt.Game:
     """Create a T-period repeated game from a simultaneous m*n stage game.
 
-    Each round is a proper subgame difference.  Within a round, Player 1
-    moves first and Player 2 moves without observing Player 1's action.
-    Terminal payoffs are the sum of stage-game payoffs along the path.
+    At every round, each P1 decision node opens a proper subgame, so
+    the game contains ((m*n)^T - 1) / (m*n - 1) subgame roots in total.
 
     Parameters
     ----------
@@ -68,6 +67,7 @@ def create_repeated_game_efg(
         - ((m*n)^T - 1) / (m*n - 1) subgame roots
     """
     assert A.shape == B.shape
+    assert A.shape[0] >= 1 and A.shape[1] >= 1
     assert T >= 1
 
     m, n = A.shape

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import typing
 
+import numpy as np
 import pytest
 
 import pygambit as gbt
@@ -144,6 +145,47 @@ SUBGAME_ROOTS_CASES = [
                             ["Push", "Push", "Push", "Push"]]
         ),
         id="centipede_5_rounds"
+    ),
+    # ------------------------------------------------------------------------
+    #                           Repeated Games
+    # ------------------------------------------------------------------------
+    pytest.param(
+        SubgameRootsTestCase(
+            factory=lambda: games.create_repeated_game_efg(
+                np.array([[1, 2, 3], [4, 5, 6]]),
+                np.array([[6, 5, 4], [3, 2, 1]]),
+                T=2, title="2*3 asymmetric repeated twice"
+            ),
+            expected_paths=(
+                [[]]
+                + [
+                    [str(j), str(i)]
+                    for i, j in itertools.product(range(2), range(3))
+                ]
+            )
+        ),
+        id="repeated_asymmetric_2*3_T2"
+    ),
+    pytest.param(
+        SubgameRootsTestCase(
+            factory=lambda: games.create_repeated_game_efg(
+                np.array([[3, 0], [5, 1]]),
+                np.array([[3, 5], [0, 1]]),
+                T=3, title="Prisoner's Dilemma repeated thrice"
+            ),
+            expected_paths=(
+                [[]]
+                + [
+                    [str(j), str(i)]
+                    for i, j in itertools.product(range(2), repeat=2)
+                ]
+                + [
+                    [str(m), str(k), str(j), str(i)]
+                    for i, j, k, m in itertools.product(range(2), repeat=4)
+                ]
+            )
+        ),
+        id="repeated_prisoners_dilemma_T3"
     ),
     # ------------------------------------------------------------------------
     #              Imperfect Information (No Absent-Mindedness)


### PR DESCRIPTION
### Description of the changes in this PR

Adds a new test-fixture generator to `tests/games.py` and extends the subgame-roots test suite using the new generator.

**New generator in `tests/games.py`:**

- `create_repeated_game_efg(A, B, T, title)` — builds a T-period repeated game from a simultaneous $m \times n$ stage game given by payoff matrices `A` and `B`. Within a round, P1 moves first and P2 follows in a single information set over P1's $m$ children, modelling the simultaneous stage game. Terminal payoffs are the path-sum of stage-game payoffs, with outcome objects deduplicated by total payoff. 
- Closely mirrors the style of the existing `create_efg_corresponding_to_bimatrix_game`.

**Test coverage added:**

- Two new tests in the subgame-roots suite covering repeated games: (i) an asymmetric $2 \times  3$ stage game repeated twice, and (ii) a $2 \times  2$ Prisoner's Dilemma repeated thrice. 
