### PR TITLE
Interpret trailing slash in payoff as /1.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,8 @@
   deleted in the game (#875)
 - Fix incorrect row index checking in swapping rows of a rectangular array (leading to errors in
   for example `simpdiv_solve`) (#868)
-
+- In GUI, typing a payoff with a trailing slash is now interpreted as a whole number rational
+  (previously this led to a validation error dialog)
 
 ### Removed
 - Built-in plotting of logit QRE for strategic games has been removed in the GUI (#809)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@
   deleted in the game (#875)
 - Fix incorrect row index checking in swapping rows of a rectangular array (leading to errors in
   for example `simpdiv_solve`) (#868)
-- In GUI, typing a payoff with a trailing slash is now interpreted as a whole number rational
+- In GUI, typing a payoff with a trailing slash is now interpreted as a whole number
   (previously this led to a validation error dialog)
 
 ### Removed

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -538,13 +538,12 @@ void EfgDisplay::OnAcceptPayoffEdit(wxCommandEvent &)
   m_payoffEditor->EndEdit();
   const GameOutcome outcome = m_payoffEditor->GetOutcome();
   const int player = m_payoffEditor->GetPlayer();
-  try {
-    m_doc->DoSetPayoff(outcome, player, m_payoffEditor->GetValue());
+  wxString value = m_payoffEditor->GetValue();
+  if (value.EndsWith("/")) {
+    value = value + "1";
   }
-  catch (ValueException &) {
-    // For the moment, we will just silently discard edits which
-    // give payoffs that are not valid numbers
-    return;
+  try {
+    m_doc->DoSetPayoff(outcome, player, value);
   }
   catch (std::exception &ex) {
     ExceptionDialog(this, ex.what()).ShowModal();

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -535,7 +535,6 @@ void EfgDisplay::OnKeyEvent(wxKeyEvent &p_event)
 
 void EfgDisplay::OnAcceptPayoffEdit(wxCommandEvent &)
 {
-  m_payoffEditor->EndEdit();
   const GameOutcome outcome = m_payoffEditor->GetOutcome();
   const int player = m_payoffEditor->GetPlayer();
   wxString value = m_payoffEditor->GetValue();
@@ -544,6 +543,9 @@ void EfgDisplay::OnAcceptPayoffEdit(wxCommandEvent &)
   }
   try {
     m_doc->DoSetPayoff(outcome, player, value);
+    m_payoffEditor->EndEdit();
+  }
+  catch (ZeroDivideException &) {
   }
   catch (std::exception &ex) {
     ExceptionDialog(this, ex.what()).ShowModal();

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -34,6 +34,7 @@
 #include "efgdisplay.h"
 #include "menuconst.h"
 #include "dlexcept.h"
+#include "valnumber.h"
 
 namespace Gambit::GUI {
 //--------------------------------------------------------------------------
@@ -47,6 +48,7 @@ END_EVENT_TABLE()
 TreePayoffEditor::TreePayoffEditor(wxWindow *p_parent)
   : wxTextCtrl(p_parent, wxID_ANY, wxT(""), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER)
 {
+  wxWindowBase::SetValidator(NumberValidator(nullptr));
   wxWindow::Show(false);
 }
 

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -538,8 +538,8 @@ void EfgDisplay::OnAcceptPayoffEdit(wxCommandEvent &)
   const GameOutcome outcome = m_payoffEditor->GetOutcome();
   const int player = m_payoffEditor->GetPlayer();
   wxString value = m_payoffEditor->GetValue();
-  if (value.EndsWith("/")) {
-    value = value + "1";
+  if (value.EndsWith(_T("/"))) {
+    value = value.Left(value.length() - 1);
   }
   try {
     m_doc->DoSetPayoff(outcome, player, value);

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -545,8 +545,6 @@ void EfgDisplay::OnAcceptPayoffEdit(wxCommandEvent &)
     m_doc->DoSetPayoff(outcome, player, value);
     m_payoffEditor->EndEdit();
   }
-  catch (ZeroDivideException &) {
-  }
   catch (std::exception &ex) {
     ExceptionDialog(this, ex.what()).ShowModal();
   }

--- a/src/gui/nfgtable.cc
+++ b/src/gui/nfgtable.cc
@@ -1225,11 +1225,6 @@ void TableWidget::SetPayoffCellValue(const wxSheetCoords &coords, const wxString
   try {
     m_doc->DoSetPayoff(outcome, player, value);
   }
-  catch (ValueException &) {
-    // For the moment, we will just silently discard edits which
-    // give payoffs that are not valid numbers
-    return;
-  }
   catch (std::exception &ex) {
     ExceptionDialog(this, ex.what()).ShowModal();
   }

--- a/src/gui/nfgtable.cc
+++ b/src/gui/nfgtable.cc
@@ -661,7 +661,12 @@ wxString PayoffsWidget::GetCellValue(const wxSheetCoords &p_coords)
 
 void PayoffsWidget::SetCellValue(const wxSheetCoords &p_coords, const wxString &p_value)
 {
-  m_table->SetPayoffCellValue(p_coords, p_value);
+  // Normalisation: Interpret trailing bare slash as /1".
+  wxString value = p_value;
+  if (value.EndsWith(_T("/"))) {
+    value = value.Left(value.length() - 1);
+  }
+  m_table->SetPayoffCellValue(p_coords, value);
 }
 
 wxSheetCellAttr PayoffsWidget::GetAttr(const wxSheetCoords &p_coords, wxSheetAttr_Type) const

--- a/src/gui/nfgtable.cc
+++ b/src/gui/nfgtable.cc
@@ -661,7 +661,6 @@ wxString PayoffsWidget::GetCellValue(const wxSheetCoords &p_coords)
 
 void PayoffsWidget::SetCellValue(const wxSheetCoords &p_coords, const wxString &p_value)
 {
-  // Normalisation: Interpret trailing bare slash as /1".
   wxString value = p_value;
   if (value.EndsWith(_T("/"))) {
     value = value.Left(value.length() - 1);

--- a/src/gui/valnumber.cc
+++ b/src/gui/valnumber.cc
@@ -178,6 +178,23 @@ void NumberValidator::OnChar(wxKeyEvent &p_event)
     auto *control = dynamic_cast<wxTextCtrl *>(m_validatorWindow);
     const wxString value = control->GetValue();
 
+    long start, end;
+    control->GetSelection(&start, &end);
+
+    // Reject edits which would produce a slash immediately followed by zero.
+    if (keyCode == '/' || keyCode == '0') {
+      wxString proposed = value;
+      proposed.Remove(start, end - start);
+      proposed.insert(start, wxString::Format("%c", keyCode));
+
+      if (proposed.Find(wxT("/0")) != wxNOT_FOUND) {
+        if (!IsSilent()) {
+          wxBell();
+        }
+        return;
+      }
+    }
+
     if ((keyCode == '.' || keyCode == '/') && (value.Find('.') != -1 || value.Find('/') != -1)) {
       // At most one slash or decimal point is allowed
       if (!IsSilent()) {


### PR DESCRIPTION
This changes the validation of payoff entries so that inputting a number with a trailing slash
is interpreted as a whole number (that is, with an implicit "1" after the slash).
