### PR TITLE
Correct payoff display regression in strategic game

### DIFF
--- a/src/gui/nfgtable.cc
+++ b/src/gui/nfgtable.cc
@@ -655,7 +655,7 @@ wxString PayoffsWidget::GetCellValue(const wxSheetCoords &p_coords)
   }
 
   const PureStrategyProfile profile = m_table->GetPayoffProfile(p_coords);
-  auto player = m_table->GetPayoffPlayer(ColToPlayer(p_coords.GetCol()));
+  auto player = m_table->GetPayoffPlayer(p_coords.GetCol());
   return {lexical_cast<std::string>(profile->GetPayoff(player)).c_str(), *wxConvCurrent};
 }
 


### PR DESCRIPTION
This corrects a regression introduced in PR #860, which incorrectly mapped players to payoff table cells so payoffs
were not being displayed correctly.
