### PR TITLE
Add 3 player max cut test for enumpoly solver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ markers = [
     "nash_enumpure_strategy: tests of enumpure_solve in pure strategies",
     "nash_enumpure_agent: tests of enumpure_solve in pure behaviors",
     "nash_enummixed_strategy: tests of enummixed_solve in mixed strategies",
+    "nash_enumpoly_strategy: tests of enumpoly_solve in mixed strategies",
     "nash_enumpoly_behavior: tests of enumpoly_solve in mixed behaviors",
     "nash_lcp_strategy: tests of lcp_solve in mixed strategies",
     "nash_lcp_behavior: tests of lcp_solve in mixed behaviors",

--- a/tests/test_games/2x2x2_nfg_from_local_max_cut_2_pure_1_mixed_eq.nfg
+++ b/tests/test_games/2x2x2_nfg_from_local_max_cut_2_pure_1_mixed_eq.nfg
@@ -6,6 +6,7 @@ NFG 1 R "2x2x2 game with 2 pure and 1 mixed equilibrium"
 - Pure strategies {a,b} encode if respective player is on left or right of the cut
 - The payoff to a player is the sum of their incident edges across the implied cut
 - Pure equilibrium iff local max cuts; in addition, uniform mixture is an equilibrium
+- In the mixed equilibrium all players mix strategies with equal probability (0.5, 0.5)
 - Equilibrium analysis for pure profiles:
     a a a:  0 0  0 -- Not Nash (regrets: 1, 4, 1)
     b a a:  1 2 -1 -- Not Nash (regrets: 0, 0, 3)

--- a/tests/test_nash.py
+++ b/tests/test_nash.py
@@ -425,9 +425,60 @@ ENUMPOLY_STRATEGY_CASES = [
                 [d("1/2", "1/2"), d("1/2", "1/2"), d("1/2", "1/2")],
             ],
             prob_tol=TOL,
+            regret_tol=TOL,
         ),
         marks=pytest.mark.nash_enumpoly_strategy,
         id="test_enumpoly_strategy_1",
+    ),
+    # coordination game with 3 pure and 4 mixed equilibria
+    pytest.param(
+        EquilibriumTestCase(
+            factory=functools.partial(games.create_EFG_for_nxn_bimatrix_coordination_game, n=3),
+            solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None, use_strategic=True),
+            expected=[
+                    [d(1, 0, 0), d(1, 0, 0)],
+                    [d(0, 1, 0), d(0, 1, 0)],
+                    [d(0, 0, 1), d(0, 0, 1)],
+                    [d("1/2", "1/2", 0), d("1/2", "1/2", 0)],
+                    [d("1/2", 0, "1/2"), d("1/2", 0, "1/2")],
+                    [d(0, "1/2", "1/2"), d(0, "1/2", "1/2")],
+                    [d("1/3", "1/3", "1/3"), d("1/3", "1/3", "1/3")],
+            ],
+            prob_tol=TOL,
+            regret_tol=TOL,
+        ),
+        marks=pytest.mark.nash_enumpoly_strategy,
+        id="test_enumpoly_strategy_2",
+    ),
+    # A three-player game with a unique Nash equilibrium in irrational mixed strategies (nau2004 sec4 catalog game)
+    pytest.param(
+        EquilibriumTestCase(
+            factory=functools.partial(gbt.catalog.load, "journals/ijgt/nau2004/sec4"),
+            solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None),
+            expected=[
+                    [d(0.6192325794725537, 0.3807674205274463), d(0.4798042226776053, 0.5201957773223946), d(0.3788253360656313, 0.6211746639343687)],
+            ],
+            prob_tol=TOL,
+            regret_tol=TOL,
+        ),
+        marks=pytest.mark.nash_enumpoly_strategy,
+        id="test_enumpoly_strategy_3",
+    ),
+    # A three-player 2x2x2 game with 3 pure, 2 incompletely mixed, and a continuum of completely mixed Nash equilibria (nau2004 sec5 catalog game)
+    pytest.param(
+        EquilibriumTestCase(
+            factory=functools.partial(gbt.catalog.load, "journals/ijgt/nau2004/sec5"),
+            solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None),
+            expected=[
+                    [d(1, 0), d(0, 1), d(1, 0)],
+                    [d(0, 1), d(1, 0), d(1, 0)],
+                    [d(0, 1), d(0, 1), d(0, 1)],
+            ],
+            prob_tol=TOL,
+            regret_tol=TOL,
+        ),
+        marks=pytest.mark.nash_enumpoly_strategy,
+        id="test_enumpoly_strategy_4",
     ),
 ]
 
@@ -992,6 +1043,7 @@ def test_nash_strategy_solver(test_case: EquilibriumTestCase, subtests) -> None:
         assert len(result.equilibria) == len(test_case.expected)
     for i, (eq, exp) in enumerate(zip(result.equilibria, test_case.expected, strict=True)):
         with subtests.test(eq=i, check="max_regret"):
+            print(eq)
             assert eq.max_regret() <= test_case.regret_tol
         with subtests.test(eq=i, check="strategy_profile"):
             expected = game.mixed_strategy_profile(rational=True, data=exp)

--- a/tests/test_nash.py
+++ b/tests/test_nash.py
@@ -1043,7 +1043,6 @@ def test_nash_strategy_solver(test_case: EquilibriumTestCase, subtests) -> None:
         assert len(result.equilibria) == len(test_case.expected)
     for i, (eq, exp) in enumerate(zip(result.equilibria, test_case.expected, strict=True)):
         with subtests.test(eq=i, check="max_regret"):
-            print(eq)
             assert eq.max_regret() <= test_case.regret_tol
         with subtests.test(eq=i, check="strategy_profile"):
             expected = game.mixed_strategy_profile(rational=True, data=exp)

--- a/tests/test_nash.py
+++ b/tests/test_nash.py
@@ -411,6 +411,27 @@ ENUMMIXED_DOUBLE_CASES = [
 ]
 
 
+ENUMPOLY_STRATEGY_CASES = [
+    # 2x2x2 strategic form game based on local max cut -- 2 pure and 1 mixed
+    pytest.param(
+        EquilibriumTestCase(
+            factory=functools.partial(
+                games.read_from_file, "2x2x2_nfg_from_local_max_cut_2_pure_1_mixed_eq.nfg"
+            ),
+            solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None),
+            expected=[
+                [d(1, 0), d(0, 1), d(1, 0)],
+                [d(0, 1), d(1, 0), d(0, 1)],
+                [d("1/2", "1/2"), d("1/2", "1/2"), d("1/2", "1/2")],
+            ],
+            prob_tol=TOL,
+        ),
+        marks=pytest.mark.nash_enumpoly_strategy,
+        id="test_enumpoly_strategy_1",
+    ),
+]
+
+
 LP_STRATEGY_RATIONAL_CASES = [
     pytest.param(
         EquilibriumTestCase(
@@ -945,6 +966,7 @@ CASES = []
 CASES += ENUMPURE_CASES
 CASES += ENUMMIXED_RATIONAL_CASES
 CASES += ENUMMIXED_DOUBLE_CASES
+CASES += ENUMPOLY_STRATEGY_CASES
 CASES += LP_STRATEGY_RATIONAL_CASES
 CASES += LP_STRATEGY_DOUBLE_CASES
 CASES += LCP_STRATEGY_RATIONAL_CASES

--- a/tests/test_nash.py
+++ b/tests/test_nash.py
@@ -450,15 +450,18 @@ ENUMPOLY_STRATEGY_CASES = [
         marks=pytest.mark.nash_enumpoly_strategy,
         id="test_enumpoly_strategy_2",
     ),
-    # A three-player game with a unique Nash equilibrium in irrational mixed strategies (nau2004 sec4 catalog game)
+    # A three-player game with a unique Nash equilibrium in irrational mixed strategies
+    # (nau2004 sec4 catalog game)
     pytest.param(
         EquilibriumTestCase(
             factory=functools.partial(gbt.catalog.load, "journals/ijgt/nau2004/sec4"),
             solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None),
             expected=[
-                    [d(0.6192325794725537, 0.3807674205274463), 
-                    d(0.4798042226776053, 0.5201957773223946), 
-                    d(0.3788253360656313, 0.6211746639343687)],
+                    [
+                        d(0.6192325794725537, 0.3807674205274463),
+                        d(0.4798042226776053, 0.5201957773223946),
+                        d(0.3788253360656313, 0.6211746639343687)
+                    ],
             ],
             prob_tol=TOL,
             regret_tol=TOL,
@@ -466,7 +469,8 @@ ENUMPOLY_STRATEGY_CASES = [
         marks=pytest.mark.nash_enumpoly_strategy,
         id="test_enumpoly_strategy_3",
     ),
-    # A three-player 2x2x2 game with 3 pure, 2 incompletely mixed, and a continuum of completely mixed Nash equilibria (nau2004 sec5 catalog game)
+    # A three-player 2x2x2 game with 3 pure, 2 incompletely mixed, and a
+    # continuum of completely mixed Nash equilibria (nau2004 sec5 catalog game)
     pytest.param(
         EquilibriumTestCase(
             factory=functools.partial(gbt.catalog.load, "journals/ijgt/nau2004/sec5"),

--- a/tests/test_nash.py
+++ b/tests/test_nash.py
@@ -456,7 +456,9 @@ ENUMPOLY_STRATEGY_CASES = [
             factory=functools.partial(gbt.catalog.load, "journals/ijgt/nau2004/sec4"),
             solver=functools.partial(gbt.nash.enumpoly_solve, stop_after=None),
             expected=[
-                    [d(0.6192325794725537, 0.3807674205274463), d(0.4798042226776053, 0.5201957773223946), d(0.3788253360656313, 0.6211746639343687)],
+                    [d(0.6192325794725537, 0.3807674205274463), 
+                    d(0.4798042226776053, 0.5201957773223946), 
+                    d(0.3788253360656313, 0.6211746639343687)],
             ],
             prob_tol=TOL,
             regret_tol=TOL,


### PR DESCRIPTION
This PR adds a test for the enumpoly solver that covers the 2x2x2 max cut normal form game, ensuring it returns the two pure and one mixed equilibirum.