### PR TITLE
Fix core dump on degenerate games by returning trivial zero-dimensional profile

### DIFF
--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -313,6 +313,9 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
                    double p_firstStep, double p_maxAccel,
                    MixedBehaviorObserverFunctionType p_observer)
 {
+  if (p_start.size() == 0) {
+    return {p_start};
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);
@@ -321,7 +324,6 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
   if (scale != 0.0) {
     p_regret *= scale;
   }
-
   const Game game = p_start.GetGame();
   Vector<double> x(ProfileToPoint(p_start));
   TracingCallbackFunction callback(game, p_observer);
@@ -347,6 +349,9 @@ LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
                          double p_firstStep, double p_maxAccel,
                          MixedBehaviorObserverFunctionType p_observer)
 {
+  if (p_start.size() == 0) {
+    return {p_start};
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);
@@ -380,6 +385,9 @@ LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double 
                       MixedBehaviorObserverFunctionType p_observer)
 {
   const LogitQREMixedBehaviorProfile start(p_frequencies.GetGame());
+  if (start.size() == 0) {
+    return start;
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -351,6 +351,9 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
                    double p_firstStep, double p_maxAccel,
                    const MixedStrategyObserverFunctionType &p_observer)
 {
+  if (p_start.size() == 0) {
+    return {p_start};
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);
@@ -385,6 +388,9 @@ LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
                          double p_firstStep, double p_maxAccel,
                          const MixedStrategyObserverFunctionType &p_observer)
 {
+  if (p_start.size() == 0) {
+    return {p_start};
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);
@@ -418,6 +424,9 @@ LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double 
                       MixedStrategyObserverFunctionType p_observer)
 {
   const LogitQREMixedStrategyProfile start(p_frequencies.GetGame());
+  if (start.size() == 0) {
+    return start;
+  }
   PathTracer tracer;
   tracer.SetMaxDecel(p_maxAccel);
   tracer.SetStepsize(p_firstStep);

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -211,34 +211,6 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    bool has_decisions = false;
-    if (game->IsTree()) {
-      for (auto player : game->GetPlayers()) {
-        if (player->GetInfosets().size() > 0) {
-          has_decisions = true;
-          break;
-        }
-      }
-    }
-    else {
-      for (auto player : game->GetPlayers()) {
-        if (player->GetStrategies().size() > 0) {
-          has_decisions = true;
-          break;
-        }
-      }
-    }
-    if (!has_decisions) {
-      if (!game->IsTree() || useStrategic) {
-        const LogitQREMixedStrategyProfile trivial_profile(game);
-        PrintProfile(std::cout, decimals, trivial_profile, true);
-      } else {
-        const LogitQREMixedBehaviorProfile trivial_profile(game);
-        PrintProfile(std::cout, decimals, trivial_profile, true);
-      }
-      return 0;
-    }
-
     if (!game->IsTree() || useStrategic) {
       auto printer = [fullGraph, decimals](const LogitQREMixedStrategyProfile &p) {
         if (fullGraph) {

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -211,6 +211,34 @@ int main(int argc, char *argv[])
       return 0;
     }
 
+    bool has_decisions = false;
+    if (game->IsTree()) {
+      for (auto player : game->GetPlayers()) {
+        if (player->GetInfosets().size() > 0) {
+          has_decisions = true;
+          break;
+        }
+      }
+    }
+    else {
+      for (auto player : game->GetPlayers()) {
+        if (player->GetStrategies().size() > 0) {
+          has_decisions = true;
+          break;
+        }
+      }
+    }
+    if (!has_decisions) {
+      if (!game->IsTree() || useStrategic) {
+        const LogitQREMixedStrategyProfile trivial_profile(game);
+        PrintProfile(std::cout, decimals, trivial_profile, true);
+      } else {
+        const LogitQREMixedBehaviorProfile trivial_profile(game);
+        PrintProfile(std::cout, decimals, trivial_profile, true);
+      }
+      return 0;
+    }
+
     if (!game->IsTree() || useStrategic) {
       auto printer = [fullGraph, decimals](const LogitQREMixedStrategyProfile &p) {
         if (fullGraph) {


### PR DESCRIPTION
**PR Title:** Fix core dump in logit solver for degenerate games (zero decisions)

### Issues closed by this PR

None. (Standalone bug fix discovered during the investigation of #492).

### Description of the changes in this PR

This PR fixes a core dump that occurred when running the QRE logit solver on degenerate games (games where no player has any decision nodes, such as `chance_root_5_moves_no_nonterm_player_nodes.efg`).

- Implemented an early exit defensive shield in `src/solvers/logit/[e/n]fglogit.cc` to detect games with a 0-dimension strategy space.
- By analogy to games with zero payoffs, the solver now cleanly constructs and returns the trivial equilibrium profile (with `lambda = 0`) instead of attempting to build an empty Jacobian matrix or throwing a runtime error.

### How to review this PR

- Review the early exit logic added to `src/tools/logit/logit.cc` after the game file is read.
- Verify the fix by running `./gambit-logit tests/test_games/chance_root_5_moves_no_nonterm_player_nodes.efg`. It should now cleanly print `NE` and exit with code 0 instead of throwing a segmentation fault.
- Run the standard test suite (`make check`) to ensure `.nfg` games are processed correctly and do not trigger `Undefined operation on game` errors.