### PR TITLE
Add get_inbook_template to bibtex formatting utilities

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -156,6 +156,9 @@ class CustomAlphaStyle(AlphaStyle):
             self.format_web_refs(e),
         ]
 
+    def get_inbook_template(self, e):
+        return self.get_incollection_template(e)
+
     def get_inproceedings_template(self, e):
         return toplevel[
             sentence[


### PR DESCRIPTION
This adds a commit fixing the Bibliography formatting that @rahulsavani noticed was accidentally left off #908 
