### PR TITLE
Fix a bug in catalog update

### DIFF
--- a/build_support/catalog/test_update.py
+++ b/build_support/catalog/test_update.py
@@ -148,6 +148,57 @@ def _make_image_files(catalog_dir, slug, fmt="efg"):
 
 
 # ---------------------------------------------------------------------------
+# Tests for catalog resource selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.catalog_update
+class TestCatalogResourceSelection:
+    def test_catalog_games_uses_requested_catalog_dir_and_restores_resource(
+        self, tmp_path, monkeypatch
+    ):
+        stale_dir = tmp_path / "installed_catalog_data"
+        checkout_dir = tmp_path / "checkout_catalog"
+        stale_dir.mkdir()
+        checkout_dir.mkdir()
+        calls = []
+
+        def fake_games(**kwargs):
+            calls.append((update.gbt.catalog._CATALOG_RESOURCE, kwargs))
+            return _make_df(_efg_row("checkout/game1"))
+
+        monkeypatch.setattr(update.gbt.catalog, "_CATALOG_RESOURCE", stale_dir)
+        monkeypatch.setattr(update.gbt.catalog, "games", fake_games)
+
+        df = update._catalog_games(checkout_dir)
+
+        assert calls == [(checkout_dir, {"include_descriptions": True})]
+        assert stale_dir == update.gbt.catalog._CATALOG_RESOURCE
+        assert list(df["Game"]) == ["checkout/game1"]
+
+    def test_generate_rst_table_uses_requested_catalog_dir_while_rendering(
+        self, tmp_path, monkeypatch
+    ):
+        stale_dir = tmp_path / "installed_catalog_data"
+        checkout_dir = tmp_path / "checkout_catalog"
+        stale_dir.mkdir()
+        checkout_dir.mkdir()
+        observed = []
+
+        def fake_write_tree_level(*args, **kwargs):
+            observed.append(update.gbt.catalog._CATALOG_RESOURCE)
+
+        monkeypatch.setattr(update.gbt.catalog, "_CATALOG_RESOURCE", stale_dir)
+        monkeypatch.setattr(update, "load_hierarchy_labels", lambda: {})
+        monkeypatch.setattr(update, "_write_tree_level", fake_write_tree_level)
+
+        update.generate_rst_table(_make_df(), tmp_path / "out.rst", catalog_dir=checkout_dir)
+
+        assert observed == [checkout_dir]
+        assert stale_dir == update.gbt.catalog._CATALOG_RESOURCE
+
+
+# ---------------------------------------------------------------------------
 # Tests for catalog_gtdraw_settings
 # ---------------------------------------------------------------------------
 

--- a/build_support/catalog/update.py
+++ b/build_support/catalog/update.py
@@ -1,6 +1,7 @@
 import argparse
 import shutil
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pandas as pd
@@ -15,6 +16,24 @@ MAKEFILE_AM = Path(__file__).parent.parent.parent / "Makefile.am"
 GTDRAW_SETTINGS_CONFIG = Path(__file__).parent / "gtdraw_settings.yaml"
 CATALOG_HIERARCHY_CONFIG = Path(__file__).parent / "catalog_hierarchy.yaml"
 SUPPORTED_GAME_FORMATS = {"efg", "nfg"}
+
+
+@contextmanager
+def _using_catalog_dir(catalog_dir: Path):
+    """Temporarily make pygambit.catalog read data from the checked-out catalog."""
+    old_resource = gbt.catalog._CATALOG_RESOURCE
+    gbt.catalog._CATALOG_RESOURCE = catalog_dir
+    try:
+        yield
+    finally:
+        gbt.catalog._CATALOG_RESOURCE = old_resource
+
+
+def _catalog_games(catalog_dir: Path | None = None) -> pd.DataFrame:
+    """Return catalog games using files from *catalog_dir*, not installed package data."""
+    catalog_dir = catalog_dir or CATALOG_DIR
+    with _using_catalog_dir(catalog_dir):
+        return gbt.catalog.games(include_descriptions=True)
 
 
 def catalog_gtdraw_settings(slug: str) -> dict:
@@ -325,7 +344,7 @@ def generate_rst_table(
     catalog_dir = catalog_dir or CATALOG_DIR
     labels = load_hierarchy_labels()
     tree = _build_slug_tree(df)
-    with open(rst_path, "w", encoding="utf-8") as f:
+    with _using_catalog_dir(catalog_dir), open(rst_path, "w", encoding="utf-8") as f:
         _write_tree_level(
             f, tree, "", labels, catalog_dir, indent="", regenerate_images=regenerate_images
         )
@@ -409,7 +428,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Create RST list-table used by doc/catalog.rst
-    df = gbt.catalog.games(include_descriptions=True)
+    df = _catalog_games()
     _warn_missing_descriptions(df)
     generate_rst_table(df, CATALOG_RST_TABLE, regenerate_images=args.regenerate_images)
     print(f"Generated {CATALOG_RST_TABLE} for use in local docs build. DO NOT COMMIT.")


### PR DESCRIPTION
The bug is that build_support/catalog/update.py does not build a fresh catalog from Git directly. It calls:
`gbt.catalog.games(include_descriptions=True)`, so it uses whatever pygambit your current python imports. If that Python has an old installed/editable pygambit, or an old `build/lib.../pygambit/catalog_data`, it will “remember” deleted games. The remembering is severe: even if one deletes the gambit locally and git clone a new one, reinstalling will still remember old games. Now this has been fixed by updating `update.py`.

The ruff error has also been fixed.