### PR TITLE
Show error on attempting to load a (B)AGG in the graphical interface.

### DIFF
--- a/src/games/gamebagg.h
+++ b/src/games/gamebagg.h
@@ -86,7 +86,7 @@ public:
   /// @name General data access
   //@{
   bool IsTree() const override { return false; }
-  virtual bool IsBagg() const { return true; }
+  bool IsAgg() const override { return true; }
   bool IsPerfectRecall() const override { return true; }
   bool IsConstSum() const override { throw UndefinedException(); }
   /// Returns the smallest payoff to any player in any outcome of the game

--- a/src/gui/app.cc
+++ b/src/gui/app.cc
@@ -126,7 +126,7 @@ AppLoadResult Application::LoadFile(const wxString &p_filename, wxWindow *p_pare
   if (!infile.good()) {
     wxMessageBox(_("Gambit could not open file for reading:\n") + p_filename,
                  _("Unable to open file"), wxOK | wxICON_ERROR, p_parent);
-    return GBT_APP_OPEN_FAILED;
+    return AppLoadResult::OpenFailed;
   }
 
   auto *doc = new GameDocument(NewTree());
@@ -135,24 +135,29 @@ AppLoadResult Application::LoadFile(const wxString &p_filename, wxWindow *p_pare
     m_fileHistory.AddFileToHistory(p_filename);
     m_fileHistory.Save(*wxConfigBase::Get());
     (void)new GameFrame(nullptr, doc);
-    return GBT_APP_FILE_OK;
+    return AppLoadResult::Success;
   }
   delete doc;
 
   try {
-    const Game nfg = ReadGame(infile);
+    const Game game = ReadGame(infile);
+    if (game->IsAgg()) {
+      wxMessageBox(_("Action graph games are not currently supported by the graphical interface"),
+                   _("Unsupported game representation"), wxOK | wxICON_ERROR, p_parent);
+      return AppLoadResult::UnsupportedRepresentation;
+    }
 
     m_fileHistory.AddFileToHistory(p_filename);
     m_fileHistory.Save(*wxConfigBase::Get());
-    doc = new GameDocument(nfg);
+    doc = new GameDocument(game);
     doc->SetFilename(p_filename);
     (void)new GameFrame(nullptr, doc);
-    return GBT_APP_FILE_OK;
+    return AppLoadResult::Success;
   }
   catch (InvalidFileException &) {
     wxMessageBox(_("File is not in a format Gambit recognizes:\n") + p_filename,
                  _("Unable to read file"), wxOK | wxICON_ERROR, p_parent);
-    return GBT_APP_PARSE_FAILED;
+    return AppLoadResult::ParseFailed;
   }
 }
 

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -32,7 +32,12 @@ namespace Gambit::GUI {
 
 class GameDocument;
 
-enum AppLoadResult { GBT_APP_FILE_OK = 0, GBT_APP_OPEN_FAILED = 1, GBT_APP_PARSE_FAILED = 2 };
+enum class AppLoadResult : unsigned int {
+  Success = 0,
+  OpenFailed = 1,
+  ParseFailed = 2,
+  UnsupportedRepresentation = 3
+};
 
 class Application final : public wxApp {
   wxString m_currentDir; /* Current position in directory tree. */


### PR DESCRIPTION
The graphical interface doesn't provide any support for working with action graph games (as they are currently only immutable).

This adds a check and a failure dialog on attempting to load a (B)AGG.  (Previously the GUI would just crash.)
