### PR TITLE
Enforce optional, unique-when-present labels for nodes and information sets

### DIFF
--- a/src/games/game.h
+++ b/src/games/game.h
@@ -554,11 +554,7 @@ public:
   Game GetGame() const;
 
   const std::string &GetLabel() const { return m_label; }
-  void SetLabel(const std::string &p_label)
-  {
-    CheckLabel(p_label);
-    m_label = p_label;
-  }
+  void SetLabel(const std::string &p_label);
 
   int GetNumber() const;
   GameNode GetChild(const GameAction &p_action)
@@ -1347,6 +1343,22 @@ inline GamePlayerRep::Sequences GamePlayerRep::GetSequences() const
 }
 
 inline Game GameNodeRep::GetGame() const { return m_game->shared_from_this(); }
+inline void GameNodeRep::SetLabel(const std::string &p_label)
+{
+  if (p_label == m_label) {
+    return;
+  }
+  CheckLabel(p_label);
+  // Node labels may be empty, but a non-empty label must be unique within the game.
+  if (!p_label.empty()) {
+    for (const auto &node : GetGame()->GetNodes()) {
+      if (node.get() != this && node->GetLabel() == p_label) {
+        throw ValueException("Node label must be unique within the game");
+      }
+    }
+  }
+  m_label = p_label;
+}
 inline int GameNodeRep::GetNumber() const
 {
   m_game->EnsureNodeOrdering();

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -289,11 +289,7 @@ public:
 
   bool IsChanceInfoset() const;
 
-  void SetLabel(const std::string &p_label)
-  {
-    CheckLabel(p_label);
-    m_label = p_label;
-  }
+  void SetLabel(const std::string &p_label);
   const std::string &GetLabel() const { return m_label; }
 
   /// @name Actions
@@ -1323,6 +1319,23 @@ inline Game GameActionRep::GetGame() const { return m_infoset->GetGame(); }
 
 inline Game GameInfosetRep::GetGame() const { return m_game->shared_from_this(); }
 inline GamePlayer GameInfosetRep::GetPlayer() const { return m_player->shared_from_this(); }
+inline void GameInfosetRep::SetLabel(const std::string &p_label)
+{
+  if (p_label == m_label) {
+    return;
+  }
+  CheckLabel(p_label);
+  // Infoset labels may be empty, but a non-empty label must be unique among
+  // the infosets of the same player.
+  if (!p_label.empty()) {
+    for (const auto &infoset : GetPlayer()->GetInfosets()) {
+      if (infoset.get() != this && infoset->GetLabel() == p_label) {
+        throw ValueException("Infoset label must be unique for the player");
+      }
+    }
+  }
+  m_label = p_label;
+}
 inline bool GameInfosetRep::IsChanceInfoset() const { return m_player->IsChance(); }
 
 inline Game GamePlayerRep::GetGame() const { return m_game->shared_from_this(); }

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -1,5 +1,6 @@
 import dataclasses
 import functools
+import itertools
 import typing
 
 import pytest
@@ -29,6 +30,15 @@ def test_infoset_label_non_ascii_rejected(label):
     game = games.read_from_file("basic_extensive_game.efg")
     with pytest.raises(UnicodeEncodeError):
         game.root.infoset.label = label
+
+
+def test_infoset_label_duplicate_within_player_raises_valueerror():
+    game = games.read_from_file("subgames.efg")
+    player = next(p for p in game.players if sum(1 for _ in p.infosets) >= 2)
+    first, second = itertools.islice(player.infosets, 2)
+    first.label = "shared"
+    with pytest.raises(ValueError):
+        second.label = "shared"
 
 
 def test_infoset_player_retrieval():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1125,6 +1125,22 @@ def test_node_label_valid(label):
     assert game.root.label == label
 
 
+def test_node_label_duplicate_raises_valueerror():
+    game = games.read_from_file("basic_extensive_game.efg")
+    game.root.label = "shared"
+    with pytest.raises(ValueError):
+        game.root.children["U1"].label = "shared"
+
+
+def test_node_label_empty_is_allowed():
+    """Node labels may be empty (unlike outcomes/players); multiple empties coexist."""
+    game = games.read_from_file("basic_extensive_game.efg")
+    game.root.label = ""
+    game.root.children["U1"].label = ""
+    assert game.root.label == ""
+    assert game.root.children["U1"].label == ""
+
+
 @pytest.mark.parametrize("label", games.INVALID_LABELS)
 def test_node_label_invalid_raises_valueerror(label):
     game = games.read_from_file("basic_extensive_game.efg")


### PR DESCRIPTION
Splits out the two "may-be-empty" label scopes from #977 as a self-contained PR.

Nodes and information sets both permit empty labels and enforce uniqueness only for non-empty ones, 
differing only in scope (nodes unique game-wide, infosets per-player). 

The non-empty scopes (players, outcomes, strategies) will follow as separate PRs.

`GameNodeRep::SetLabel` / `GameInfosetRep::SetLabel`: a non-empty label must be valid and unique; 
multiple objects may be unlabeled.