### PR TITLE
Fix linter conflict

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 99
 indent-width = 4
+extend-ignore = E203
 include =
   setup.py
   src/pygambit

--- a/build_support/catalog/test_update.py
+++ b/build_support/catalog/test_update.py
@@ -695,7 +695,7 @@ class TestHierarchicalRstOutput:
         assert "   .. dropdown:: My Source\n   \n" in rst
         # Confirm :open: does not immediately follow the second-level dropdown
         src_idx = rst.index("   .. dropdown:: My Source")
-        assert ":open:" not in rst[src_idx:src_idx + 40]
+        assert ":open:" not in rst[src_idx : src_idx + 40]
 
     def test_game_dropdown_is_open(self, tmp_path, monkeypatch):
         """Individual game dropdowns carry ``:open:`` so game content is visible on expand."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ select = [
     "Q", # prefer double quotes
     "W291", # trailing-whitespace
 ]
-ignore = []
+ignore = ["E203"]
 
 fixable = ["ALL"]
 unfixable = []


### PR DESCRIPTION
When saving files in an IDE (e.g. VSCode/Antigravity) with the Ruff plugin installed and format-on-save enabled, the formatter automatically reformats Python slices that contain complex expressions (e.g., changing `rst[src_idx:src_idx + 40]` to `rst[src_idx : src_idx + 40]`). This is intentional behavior by modern formatters (like Black and Ruff) to improve readability and complies with PEP 8.

However, the pre-commit hooks for both `ruff` and `flake8` enforce the `pycodestyle` rule `E203` (whitespace before ':'), which strictly disallows this spacing. As a result, files formatted correctly by the IDE were being rejected by the pre-commit linters, blocking commits. This could be an annoying blocker other developers may face. 

### Description of the changes in this PR

This PR adds `E203` to the ignore list for both linters:
- Updated `pyproject.toml` to ignore `E203` in `[tool.ruff.lint]`.
- Updated `.flake8` to include `extend-ignore = E203`.
- Saved one file as an example and was able to commit the change without the pre-commit complaining

### How to review this PR

Decide if this is something we need.