### PR TITLE
Add the original absent-minded driver from Gilboa (1997) to the catalogue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,7 +206,7 @@ EXTRA_DIST = \
 	contrib/games/zero.nfg \
 	src/README.rst \
 	catalog/bagwell1995.efg \
-	catalog/gilboa1997/fig1.efg
+	catalog/gilboa1997/fig1.efg \
 	catalog/gilboa1997/fig2.efg \
 	catalog/jakobsen2016/fig1a.efg \
 	catalog/jakobsen2016/fig1b.efg \

--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,7 @@ EXTRA_DIST = \
 	contrib/games/zero.nfg \
 	src/README.rst \
 	catalog/bagwell1995.efg \
+	catalog/gilboa1997/fig1.efg
 	catalog/gilboa1997/fig2.efg \
 	catalog/jakobsen2016/fig1a.efg \
 	catalog/jakobsen2016/fig1b.efg \

--- a/catalog/gilboa1997/fig1.efg
+++ b/catalog/gilboa1997/fig1.efg
@@ -1,0 +1,9 @@
+EFG 2 R "Absent-Minded Driver (Gilboa 1997, GEB, Figure 2)" { "Player 1" }
+"The original absent-minded driver problem from
+`Gil97 <https://gambitproject.readthedocs.io/en/latest/biblio.html#Gil97>`_"
+
+p "" 1 1 "" { "B" "E" } 0
+p "" 1 1 "" { "B" "E" } 0
+t "" 1 "Outcome 1" { 1 }
+t "" 2 "Outcome 2" { 4 }
+t "" 3 "Outcome 3" { 0 }

--- a/catalog/gilboa1997/fig2.efg
+++ b/catalog/gilboa1997/fig2.efg
@@ -1,4 +1,4 @@
-EFG 2 R "Gilboa (1997) Two-Selves Absent-Minded Driver" { "Player 1" }
+EFG 2 R "Two-Selves Absent-Minded Driver (Gilboa 1997, GEB, Figure 2)" { "Player 1" }
 "A reformulation of the absent-minded driver problem from
 `Gil97 <https://gambitproject.readthedocs.io/en/latest/biblio.html#Gil97>`_
 using a multi-self approach.  A chance move determines the order in which two selves act,
@@ -11,7 +11,7 @@ p "" 1 1 "" { "E" "B" } 0
 t "" 1 "Outcome 1" { 0 }
 p "" 1 2 "" { "B" "E" } 0
 t "" 2 "Outcome 2" { 1 }
-t "" 3 "Outcome 3" { 2 }
+t "" 3 "Outcome 3" { 4 }
 p "" 1 2 "" { "B" "E" } 0
 p "" 1 1 "" { "E" "B" } 0
 t "" 4 "Outcome 4" { 4 }


### PR DESCRIPTION
Contributes to #394 

**Description of the changes**
This PR adds `gilboa1997/fig1.efg` to the catalogue and applies minor polishes to `gilboa1997/fig2.efg`

Makefile.am has been updated.


