### PR TITLE
Suggested aesthetic changes to catalog

### DIFF
--- a/build_support/catalog/gtdraw_settings.yaml
+++ b/build_support/catalog/gtdraw_settings.yaml
@@ -1,10 +1,12 @@
 # Default draw_tree settings applied to all catalog games.
 defaults:
-  color_scheme: gambit
+  color_scheme: colorblind
   font_family: sffamily
   font_italic: true
   shared_terminal_depth: true
   sublevel_scaling: 0
+  iset_fill: true
+  iset_boundary: none
 
 # Per-game overrides. Keys are slug prefixes or exact slugs.
 # For a given game, all matching keys are applied shortest-first,
@@ -27,7 +29,18 @@ overrides:
     shared_terminal_depth: false
   journals/mor/vonstengelforges2008/fig1:
     sublevel_scaling: 1
+  journals/mor/vonstengelforges2008/fig6:
+    action_label_dist: 3.0
   journals/mor/vonstengelforges2008/fig9:
     sublevel_scaling: 0.5
   journals/geb/gilboa1997/fig1:
     action_label_dist: 5.0
+  conf/itcs/jakobsen2016/fig3:
+    action_label_dist: 3.0
+    color_scheme: custom
+    custom_colors:
+      0: '#759138'
+      1: '#007FFF'
+      2: '#DD79E0'
+      3: '#1616BC'
+      4: '#985003'


### PR DESCRIPTION
### Description of the changes in this PR

This PR updates the catalog visuals by adjusting the `gtdraw` settings used in the following ways:
- Swaps the "gambit" colour scheme for "colorblind", with an exception for one 4 player `conf/itcs/jakobsen2016/fig3` where the 4th colour is changed from the default to something a bit darker
- Uses filled information sets with no borders
- Small adjustments to the distance action labels sit from edges for several games

No changes to any layouts.

### How to review this PR

Look at the catalog page in the docs build: https://gambitproject--959.org.readthedocs.build/en/959/catalog.html#catalog

Give opinions! :)