### PR TITLE
Structure of hp method, ComputeInitialPoint and ExtractEquilibrium methods

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -315,7 +315,9 @@ gtracer_SOURCES = \
 
 hp_SOURCES = \
 	src/solvers/hp/hp.h \
-	src/solvers/hp/hp.cc
+	src/solvers/hp/hp.cc \
+	src/solvers/hp/hpsystem.h \
+	src/solvers/hp/hpsystem.cc
 
 if IS_WIN32
 AM_LDFLAGS = -static -static-libgcc -static-libstdc++

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -623,7 +623,7 @@ cdef extern from "solvers/logit/logit.h":
 
 cdef extern from "solvers/hp/hp.h":
     stdlist[c_MixedStrategyProfile[double]] HPStrategySolve(
-            c_Game, c_MixedStrategyProfile[double]
+            c_MixedStrategyProfile[double]
     ) except +RuntimeError
 
 

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -622,7 +622,9 @@ cdef extern from "solvers/logit/logit.h":
 
 
 cdef extern from "solvers/hp/hp.h":
-    stdlist[c_MixedStrategyProfile[double]] HPStrategySolve(c_Game) except +RuntimeError
+    stdlist[c_MixedStrategyProfile[double]] HPStrategySolve(
+            c_Game, c_MixedStrategyProfile[double]
+    ) except +RuntimeError
 
 
 cdef extern from "nash.h":

--- a/src/pygambit/nash.pxi
+++ b/src/pygambit/nash.pxi
@@ -370,6 +370,6 @@ def _logit_behavior_branch(game: Game,
     return ret
 
 
-def _hp_strategy_solve(game: Game,
+def _hp_strategy_solve(
                        prior: MixedStrategyProfileDouble) -> list[MixedStrategyProfileDouble]:
-    return _convert_mspd(HPStrategySolve(game.game, deref(prior.profile)))
+    return _convert_mspd(HPStrategySolve(deref(prior.profile)))

--- a/src/pygambit/nash.pxi
+++ b/src/pygambit/nash.pxi
@@ -370,5 +370,6 @@ def _logit_behavior_branch(game: Game,
     return ret
 
 
-def _hp_strategy_solve(game: Game) -> list[MixedStrategyProfileDouble]:
-    return _convert_mspd(HPStrategySolve(game.game))
+def _hp_strategy_solve(game: Game,
+                       prior: MixedStrategyProfileDouble) -> list[MixedStrategyProfileDouble]:
+    return _convert_mspd(HPStrategySolve(game.game, deref(prior.profile)))

--- a/src/pygambit/nash.py
+++ b/src/pygambit/nash.py
@@ -808,6 +808,7 @@ def logit_solve(
 
 def hp_solve(
         game: libgbt.Game,
+        prior: libgbt.MixedStrategyProfileDouble,
 ) -> NashComputationResult:
     """Compute Nash equilibria of a game using :cite:p:`HerPee01`
 
@@ -818,13 +819,15 @@ def hp_solve(
     ----------
     game : Game
         The game to compute equilibria in.
+    prior : MixedStrategyProfileDouble
+        The prior distribution over strategies.
 
     Returns
     -------
     res : NashComputationResult
         The result represented as a ``NashComputationResult`` object.
     """
-    equilibria = libgbt._hp_strategy_solve(game)
+    equilibria = libgbt._hp_strategy_solve(game, prior)
     return NashComputationResult(
         game=game,
         method="hp",

--- a/src/pygambit/nash.py
+++ b/src/pygambit/nash.py
@@ -807,7 +807,6 @@ def logit_solve(
 
 
 def hp_solve(
-        game: libgbt.Game,
         prior: libgbt.MixedStrategyProfileDouble,
 ) -> NashComputationResult:
     """Compute Nash equilibria of a game using :cite:p:`HerPee01`
@@ -817,8 +816,6 @@ def hp_solve(
 
     Parameters
     ----------
-    game : Game
-        The game to compute equilibria in.
     prior : MixedStrategyProfileDouble
         The prior distribution over strategies.
 
@@ -827,9 +824,9 @@ def hp_solve(
     res : NashComputationResult
         The result represented as a ``NashComputationResult`` object.
     """
-    equilibria = libgbt._hp_strategy_solve(game, prior)
+    equilibria = libgbt._hp_strategy_solve(prior)
     return NashComputationResult(
-        game=game,
+        game=prior.game,
         method="hp",
         rational=False,
         use_strategic=True,

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -27,14 +27,11 @@
 
 namespace Gambit {
 std::list<MixedStrategyProfile<double>>
-HPStrategySolve(const Game &p_game, const MixedStrategyProfile<double> &p_prior)
+HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
 {
   const std::list<MixedStrategyProfile<double>> result;
-  const StrategySupportProfile support(p_game);
 
-  const MixedStrategyProfile<double> prior(p_prior);
-
-  const HPEquationSystem system(p_game, p_prior);
+  const HPEquationSystem system(p_prior);
   Vector<double> init_pt = system.ComputeInitialPoint();
 
   std::cout << "Computed starting vector (alpha form): ";

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -23,16 +23,30 @@
 #include <iostream>
 #include "gambit.h"
 #include "solvers/hp/hp.h"
+#include "solvers/hp/hpsystem.h"
 
 namespace Gambit {
-std::list<MixedStrategyProfile<double>> HPStrategySolve(const Game &p_game)
+std::list<MixedStrategyProfile<double>>
+HPStrategySolve(const Game &p_game, const MixedStrategyProfile<double> &p_prior)
 {
-  std::list<MixedStrategyProfile<double>> result;
+  const std::list<MixedStrategyProfile<double>> result;
   const StrategySupportProfile support(p_game);
 
-  const MixedStrategyProfile<double> trivial_profile = support.NewMixedStrategyProfile<double>();
+  const MixedStrategyProfile<double> prior(p_prior);
 
-  result.push_back(trivial_profile);
-  return result;
+  const HPEquationSystem system(p_game, p_prior);
+  Vector<double> init_pt = system.ComputeInitialPoint();
+
+  std::cout << "Computed starting vector (alpha form): ";
+  for (size_t i = 1; i <= init_pt.size(); ++i) {
+    std::cout << init_pt[i] << " ";
+  }
+  std::cout << std::endl;
+
+  std::list<MixedStrategyProfile<double>> ret;
+  const MixedStrategyProfile<double> T_0 = system.ExtractEquilibrium(init_pt);
+  ret.push_back(T_0);
+
+  return ret;
 }
 } // namespace Gambit

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -39,7 +39,10 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
   const PathTracer tracer;
   double omega = 1.0;
 
-  auto termination_condition = [](const Vector<double> &point) { return point[1] >= 1.0; };
+  auto termination_condition = [](const Vector<double> &point) { return point[1] >= 1.5; };
+  auto criterion_function = [](const Vector<double> &point,
+                               const Vector<double> &tangent) -> double { return point[1] - 1.0; };
+
   const TracePathResult result = tracer.TracePath(
       [&system](const Vector<double> &point, Vector<double> &lhs) { system.GetValue(point, lhs); },
       [&system](const Vector<double> &point, Matrix<double> &jac) {
@@ -60,7 +63,8 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
           std::cout << prob_vector[i] << " ";
         }
         std::cout << std::endl;
-      });
+      },
+      criterion_function);
 
   equilibria.push_back(system.ExtractEquilibrium(x));
   return equilibria;

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -24,26 +24,45 @@
 #include "gambit.h"
 #include "solvers/hp/hp.h"
 #include "solvers/hp/hpsystem.h"
+#include "solvers/logit/path.h"
 
 namespace Gambit {
 std::list<MixedStrategyProfile<double>>
 HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
 {
-  const std::list<MixedStrategyProfile<double>> result;
 
-  const HPEquationSystem system(p_prior);
-  Vector<double> init_pt = system.ComputeInitialPoint();
+  std::list<MixedStrategyProfile<double>> equilibria;
 
-  std::cout << "Computed starting vector (alpha form): ";
-  for (size_t i = 1; i <= init_pt.size(); ++i) {
-    std::cout << init_pt[i] << " ";
-  }
-  std::cout << std::endl;
+  HPEquationSystem system(p_prior);
+  Vector<double> x = system.ComputeInitialPoint();
 
-  std::list<MixedStrategyProfile<double>> ret;
-  const MixedStrategyProfile<double> T_0 = system.ExtractEquilibrium(init_pt);
-  ret.push_back(T_0);
+  const PathTracer tracer;
+  double omega = 1.0;
 
-  return ret;
+  auto termination_condition = [](const Vector<double> &point) { return point[1] >= 1.0; };
+  const TracePathResult result = tracer.TracePath(
+      [&system](const Vector<double> &point, Vector<double> &lhs) { system.GetValue(point, lhs); },
+      [&system](const Vector<double> &point, Matrix<double> &jac) {
+        system.GetJacobian(point, jac);
+      },
+      x, omega, termination_condition,
+      [&system](const Vector<double> &point) {
+        std::cout << "[Path Tracer Step] t = " << point[1];
+        std::cout << " | Alfas: ";
+        for (size_t i = 2; i <= 5; ++i) {
+          std::cout << point[i] << " ";
+        }
+        std::cout << "| Mu: " << point[6] << " " << point[7] << std::endl;
+
+        std::cout << "Full point vector in probabilities: ";
+        Vector<double> prob_vector = system.ExtractEquilibrium(point).GetProbVector();
+        for (size_t i = 1; i <= prob_vector.size(); ++i) {
+          std::cout << prob_vector[i] << " ";
+        }
+        std::cout << std::endl;
+      });
+
+  equilibria.push_back(system.ExtractEquilibrium(x));
+  return equilibria;
 }
 } // namespace Gambit

--- a/src/solvers/hp/hp.h
+++ b/src/solvers/hp/hp.h
@@ -26,7 +26,8 @@
 #include <list>
 
 namespace Gambit {
-std::list<MixedStrategyProfile<double>> HPStrategySolve(const Game &p_game);
+std::list<MixedStrategyProfile<double>>
+HPStrategySolve(const Game &p_game, const MixedStrategyProfile<double> &p_prior);
 } // namespace Gambit
 
 #endif // HP_H

--- a/src/solvers/hp/hp.h
+++ b/src/solvers/hp/hp.h
@@ -27,7 +27,7 @@
 
 namespace Gambit {
 std::list<MixedStrategyProfile<double>>
-HPStrategySolve(const Game &p_game, const MixedStrategyProfile<double> &p_prior);
+HPStrategySolve(const MixedStrategyProfile<double> &p_prior);
 } // namespace Gambit
 
 #endif // HP_H

--- a/src/solvers/hp/hpsystem.cc
+++ b/src/solvers/hp/hpsystem.cc
@@ -25,8 +25,8 @@
 #include "solvers/hp/hpsystem.h"
 
 namespace Gambit {
-HPEquationSystem::HPEquationSystem(const Game &game, const MixedStrategyProfile<double> &prior)
-  : m_game(game), m_prior(prior)
+HPEquationSystem::HPEquationSystem(const MixedStrategyProfile<double> &prior)
+  : m_game(prior.GetGame()), m_prior(prior)
 {
 }
 
@@ -76,6 +76,11 @@ Vector<double> HPEquationSystem::ComputeInitialPoint() const
       if (std::abs(lambda) < tol && !found_br) {
         start_point[alpha_idx++] = 1.0; // Best response
         found_br = true;
+      }
+      else if (std::abs(lambda) < tol) {
+        throw std::runtime_error("Multiple best responses found for player " +
+                                 std::to_string(player_idx) +
+                                 ". Only one best response is allowed.");
       }
       else {
         // Avoid sqrt of negative numbers

--- a/src/solvers/hp/hpsystem.cc
+++ b/src/solvers/hp/hpsystem.cc
@@ -1,0 +1,109 @@
+//
+// This file is part of Gambit
+// Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
+//
+// FILE: src/solvers/hp/hpsystem.cc
+// Computation of a Nash equilibria using a differentiable homotopy
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#include <iostream>
+#include "gambit.h"
+#include "solvers/hp/hpsystem.h"
+
+namespace Gambit {
+HPEquationSystem::HPEquationSystem(const Game &game, const MixedStrategyProfile<double> &prior)
+  : m_game(game), m_prior(prior)
+{
+}
+
+Vector<double> HPEquationSystem::ComputeInitialPoint() const
+{
+  const int n_players = m_game->GetPlayers().size();
+  int m_star = 0;
+  const double tol = 1e-9; // Tolerance for floating-point comparisons
+  for (const auto &player : m_game->GetPlayers()) {
+    m_star += player->GetStrategies().size();
+  }
+
+  // Dimension: 1 (t) + m_star (total strategies) + n (number of players)
+  const int vector_size = 1 + m_star + n_players;
+  Vector<double> start_point(vector_size);
+
+  start_point[1] = 0.0; // t = 0
+
+  int alpha_idx = 2;
+  int player_idx = 1;
+
+  for (const auto &player : m_game->GetPlayers()) {
+
+    double max_payoff = -std::numeric_limits<double>::infinity();
+    std::vector<double> payoffs_against_prior;
+    payoffs_against_prior.reserve(player->GetStrategies().size());
+
+    // Finding mu^i (the maximum payoff for player i against the prior)
+    for (const auto &strategy : player->GetStrategies()) {
+      const double payoff = m_prior.GetPayoff(strategy);
+      payoffs_against_prior.push_back(payoff);
+
+      if (payoff > max_payoff) {
+        max_payoff = payoff;
+      }
+    }
+
+    // Store mu^i
+    start_point[1 + m_star + player_idx] = max_payoff;
+
+    // Compute alpha^i_s for each strategy s of player i
+    int local_s_idx = 0;
+    bool found_br = false; // Flag to check if a best response has been found
+
+    for (const auto &strategy : player->GetStrategies()) {
+      const double lambda = max_payoff - payoffs_against_prior[local_s_idx++];
+      if (std::abs(lambda) < tol && !found_br) {
+        start_point[alpha_idx++] = 1.0; // Best response
+        found_br = true;
+      }
+      else {
+        // Avoid sqrt of negative numbers
+        start_point[alpha_idx++] = -std::sqrt(std::max(0.0, lambda));
+      }
+    }
+    player_idx++;
+  }
+
+  return start_point;
+}
+
+MixedStrategyProfile<double>
+HPEquationSystem::ExtractEquilibrium(const Vector<double> &final_point) const
+{
+  MixedStrategyProfile<double> ret = m_game->NewMixedStrategyProfile(0.0);
+  int alpha_idx = 2; // First position is reserved to t
+
+  for (const auto &player : m_game->GetPlayers()) {
+    for (const auto &strategy : player->GetStrategies()) {
+      const double alpha_val = final_point[alpha_idx++];
+      const double prob = this->AlphaToSigma(alpha_val);
+      ret[strategy] = prob;
+    }
+  }
+  ret = ret.Normalize();
+
+  return ret;
+}
+
+} // end namespace Gambit

--- a/src/solvers/hp/hpsystem.cc
+++ b/src/solvers/hp/hpsystem.cc
@@ -26,18 +26,137 @@
 
 namespace Gambit {
 HPEquationSystem::HPEquationSystem(const MixedStrategyProfile<double> &prior)
-  : m_game(prior.GetGame()), m_prior(prior)
+  : m_game(prior.GetGame()), m_prior(prior),
+    m_current_sigma(prior.GetGame()->NewMixedStrategyProfile(0.0)),
+    m_star(prior.MixedProfileLength())
 {
+  m_payoffs_against_prior.reserve(m_prior.MixedProfileLength());
+  for (const auto &player : m_game->GetPlayers()) {
+    for (const auto &strategy : player->GetStrategies()) {
+      m_payoffs_against_prior.push_back(m_prior.GetPayoff(strategy));
+    }
+  }
+}
+
+void HPEquationSystem::GetValue(const Vector<double> &point, Vector<double> &lhs) const
+{
+  const double t = point[1];
+
+  int temp_alpha_idx = 2;
+  for (const auto &player : m_game->GetPlayers()) {
+    for (const auto &strategy : player->GetStrategies()) {
+      m_current_sigma[strategy] = AlphaToSigma(point[temp_alpha_idx++]);
+    }
+  }
+
+  int alpha_idx = 2;
+  int eq_idx = 1;
+  int player_idx = 1;
+  int flat_strategy_idx = 0;
+
+  for (const auto &player : m_game->GetPlayers()) {
+
+    const double mu = point[1 + m_star + player_idx];
+    double sum_sigma = 0.0;
+
+    // (a) Best response equations
+    for (const auto &strategy : player->GetStrategies()) {
+      const double alpha = point[alpha_idx++];
+      const double lambda = AlphaToLambda(alpha);
+      const double sigma = AlphaToSigma(alpha);
+      sum_sigma += sigma;
+
+      const double v_i = CalculateDynamicPayoff(flat_strategy_idx++, strategy, m_current_sigma, t);
+
+      lhs[eq_idx++] = v_i + lambda - mu;
+    }
+
+    // (b) Probability sum equation
+    lhs[eq_idx++] = sum_sigma - 1.0;
+
+    player_idx++;
+  }
+}
+
+void HPEquationSystem::GetJacobian(const Vector<double> &point, Matrix<double> &p_jac) const
+{
+  const double t = point[1];
+
+  // Compute current sigma from alpha values
+  int temp_alpha_idx = 2;
+  for (const auto &player : m_game->GetPlayers()) {
+    for (const auto &strategy : player->GetStrategies()) {
+      m_current_sigma[strategy] = AlphaToSigma(point[temp_alpha_idx++]);
+    }
+  }
+
+  // Initialize the Jacobian matrix to zero
+  p_jac = 0.0;
+
+  int eq_idx = 1;
+  int player_idx = 1;
+  int flat_s1_idx = 0;
+
+  for (const auto &player1 : m_game->GetPlayers()) {
+
+    // (a) Best response equations
+    for (const auto &strat1 : player1->GetStrategies()) {
+
+      // Column of t:
+      const double payoff_vs_sigma = m_current_sigma.GetPayoff(strat1);
+      const double payoff_vs_prior = m_payoffs_against_prior[flat_s1_idx];
+      p_jac(1, eq_idx) = payoff_vs_sigma - payoff_vs_prior;
+
+      // Column of mu_i: Derivative with respect to mu of this player (-1.0)
+      p_jac(1 + m_star + player_idx, eq_idx) = -1.0;
+
+      // Alpha columns:
+      int alpha_col = 2;
+      for (const auto &player2 : m_game->GetPlayers()) {
+        for (const auto &strat2 : player2->GetStrategies()) {
+          const double alpha2 = point[alpha_col];
+
+          if (player1 == player2) {
+            // Same strategy, use the derivative of lambda with respect to alpha
+            if (strat1 == strat2) {
+              p_jac(alpha_col, eq_idx) = AlphaToLambdaDeriv(alpha2);
+            }
+          }
+          else {
+            // Using chain rule
+            const double deriv_u =
+                m_current_sigma.GetPayoffDeriv(player1->GetNumber(), strat1, strat2);
+            const double deriv_sigma = AlphaToSigmaDeriv(alpha2);
+            p_jac(alpha_col, eq_idx) = t * deriv_u * deriv_sigma;
+          }
+          alpha_col++;
+        }
+      }
+      eq_idx++;
+      flat_s1_idx++;
+    }
+
+    // (b) Probability sum equation
+    // Derivative with respect to 't' and 'mu' is 0
+    // Only derivatives with respect to the alphas of this player
+    int alpha_col = 2;
+    for (const auto &player2 : m_game->GetPlayers()) {
+      for (const auto &strat2 : player2->GetStrategies()) {
+        if (player1 == player2) {
+          p_jac(alpha_col, eq_idx) = AlphaToSigmaDeriv(point[alpha_col]);
+        }
+        alpha_col++;
+      }
+    }
+    eq_idx++;
+    player_idx++;
+  }
 }
 
 Vector<double> HPEquationSystem::ComputeInitialPoint() const
 {
   const int n_players = m_game->GetPlayers().size();
-  int m_star = 0;
   const double tol = 1e-9; // Tolerance for floating-point comparisons
-  for (const auto &player : m_game->GetPlayers()) {
-    m_star += player->GetStrategies().size();
-  }
 
   // Dimension: 1 (t) + m_star (total strategies) + n (number of players)
   const int vector_size = 1 + m_star + n_players;
@@ -47,18 +166,14 @@ Vector<double> HPEquationSystem::ComputeInitialPoint() const
 
   int alpha_idx = 2;
   int player_idx = 1;
+  int flat_strategy_idx = 0; // Index for accessing m_payoffs_against_prior
 
   for (const auto &player : m_game->GetPlayers()) {
-
-    double max_payoff = -std::numeric_limits<double>::infinity();
-    std::vector<double> payoffs_against_prior;
-    payoffs_against_prior.reserve(player->GetStrategies().size());
-
+    const int temp_idx = flat_strategy_idx;
     // Finding mu^i (the maximum payoff for player i against the prior)
+    double max_payoff = -std::numeric_limits<double>::infinity();
     for (const auto &strategy : player->GetStrategies()) {
-      const double payoff = m_prior.GetPayoff(strategy);
-      payoffs_against_prior.push_back(payoff);
-
+      const double payoff = m_payoffs_against_prior[flat_strategy_idx++];
       if (payoff > max_payoff) {
         max_payoff = payoff;
       }
@@ -68,11 +183,11 @@ Vector<double> HPEquationSystem::ComputeInitialPoint() const
     start_point[1 + m_star + player_idx] = max_payoff;
 
     // Compute alpha^i_s for each strategy s of player i
-    int local_s_idx = 0;
-    bool found_br = false; // Flag to check if a best response has been found
 
+    bool found_br = false; // Flag to check if a best response has been found
+    int local_s_idx = temp_idx;
     for (const auto &strategy : player->GetStrategies()) {
-      const double lambda = max_payoff - payoffs_against_prior[local_s_idx++];
+      const double lambda = max_payoff - m_payoffs_against_prior[local_s_idx++];
       if (std::abs(lambda) < tol && !found_br) {
         start_point[alpha_idx++] = 1.0; // Best response
         found_br = true;
@@ -109,6 +224,16 @@ HPEquationSystem::ExtractEquilibrium(const Vector<double> &final_point) const
   ret = ret.Normalize();
 
   return ret;
+}
+
+// v^i(t, s)
+double HPEquationSystem::CalculateDynamicPayoff(int action_index, const GameStrategy &strategy,
+                                                const MixedStrategyProfile<double> &current_sigma,
+                                                double t) const
+{
+  const double payoff_against_sigma = current_sigma.GetPayoff(strategy);
+  const double payoff_against_prior = m_payoffs_against_prior[action_index];
+  return t * payoff_against_sigma + (1.0 - t) * payoff_against_prior;
 }
 
 } // end namespace Gambit

--- a/src/solvers/hp/hpsystem.h
+++ b/src/solvers/hp/hpsystem.h
@@ -45,15 +45,25 @@ public:
 private:
   const Game m_game;
   MixedStrategyProfile<double> m_prior;
+  std::vector<double> m_payoffs_against_prior;
+  int m_star;
+  mutable MixedStrategyProfile<double> m_current_sigma;
 
   // Transforms alpha to sigma and lambda
   inline double AlphaToSigma(double alpha) const { return (alpha > 0.0) ? (alpha * alpha) : 0.0; }
   inline double AlphaToLambda(double alpha) const { return (alpha < 0.0) ? (alpha * alpha) : 0.0; }
 
-  // Dynamic payoffs
-  double CalculateMarginalPayoff(int player, int strategy_idx,
-                                 const MixedStrategyProfile<double> &current_sigma,
-                                 double t) const;
+  // d(sigma)/d(alpha)
+  inline double AlphaToSigmaDeriv(double alpha) const { return (alpha > 0.0) ? 2.0 * alpha : 0.0; }
+  // d(lambda)/d(alpha)
+  inline double AlphaToLambdaDeriv(double alpha) const
+  {
+    return (alpha < 0.0) ? 2.0 * alpha : 0.0;
+  }
+
+  // v^i(t, s)
+  double CalculateDynamicPayoff(int action_index, const GameStrategy &strategy,
+                                const MixedStrategyProfile<double> &current_sigma, double t) const;
 };
 
 } // namespace Gambit

--- a/src/solvers/hp/hpsystem.h
+++ b/src/solvers/hp/hpsystem.h
@@ -1,0 +1,60 @@
+//
+// This file is part of Gambit
+// Copyright (c) 1994-2026, The Gambit Project (http://www.gambit-project.org)
+//
+// FILE: src/solvers/hp/hpsystem.h
+// Computation of a Nash equilibria using a differentiable homotopy
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#ifndef HPSYSTEM_H
+#define HPSYSTEM_H
+
+#include <functional>
+
+namespace Gambit {
+
+class HPEquationSystem {
+public:
+  HPEquationSystem(const Game &game, const MixedStrategyProfile<double> &prior);
+
+  // Evaluates H(t, alpha, mu) = 0
+  void GetValue(const Vector<double> &point, Vector<double> &lhs) const;
+
+  void GetJacobian(const Vector<double> &point, Matrix<double> &jac) const;
+
+  // Computes the initial point for the homotopy path tracing (t=0)
+  Vector<double> ComputeInitialPoint() const;
+
+  // Transforms the final vector into an equilibrium mixed strategy profile
+  MixedStrategyProfile<double> ExtractEquilibrium(const Vector<double> &final_point) const;
+
+private:
+  const Game &m_game;
+  MixedStrategyProfile<double> m_prior;
+
+  // Transforms alpha to sigma and lambda
+  inline double AlphaToSigma(double alpha) const { return (alpha > 0.0) ? (alpha * alpha) : 0.0; }
+  inline double AlphaToLambda(double alpha) const { return (alpha < 0.0) ? (alpha * alpha) : 0.0; }
+
+  // Dynamic payoffs
+  double CalculateMarginalPayoff(int player, int strategy_idx,
+                                 const MixedStrategyProfile<double> &current_sigma,
+                                 double t) const;
+};
+
+} // namespace Gambit
+#endif // HPSYSTEM_H

--- a/src/solvers/hp/hpsystem.h
+++ b/src/solvers/hp/hpsystem.h
@@ -29,7 +29,7 @@ namespace Gambit {
 
 class HPEquationSystem {
 public:
-  HPEquationSystem(const Game &game, const MixedStrategyProfile<double> &prior);
+  HPEquationSystem(const MixedStrategyProfile<double> &prior);
 
   // Evaluates H(t, alpha, mu) = 0
   void GetValue(const Vector<double> &point, Vector<double> &lhs) const;
@@ -43,7 +43,7 @@ public:
   MixedStrategyProfile<double> ExtractEquilibrium(const Vector<double> &final_point) const;
 
 private:
-  const Game &m_game;
+  const Game m_game;
   MixedStrategyProfile<double> m_prior;
 
   // Transforms alpha to sigma and lambda

--- a/tests/test_hp.py
+++ b/tests/test_hp.py
@@ -70,7 +70,6 @@ def create_t0_degenerate_example() -> gbt.MixedStrategyProfileDouble:
     prior = game.mixed_strategy_profile()
     p1, p2 = list(game.players)
 
-    # El prior que descubriste accidentalmente
     prior[list(p1.strategies)[0]] = 2.0 / 3.0
     prior[list(p1.strategies)[1]] = 1.0 / 3.0
     prior[list(p2.strategies)[0]] = 1.0 / 3.0
@@ -83,7 +82,7 @@ HP_CASES = [
     pytest.param(
         HPSolverTestCase(
             factory=create_hp_paper_example,
-            expected=[d(0.8, 0.2), d(1.0 / 3.0, 2.0 / 3.0)],
+            expected=[d(0.0, 1.0), d(0.0, 1.0)],
         ),
         marks=pytest.mark.xfail(reason="Mathematical curve tracking not yet fully implemented"),
         id="test_hp_herings_peeters_example",

--- a/tests/test_hp.py
+++ b/tests/test_hp.py
@@ -1,0 +1,135 @@
+"""Test of calls to the Herings & Peeters (2001) homotopy solver."""
+
+import dataclasses
+import typing
+
+import numpy as np
+import pytest
+
+import pygambit as gbt
+
+TOL = 1e-6
+
+
+def d(*probs) -> tuple:
+    """Helper function to let us write d() to be suggestive of
+    "probability distribution on simplex" ("Delta")
+    """
+    return tuple(probs)
+
+
+@dataclasses.dataclass
+class HPSolverTestCase:
+    """Summarising the data relevant for a test fixture of a call to the HP solver."""
+    factory: typing.Callable[[], gbt.MixedStrategyProfileDouble]
+    expected: list
+    prob_tol: float = TOL
+
+
+def create_hs_base_game() -> gbt.Game:
+    """Creates the base 2x2 game used in all examples from Harsanyi & Selten (1988) Section 4.11
+    and also featured in Herings & Peeters (2001).
+    """
+    p1_payoffs = np.array([[2, 0], [0, 1]])
+    p2_payoffs = np.array([[1, 0], [0, 4]])
+    return gbt.Game.from_arrays(p1_payoffs, p2_payoffs, title="HS 1988 Base Game")
+
+
+def create_hp_paper_example() -> gbt.MixedStrategyProfileDouble:
+    """Creates the example from Herings & Peeters (2001) Figure 1.
+    Also used in Harsanyi & Selten (1988) Section 4.11. -Second Example."""
+    game = create_hs_base_game()
+    prior = game.mixed_strategy_profile()
+    p1, p2 = list(game.players)
+
+    prior[list(p1.strategies)[0]] = 0.5
+    prior[list(p1.strategies)[1]] = 0.5
+    prior[list(p2.strategies)[0]] = 2.0 / 3.0
+    prior[list(p2.strategies)[1]] = 1.0 / 3.0
+
+    return prior
+
+
+def create_hs_example_1() -> gbt.MixedStrategyProfileDouble:
+    """Harsanyi & Selten (1988) Section 4.11 - First Example."""
+    game = create_hs_base_game()
+    prior = game.mixed_strategy_profile()
+    p1, p2 = list(game.players)
+
+    prior[list(p1.strategies)[0]] = 1.0 / 3.0
+    prior[list(p1.strategies)[1]] = 2.0 / 3.0
+    prior[list(p2.strategies)[0]] = 1.0 / 6.0
+    prior[list(p2.strategies)[1]] = 5.0 / 6.0
+
+    return prior
+
+
+def create_t0_degenerate_example() -> gbt.MixedStrategyProfileDouble:
+    """A prior that causes multiple best responses exactly at t=0."""
+    game = create_hs_base_game()
+    prior = game.mixed_strategy_profile()
+    p1, p2 = list(game.players)
+
+    # El prior que descubriste accidentalmente
+    prior[list(p1.strategies)[0]] = 2.0 / 3.0
+    prior[list(p1.strategies)[1]] = 1.0 / 3.0
+    prior[list(p2.strategies)[0]] = 1.0 / 3.0
+    prior[list(p2.strategies)[1]] = 2.0 / 3.0
+
+    return prior
+
+
+HP_CASES = [
+    pytest.param(
+        HPSolverTestCase(
+            factory=create_hp_paper_example,
+            expected=[d(0.8, 0.2), d(1.0 / 3.0, 2.0 / 3.0)],
+        ),
+        marks=pytest.mark.xfail(reason="Mathematical curve tracking not yet fully implemented"),
+        id="test_hp_herings_peeters_example",
+    ),
+    pytest.param(
+        HPSolverTestCase(
+            factory=create_hs_example_1,
+            expected=[d(0.0, 1.0), d(0.0, 1.0)],
+        ),
+        marks=pytest.mark.xfail(reason="Mathematical curve tracking not yet fully implemented"),
+        id="test_hp_hs_example_1",
+    ),
+]
+
+
+@pytest.mark.nash
+@pytest.mark.parametrize("test_case", HP_CASES)
+def test_hp_strategy_solver(test_case: HPSolverTestCase, subtests) -> None:
+    """Test calls of the HP solver with starting priors.
+
+    Subtests:
+    - Number of equilibria found is exactly 1.
+    - Equilibrium profile matches the expected theoretical result.
+    """
+    prior = test_case.factory()
+    game = prior.game
+
+    result = gbt.nash.hp_solve(prior=prior)
+
+    with subtests.test("number of equilibria found"):
+        # The HP method uniquely selects exactly 1 equilibrium.
+        assert len(result.equilibria) == 1
+
+    eq = result.equilibria[0]
+    expected = game.mixed_strategy_profile(rational=False, data=test_case.expected)
+
+    with subtests.test("strategy_profile matches expected"):
+        for player in game.players:
+            for strategy in player.strategies:
+                assert abs(eq[strategy] - expected[strategy]) <= test_case.prob_tol
+
+
+@pytest.mark.nash
+def test_hp_degenerate_t0_prior_raises_error() -> None:
+    """Test that the HP solver correctly identifies when given a degenerate prior."""
+    prior = create_t0_degenerate_example()
+    with pytest.raises(RuntimeError, match="Multiple best responses found for player 1. "
+                       "Only one best response is allowed."):
+        gbt.nash.hp_solve(prior=prior)

--- a/tests/test_hp.py
+++ b/tests/test_hp.py
@@ -84,7 +84,6 @@ HP_CASES = [
             factory=create_hp_paper_example,
             expected=[d(0.0, 1.0), d(0.0, 1.0)],
         ),
-        marks=pytest.mark.xfail(reason="Mathematical curve tracking not yet fully implemented"),
         id="test_hp_herings_peeters_example",
     ),
     pytest.param(
@@ -92,7 +91,6 @@ HP_CASES = [
             factory=create_hs_example_1,
             expected=[d(0.0, 1.0), d(0.0, 1.0)],
         ),
-        marks=pytest.mark.xfail(reason="Mathematical curve tracking not yet fully implemented"),
         id="test_hp_hs_example_1",
     ),
 ]


### PR DESCRIPTION
### Issues closed by this PR
None

### Description of the changes in this PR

1. **Solver Architecture:** Created the new `src/solvers/hp/hpsystem.h` and `src/solvers/hp/hpsystem.cc` files that will have the mathematical implementation of the algorithm.  `src/solvers/hp/hpsystem.h` includes a draft of the declaration of the methods that will be used. 
2. **Variable Transformation:** Implemented the $\sigma(\alpha)$ and $\lambda(\alpha)$ transformations.
3. **Start Point Calculation (`t=0`):** Implemented `HPEquationSystem::ComputeInitialPoint()` to compute the starting vector $(t, \alpha, \mu)$ by finding the best response to the prior belief.
4. **Equilibrium Extraction:** Implemented `HPEquationSystem::ExtractEquilibrium()` to map the final $\alpha$ variables back into a normalized `MixedStrategyProfile<double>`.
5. **PyGambit Update:** Modified`Makefile.am`  to inform about the new files, `gambit.pxd`, `nash.pxi`, and `nash.py`. Now, `pygambit.nash.hp_solve()` receives two parameters: the game and the prior.
6. **`hp.cc`  Update:** Given a game and a prior, it computes the initial point (t=0), writes the vector in "alpha form" (this is provisional) and returns the `MixedStrategyProfile<double>` associated.

 **Important Notes:**
- `tol` being defined as 1e-9 is provisional. It should be scaled according to the proportins of the game. Maybe using a variable `scale` as it is done in `src/solvers/logit/efglogit.cc` would be a nice solution.
- A big problem we may face is that the paper assumes a generic prior generating a strictly unique best response. This will not always be the case, so for now, I have assigned 1 to the first best response found, and 0 to the other tied strategies. However, ths will lead to a crash, since the entire algorithm works assuming that there cannot be two variables alpha being zero at the same time, as especified in page 183. Therefore, we can either warn the user and stop the execution if multiple best responses are found, which is probably not a fine solution, or implement a perturbation method that changes the prior when a degenerate tie is detected,

### How to review this PR
- **Mathematical Logic:** Review `src/solvers/hp/hpsystem.cc` and compare `ComputeInitialPoint()` against the theoretical setup in Section 4 of Herings & Peeters (2001).
- **Testing:**  The next Python script uses the example proposed in the paper. The expected result is [(1,0), (0,1)]
```python
import numpy as np
import pygambit 

p1_payoffs = np.array([[2, 0], [0, 1]])
p2_payoffs = np.array([[1, 0], [0, 4]])
game = pygambit.Game.from_arrays(p1_payoffs, p2_payoffs, title="Harsanyi-Selten")

prior = game.mixed_strategy_profile()


p1 = list(game.players)[0]
p2 = list(game.players)[1]


s1_p1 = list(p1.strategies)[0]
s2_p1 = list(p1.strategies)[1]
s1_p2 = list(p2.strategies)[0]
s2_p2 = list(p2.strategies)[1]

prior[s1_p1] = 0.5
prior[s2_p1] = 0.5
prior[s1_p2] = 2.0 / 3.0
prior[s2_p2] = 1.0 / 3.0

print("Prior:")
print(prior)

resultado = pygambit.nash.hp_solve(game, prior=prior)
print("Final result (probabilities form):")
print(resultado)
```

