### PR TITLE
Fix incorrect generation of .nfg files from some strategic games.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Corrected resizing of row and column index labels in strategic form so pivoting works correctly. (#844)
+- Corrected incorrect output of strategic game tables to .nfg files if strategies have previously been
+  deleted in the game (#875)
 
 ### Removed
 - Built-in plotting of logit QRE for strategic games has been removed in the GUI (#809)

--- a/src/games/gametable.cc
+++ b/src/games/gametable.cc
@@ -482,8 +482,10 @@ void GameTableRep::WriteNfgFile(std::ostream &p_file) const
   }
   p_file << "}" << std::endl;
 
-  for (auto result : m_results) {
-    p_file << ((result) ? result->m_number : 0) << ' ';
+  for (auto iter : StrategyContingencies(
+           StrategySupportProfile(std::const_pointer_cast<GameRep>(shared_from_this())))) {
+    const auto outcome = iter->GetOutcome();
+    p_file << ((outcome) ? outcome->m_number : 0) << ' ';
   }
   p_file << std::endl;
 }


### PR DESCRIPTION
`WriteNfgFile` on games with a table representation prefers to use the outcome version of the .nfg file format.  The implementation of this was not taking into account
that if strategies are deleted in the game, we do not immediately reallocate the table of outcomes, and so the whole table was being exported (not just the portion relevant to the remaining strategies).

Fixes #875.

