### PR TITLE
Render reduced-strategy labels lazily

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+- Labels for reduced strategies are now rendered lazily on first access rather than
+  eagerly during strategy generation. Strategy labels are unchanged.
+
 ## [16.7.0] - 2026-07-11
 
 ### Added

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [17.0.0] - unreleased
 
 ### Changed
 - Labels for reduced strategies are now rendered lazily on first access rather than

--- a/src/games/game.cc
+++ b/src/games/game.cc
@@ -94,14 +94,8 @@ void GamePlayerRep::MakeStrategy(const std::map<GameInfosetRep *, int> &behav)
 {
   auto strategy = std::make_shared<GameStrategyRep>(this, m_strategies.size() + 1, "");
   strategy->m_behav = behav;
-  for (const auto &infoset : m_infosets) {
-    strategy->m_label += (contains(strategy->m_behav, infoset.get()))
-                             ? std::to_string(strategy->m_behav[infoset.get()])
-                             : "*";
-  }
-  if (strategy->m_label.empty()) {
-    strategy->m_label = "*";
-  }
+  // A derived-label strategy: the text label is rendered from m_behav on the first GetLabel()
+  strategy->m_label.reset();
   m_strategies.push_back(strategy);
 }
 
@@ -305,8 +299,9 @@ MixedStrategyProfile<T>::MixedStrategyProfile(const MixedBehaviorProfile<T> &p_p
     for (const auto &strategy : player->m_strategies) {
       auto prob = static_cast<T>(1);
       for (const auto &infoset : player->m_infosets) {
-        if (strategy->m_behav[infoset.get()] > 0) {
-          prob *= p_profile[infoset->GetAction(strategy->m_behav[infoset.get()])];
+        if (contains(strategy->m_behav, infoset.get()) &&
+            strategy->m_behav.at(infoset.get()) > 0) {
+          prob *= p_profile[infoset->GetAction(strategy->m_behav.at(infoset.get()))];
         }
       }
       (*m_rep)[strategy] = prob;

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -28,6 +28,7 @@
 #include <stack>
 #include <queue>
 #include <memory>
+#include <optional>
 
 #include "number.h"
 #include "gameobject.h"
@@ -343,7 +344,9 @@ class GameStrategyRep : public std::enable_shared_from_this<GameStrategyRep> {
   bool m_valid{true};
   GamePlayerRep *m_player;
   int m_number;
-  std::string m_label;
+  /// Stored label or std::nullopt for a strategy whose label is derived: strategies created by
+  /// GamePlayerRep::MakeStrategy() render a label from m_behav on the first call to GetLabel()
+  mutable std::optional<std::string> m_label;
   std::map<GameInfosetRep *, int> m_behav;
 
 public:
@@ -363,7 +366,7 @@ public:
   /// @name Data access
   //@{
   /// Returns the text label associated with the strategy
-  const std::string &GetLabel() const { return m_label; }
+  const std::string &GetLabel() const;
   /// Sets the text label associated with the strategy
   void SetLabel(const std::string &p_label);
 
@@ -1318,7 +1321,14 @@ inline GamePlayer GameStrategyRep::GetPlayer() const { return m_player->shared_f
 inline Game GameStrategyRep::GetGame() const { return m_player->GetGame(); }
 inline void GameStrategyRep::SetLabel(const std::string &p_label)
 {
-  if (p_label == m_label) {
+  // Compare against GetLabel(), not m_label: a derived-label strategy stores no label,
+  // so the raw comparison is vacuously false and setting a label
+  // equal to the rendered one would fall through to CheckStrategyLabel, where
+  // the strategy would spuriously collide with itself.  (The infoset SetLabel
+  // excludes self with `!= this` inside its own loop; the strategy loop lives
+  // in CheckStrategyLabel, shared with NewStrategy where no self exists yet,
+  // so this early return is the self-exclusion.)
+  if (p_label == GetLabel()) {
     return;
   }
   GetPlayer()->CheckStrategyLabel(p_label);
@@ -1473,6 +1483,19 @@ inline GamePlayerRep::Infosets GamePlayerRep::GetInfosets() const
 }
 
 inline Game GameSubgameRep::GetGame() const { return m_game->shared_from_this(); }
+
+inline const std::string &GameStrategyRep::GetLabel() const
+{
+  if (!m_label) {
+    std::string label;
+    for (const auto &infoset : m_player->GetInfosets()) {
+      const auto action = m_behav.find(infoset.get());
+      label += (action != m_behav.end()) ? std::to_string(action->second) : "*";
+    }
+    m_label = label.empty() ? "*" : std::move(label);
+  }
+  return *m_label;
+}
 
 //=======================================================================
 

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -1321,13 +1321,6 @@ inline GamePlayer GameStrategyRep::GetPlayer() const { return m_player->shared_f
 inline Game GameStrategyRep::GetGame() const { return m_player->GetGame(); }
 inline void GameStrategyRep::SetLabel(const std::string &p_label)
 {
-  // Compare against GetLabel(), not m_label: a derived-label strategy stores no label,
-  // so the raw comparison is vacuously false and setting a label
-  // equal to the rendered one would fall through to CheckStrategyLabel, where
-  // the strategy would spuriously collide with itself.  (The infoset SetLabel
-  // excludes self with `!= this` inside its own loop; the strategy loop lives
-  // in CheckStrategyLabel, shared with NewStrategy where no self exists yet,
-  // so this early return is the self-exclusion.)
   if (p_label == GetLabel()) {
     return;
   }

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -1741,7 +1741,7 @@ Rational TreePureStrategyProfileRep::GetPayoff(const GamePlayer &p_player) const
   for (const auto &player : m_game->GetPlayers()) {
     for (const auto &infoset : player->GetInfosets()) {
       try {
-        behav.SetAction(infoset->GetAction(GetStrategy(player)->m_behav[infoset.get()]));
+        behav.SetAction(infoset->GetAction(GetStrategy(player)->m_behav.at(infoset.get())));
       }
       catch (std::out_of_range &) {
       }


### PR DESCRIPTION
### Description of the changes in this PR

`GamePlayerRep::MakeStrategy` built a text label for every reduced strategy eagerly, scanning all of the 
player's information sets with two map lookups each. The label is often never read, and its construction is 
`O(strategies × infosets)` in time and allocations.

This PR makes it lazy. `GameStrategyRep::m_label` becomes a `mutable std::optional<std::string>`; 
`MakeStrategy` leaves it empty and `GetLabel()` renders from `m_behav` on first access, then caches. 
The rendered text is unchanged.

It also replaces `operator[]` with `contains()`/`at()` on the two paths that read `m_behav` 
(the behavior-to-strategy profile constructor and `TreePureStrategyProfileRep::GetPayoff`). 
`operator[]` inserted a zero for every absent information set, expanding each strategy's map on first read; 
the const-correct access preserves the sparsity `MakeStrategy` produces.

No behavioral change.


