### PR TITLE
Fix `PlayerActions.__len__` iterating actions instead of infosets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@
   to the left, wrapping if appropriate).
 - Max regret is calculated correctly for strategy and behavior profiles on games with zero player
   strategies or actions (is defined to be 0 trivially)  (#904)
+- Corrected calculation of total number of actions for a player in `pygambit` (#938)
 
 ### Changed
 - Added a new welcome/landing window on launching the GUI without a game.  This has the effect of

--- a/src/pygambit/player.pxi
+++ b/src/pygambit/player.pxi
@@ -82,7 +82,7 @@ class PlayerActions:
         return f"PlayerActions(player={self.player})"
 
     def __len__(self) -> int:
-        return sum(len(s.actions) for s in self.player.actions)
+        return sum(len(s.actions) for s in self.player.infosets)
 
     def __iter__(self) -> typing.Iterator[Action]:
         for infoset in self.player.infosets:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -256,5 +256,4 @@ def test_strategy_action_raises_error_for_strategic_game():
 def test_player_actions_len():
     game = games.create_stripped_down_poker_efg()
     for player in game.players:
-        from_iter = len(list(player.actions))
-        assert len(player.actions) == from_iter
+        assert len(player.actions) == len(list(player.actions))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -251,3 +251,10 @@ def test_strategy_action_raises_error_for_strategic_game():
 
     with pytest.raises(gbt.UndefinedOperationError):
         strategy.action(test_infoset)
+
+
+def test_player_actions_len():
+    game = games.create_stripped_down_poker_efg()
+    for player in game.players:
+        from_iter = len(list(player.actions))
+        assert len(player.actions) == from_iter


### PR DESCRIPTION
Fixes `PlayerActions.__len__`, which summed `len(s.actions)` while iterating `self.player.actions`. 
Now iterates `self.player.infosets`, matching `__iter__` and the correct `GameActions.__len__`. 

Adds a test checking `len(player.actions) == len(list(player.actions))`.