### PR TITLE
Fix quadratic build time when many infosets are emptied in game generators

### DIFF
--- a/src/games/game.h
+++ b/src/games/game.h
@@ -220,7 +220,7 @@ public:
   void Invalidate() { m_valid = false; }
 
   Game GetGame() const;
-  int GetNumber() const { return m_number; }
+  int GetNumber() const;
 
   GamePlayer GetPlayer() const;
 
@@ -1226,6 +1226,12 @@ inline GameNode GameInfosetRep::GetMember(int p_index) const
 {
   m_game->EnsureInfosetOrdering();
   return m_members.at(p_index - 1);
+}
+
+inline int GameInfosetRep::GetNumber() const
+{
+  m_game->EnsureInfosetOrdering();
+  return m_number;
 }
 
 inline GameInfosetRep::Members GameInfosetRep::GetMembers() const

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -147,7 +147,7 @@ void GameTreeRep::DeleteAction(GameAction p_action)
     member->m_children.erase(it);
   }
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 GameInfoset GameActionRep::GetInfoset() const { return m_infoset->shared_from_this(); }
@@ -195,7 +195,7 @@ void GameTreeRep::SetPlayer(GameInfoset p_infoset, GamePlayer p_player)
   p_player->m_infosets.push_back(p_infoset);
 
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 bool GameInfosetRep::Precedes(GameNode p_node) const
@@ -239,7 +239,7 @@ GameAction GameTreeRep::InsertAction(GameInfoset p_infoset, GameAction p_action 
   m_numNodes += p_infoset->m_members.size();
   // m_numNonterminalNodes stays unchanged when an action is appended to an information set
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
   return action;
 }
 
@@ -254,7 +254,7 @@ void GameTreeRep::RemoveMember(GameInfosetRep *p_infoset, GameNodeRep *p_node)
     p_infoset->m_player->m_infosets.erase(std::find(
         player->m_infosets.begin(), player->m_infosets.end(), p_infoset->shared_from_this()));
   }
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 void GameTreeRep::Reveal(GameInfoset p_atInfoset, GamePlayer p_player)
@@ -281,7 +281,7 @@ void GameTreeRep::Reveal(GameInfoset p_atInfoset, GamePlayer p_player)
   }
 
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 //========================================================================
@@ -427,7 +427,7 @@ void GameTreeRep::DeleteParent(GameNode p_node)
 
   oldParent->Invalidate();
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 void GameTreeRep::DeleteTree(GameNode p_node)
@@ -454,7 +454,7 @@ void GameTreeRep::DeleteTree(GameNode p_node)
   node->m_label = "";
 
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 void GameTreeRep::CopySubtree(GameNodeRep *dest, GameNodeRep *src, GameNodeRep *stop)
@@ -496,7 +496,7 @@ void GameTreeRep::CopyTree(GameNode p_dest, GameNode p_src)
       CopySubtree(dest_child->get(), src_child->get(), dest);
     }
     ClearComputedValues();
-    InvalidateNodeOrdering();
+    InvalidateTreeOrdering();
   }
 }
 
@@ -520,7 +520,7 @@ void GameTreeRep::MoveTree(GameNode p_dest, GameNode p_src)
   dest->m_outcome = nullptr;
 
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
 }
 
 Game GameTreeRep::CopySubgame(GameNode p_root) const
@@ -629,7 +629,7 @@ GameInfoset GameTreeRep::AppendMove(GameNode p_node, GameInfoset p_infoset)
                 });
   m_numNonterminalNodes++;
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
   return node->m_infoset->shared_from_this();
 }
 
@@ -686,7 +686,7 @@ GameInfoset GameTreeRep::InsertMove(GameNode p_node, GameInfoset p_infoset)
   m_numNodes += newNode->m_infoset->m_actions.size();
   m_numNonterminalNodes++;
   ClearComputedValues();
-  InvalidateNodeOrdering();
+  InvalidateTreeOrdering();
   return p_infoset;
 }
 

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -253,7 +253,6 @@ void GameTreeRep::RemoveMember(GameInfosetRep *p_infoset, GameNodeRep *p_node)
     p_infoset->Invalidate();
     p_infoset->m_player->m_infosets.erase(std::find(
         player->m_infosets.begin(), player->m_infosets.end(), p_infoset->shared_from_this()));
-    RenumberInfosets(player);
   }
   InvalidateNodeOrdering();
 }

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -61,7 +61,8 @@ protected:
 
   /// @name Managing the representation
   //@{
-  void InvalidateNodeOrdering() const
+  /// Jointly invalidates the ordering of the nodes and the ordering of the information sets.
+  void InvalidateTreeOrdering() const
   {
     m_nodesOrdered = false;
     m_infosetsOrdered = false;


### PR DESCRIPTION
### Fix quadratic build time during incremental tree construction

``GameTreeRep::RemoveMember`` called ``RenumberInfosets`` unconditionally when
an infoset became empty, doing O(``player.infosets.size()``) work on every call.  
I noticed this while profiling the subgame-roots checker on a depth-18 binary game 
(~524K nodes), where build time dominated and ran into the minutes per game.

The current pattern is building a perfect-information tree and then merging siblings 
into shared infosets via SetInfoset.  Each merge empties a singleton infoset and triggers 
the renumber: a linear sequence of merges becomes quadratic.

``GameTreeRep`` already provides ``EnsureInfosetOrdering()`` as a lazy canonicalization, 
and all public reads of ``GameInfosetRep::GetNumber`` should use it. 

This PR:

  * removes the eager ``RenumberInfosets`` from ``RemoveMember``;

  * makes ``GameInfosetRep::GetNumber()`` pass through ``EnsureInfosetOrdering``
    explicitly, mirroring ``GameNodeRep::GetNumber()``. 

For a 524K-node binary tree with sibling merging, 10 iterations of
build + ``is_subgame_root`` drop from **12 min 20 s to 1 min 45 s**.  
The speedup is entirely in the build phase; subgame detection itself is unaffected by this patch.