### PR TITLE
Update instructions on when to include EF files in the catalog (and other tips)

### DIFF
--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -69,35 +69,35 @@ Currently supported representations are:
 
          pygambit.catalog.load("books/watson2013/exercise29_6")
 
-   .. note::
+3. **[Optional] Add custom game layout(s):**
 
-      For extensive form games, you may optionally commit a curated ``.ef`` file alongside the ``.efg``
-      (e.g. ``catalog/source/game.ef``).
-      When present, ``update.py`` will use this file directly as input to DrawTree instead of
-      auto-generating the layout from the ``.efg``, preserving any hand-tuned layout.
-      Consult the `DrawTree docs <https://www.gambit-project.org/draw_tree/>`_ for the ``.ef`` format.
+   For extensive form games, you may optionally commit a curated ``.ef`` file alongside the ``.efg``
+   (e.g. ``catalog/source/game.ef``).
+   When present, ``update.py`` will use this file directly as input to DrawTree instead of
+   auto-generating the layout from the ``.efg``, preserving any hand-tuned layout.
+   Consult the `DrawTree docs <https://www.gambit-project.org/draw_tree/>`_ for the ``.ef`` format.
 
-      In general, ``.ef`` files should only be added when the layout they provide differs significantly
-      from what DrawTree produces automatically; if the auto-generated layout is reasonable, there is
-      no need to include one.
+   In general, ``.ef`` files should only be added when the layout they provide differs significantly
+   from what DrawTree produces automatically; if the auto-generated layout is reasonable, there is
+   no need to include one.
 
-      If the game has an original layout from a published source (e.g. a textbook or journal article),
-      you **should** try to capture that layout in an ``.ef`` file — you can create it manually or
-      try passing the ``.ef`` format spec and a screenshot of the original to an AI to generate it.
+   If the game has an original layout from a published source (e.g. a textbook or journal article),
+   you **should** try to capture that layout in an ``.ef`` file — you can create it manually or
+   try passing the ``.ef`` format spec and a screenshot of the original to an AI to generate it.
 
-      **Layout variants:** To display multiple layout variants on the catalog page (rendered as
-      clickable tabs), commit additional ``.ef`` files using the ``{slug}__{label}.ef`` naming
-      convention (double underscore separator), e.g.:
+   **Layout variants:** To display multiple layout variants on the catalog page (rendered as
+   clickable tabs), commit additional ``.ef`` files using the ``{slug}__{label}.ef`` naming
+   convention (double underscore separator), e.g.:
 
-      .. code-block:: text
+   .. code-block:: text
 
-         catalog/example/game.ef                     # primary (tab label "Default")
-         catalog/example/game__original_layout.ef    # additional (tab label "Original Layout")
+      catalog/example/game.ef                     # primary (tab label "Default")
+      catalog/example/game__original_layout.ef    # additional (tab label "Original Layout")
 
-      The label shown on each tab is derived automatically from the filename suffix: underscores
-      are replaced by spaces and the result is title-cased (e.g. ``__alt_version`` → "Alt Version").
+   The label shown on each tab is derived automatically from the filename suffix: underscores
+   are replaced by spaces and the result is title-cased (e.g. ``__alt_version`` → "Alt Version").
 
-3. **Update the build files:**
+4. **Update the build files:**
 
    Ensure you have installed the package in editable mode to automatically pick up the new game file(s) in the ``pygambit.catalog`` module without reinstalling each time.
    Then use the ``update.py`` script to update Gambit's documentation & build files, as well as generating images for the new game(s).
@@ -119,14 +119,14 @@ Currently supported representations are:
       - If haven't done an editable install of ``pygambit`` in your python environment, you'll need to re-install it before running the update script to include new games in the catalog module.
       - Running the script with the ``--build`` flag updates ``build_support/catalog/catalog.am``, which is included in ``Makefile.am``. If you moved games that were previously in ``contrib/games`` you'll need to also manually remove those files from ``EXTRA_DIST`` in ``Makefile.am``.
 
-4. **[Optional] Test your updates to the documentation locally:**
+5. **[Optional] Test your updates to the documentation locally:**
 
    The previous step will (re)build your local copy of the Gambit Catalog RST page used by the documentation.
    You should then build the docs in the :ref:`usual way <editing-docs>`.
    Open the catalog page at ``doc/_build/html/catalog.html`` to view your changes.
    Iterate steps 2-4 as required.
 
-5. **Submit a pull request to GitHub with all changes.**
+6. **Submit a pull request to GitHub with all changes.**
 
    Submit a PR according to the :ref:`usual workflow <submit-contribution>`.
    Ensure that any additions and changes to game files, ``build_support/catalog/draw_tree_settings.yaml``, ``build_support/catalog/update.py`` and ``build_support/catalog/catalog.am`` are included.

--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -121,7 +121,7 @@ Currently supported representations are:
 
    .. tip::
 
-      If you encounter any issues with game files in your python environment not matching the current branch preventing the update script or docs build (step below) try running the following first:
+      If you encounter any issues with game files in your python environment not matching the current branch preventing the update script or docs build working (step below) try running the following first:
 
       .. code-block:: bash
 

--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -119,6 +119,14 @@ Currently supported representations are:
       - If haven't done an editable install of ``pygambit`` in your python environment, you'll need to re-install it before running the update script to include new games in the catalog module.
       - Running the script with the ``--build`` flag updates ``build_support/catalog/catalog.am``, which is included in ``Makefile.am``. If you moved games that were previously in ``contrib/games`` you'll need to also manually remove those files from ``EXTRA_DIST`` in ``Makefile.am``.
 
+   .. tip::
+
+      If you encounter any issues with game files in your python environment not matching the current branch preventing the update script or docs build (step below) try running the following first:
+
+      .. code-block:: bash
+
+          git clean -fdX catalog/img doc/catalog_table.rst
+
 5. **[Optional] Test your updates to the documentation locally:**
 
    The previous step will (re)build your local copy of the Gambit Catalog RST page used by the documentation.

--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -77,17 +77,25 @@ Currently supported representations are:
       auto-generating the layout from the ``.efg``, preserving any hand-tuned layout.
       Consult the `DrawTree docs <https://www.gambit-project.org/draw_tree/>`_ for the ``.ef`` format.
 
+      In general, ``.ef`` files should only be added when the layout they provide differs significantly
+      from what DrawTree produces automatically; if the auto-generated layout is reasonable, there is
+      no need to include one.
+
+      If the game has an original layout from a published source (e.g. a textbook or journal article),
+      you **should** try to capture that layout in an ``.ef`` file — you can create it manually or
+      try passing the ``.ef`` format spec and a screenshot of the original to an AI to generate it.
+
       **Layout variants:** To display multiple layout variants on the catalog page (rendered as
       clickable tabs), commit additional ``.ef`` files using the ``{slug}__{label}.ef`` naming
       convention (double underscore separator), e.g.:
 
       .. code-block:: text
 
-         catalog/example/game.ef          # primary (tab label "Default")
-         catalog/example/game__wide.ef    # additional (tab label "Wide")
+         catalog/example/game.ef                     # primary (tab label "Default")
+         catalog/example/game__original_layout.ef    # additional (tab label "Original Layout")
 
       The label shown on each tab is derived automatically from the filename suffix: underscores
-      are replaced by spaces and the result is title-cased (e.g. ``__very_wide`` → "Very Wide").
+      are replaced by spaces and the result is title-cased (e.g. ``__alt_version`` → "Alt Version").
 
 3. **Update the build files:**
 

--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -127,6 +127,11 @@ Currently supported representations are:
 
           git clean -fdX catalog/img doc/catalog_table.rst
 
+   .. tip::
+
+      If the game visuals for extensive form games need some work and you aren't sure which settings to change in ``build_support/catalog/draw_tree_settings.yaml``, try loading the EFG in the DrawTree GUI and adjusting the layout there.
+      There is an option to [download settings](https://www.gambit-project.org/draw_tree/gui/#exporting-and-reusing-settings) which can be used in the Gambit catalog.
+
 5. **[Optional] Test your updates to the documentation locally:**
 
    The previous step will (re)build your local copy of the Gambit Catalog RST page used by the documentation.

--- a/doc/developer.catalog.rst
+++ b/doc/developer.catalog.rst
@@ -130,7 +130,7 @@ Currently supported representations are:
    .. tip::
 
       If the game visuals for extensive form games need some work and you aren't sure which settings to change in ``build_support/catalog/draw_tree_settings.yaml``, try loading the EFG in the DrawTree GUI and adjusting the layout there.
-      There is an option to [download settings](https://www.gambit-project.org/draw_tree/gui/#exporting-and-reusing-settings) which can be used in the Gambit catalog.
+      There is an option to `download settings <https://www.gambit-project.org/draw_tree/gui/#exporting-and-reusing-settings>`_ which can be used in the Gambit catalog.
 
 5. **[Optional] Test your updates to the documentation locally:**
 


### PR DESCRIPTION


### Issues closed by this PR


- Closes #939

### Description of the changes in this PR

This PR changes the developer documentation to provide a better explanation on when to add curated layouts via EF files for catalog games, and when not to.

Also includes some other tips for updating the catalog including how to use DrawTree GUI to customise game visuals and how to ensure that your python environment doesn't retain game files from other branches.

### How to review this PR

See the readthedocs build once it has finished and go to Developer docs -> Updating the games catalog: https://gambitproject--948.org.readthedocs.build/en/948/developer.catalog.html