### PR TITLE
Standardise callbacks for Nash computation algorithms

### DIFF
--- a/src/games/nash.h
+++ b/src/games/nash.h
@@ -29,22 +29,16 @@
 namespace Gambit::Nash {
 
 template <class T>
-using StrategyCallbackType =
-    std::function<void(const MixedStrategyProfile<T> &, const std::string &)>;
+using StrategyCallbackType = std::function<void(const MixedStrategyProfile<T> &)>;
 
 /// @brief A fallback callback function for mixed strategy profiles that does nothing
-template <class T> void NullStrategyCallback(const MixedStrategyProfile<T> &, const std::string &)
-{
-}
+template <class T> void NullStrategyCallback(const MixedStrategyProfile<T> &) {}
 
 template <class T>
-using BehaviorCallbackType =
-    std::function<void(const MixedBehaviorProfile<T> &, const std::string &)>;
+using BehaviorCallbackType = std::function<void(const MixedBehaviorProfile<T> &)>;
 
 /// @brief A fallback callback function for mixed behavior profiles that does nothing
-template <class T> void NullBehaviorCallback(const MixedBehaviorProfile<T> &, const std::string &)
-{
-}
+template <class T> void NullBehaviorCallback(const MixedBehaviorProfile<T> &) {}
 
 template <class T>
 std::list<MixedBehaviorProfile<T>>

--- a/src/solvers/enummixed/enummixed.cc
+++ b/src/solvers/enummixed/enummixed.cc
@@ -176,7 +176,7 @@ EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onE
         }
         eqm = eqm.Normalize();
         solution->m_extremeEquilibria.push_back(eqm);
-        p_onEquilibrium(eqm, "NE");
+        p_onEquilibrium(eqm);
 
         // note: The keys give the mixed strategy associated with each node.
         //       The keys should also keep track of the basis

--- a/src/solvers/enumpoly/efgpoly.cc
+++ b/src/solvers/enumpoly/efgpoly.cc
@@ -224,8 +224,8 @@ namespace Gambit::Nash {
 
 std::list<MixedBehaviorProfile<double>>
 EnumPolyBehaviorSolve(const Game &p_game, int p_stopAfter, double p_maxregret,
-                      EnumPolyMixedBehaviorObserverFunctionType p_onEquilibrium,
-                      EnumPolyBehaviorSupportObserverFunctionType p_onSupport)
+                      BehaviorCallbackType<double> p_onEquilibrium,
+                      EnumPolyEventCallbackType<BehaviorSupportProfile> p_onEvent)
 {
   const double scale = p_game->GetMaxPayoff() - p_game->GetMinPayoff();
   if (scale != 0.0) {
@@ -236,16 +236,16 @@ EnumPolyBehaviorSolve(const Game &p_game, int p_stopAfter, double p_maxregret,
   auto possible_supports = PossibleNashBehaviorSupports(p_game);
 
   for (auto support : possible_supports->m_supports) {
-    p_onSupport("candidate", support);
+    p_onEvent(EnumPolyCandidateSupportEvent<BehaviorSupportProfile>{support});
     bool isSingular = false;
     for (const auto &solution :
          SolveSupport(support, isSingular, std::max(p_stopAfter - static_cast<int>(ret.size()), 0),
                       p_maxregret)) {
-      p_onEquilibrium(solution);
+      p_onEquilibrium(solution, "NE");
       ret.push_back(solution);
     }
     if (isSingular) {
-      p_onSupport("singular", support);
+      p_onEvent(EnumPolySingularSupportEvent<BehaviorSupportProfile>{support});
     }
     if (p_stopAfter > 0 && static_cast<int>(ret.size()) >= p_stopAfter) {
       break;

--- a/src/solvers/enumpoly/efgpoly.cc
+++ b/src/solvers/enumpoly/efgpoly.cc
@@ -241,7 +241,7 @@ EnumPolyBehaviorSolve(const Game &p_game, int p_stopAfter, double p_maxregret,
     for (const auto &solution :
          SolveSupport(support, isSingular, std::max(p_stopAfter - static_cast<int>(ret.size()), 0),
                       p_maxregret)) {
-      p_onEquilibrium(solution, "NE");
+      p_onEquilibrium(solution);
       ret.push_back(solution);
     }
     if (isSingular) {

--- a/src/solvers/enumpoly/enumpoly.h
+++ b/src/solvers/enumpoly/enumpoly.h
@@ -24,46 +24,41 @@
 #ifndef GAMBIT_SOLVERS_ENUMPOLY_ENUMPOLY_H
 #define GAMBIT_SOLVERS_ENUMPOLY_ENUMPOLY_H
 
+#include <variant>
+
 #include "games/nash.h"
 #include "solvers/nashsupport/nashsupport.h"
 
 namespace Gambit::Nash {
 
-using EnumPolyMixedStrategyObserverFunctionType =
-    std::function<void(const MixedStrategyProfile<double> &)>;
+template <class Support> struct EnumPolyCandidateSupportEvent {
+  const Support &support;
+};
 
-inline void EnumPolyNullMixedStrategyObserver(const MixedStrategyProfile<double> &) {}
+template <class Support> struct EnumPolySingularSupportEvent {
+  const Support &support;
+};
 
-using EnumPolyStrategySupportObserverFunctionType =
-    std::function<void(const std::string &, const StrategySupportProfile &)>;
+template <class Support>
+using EnumPolyEvent =
+    std::variant<EnumPolyCandidateSupportEvent<Support>, EnumPolySingularSupportEvent<Support>>;
 
-inline void EnumPolyNullStrategySupportObserver(const std::string &,
-                                                const StrategySupportProfile &)
-{
-}
+template <class Support>
+using EnumPolyEventCallbackType = std::function<void(const EnumPolyEvent<Support> &)>;
 
-std::list<MixedStrategyProfile<double>> EnumPolyStrategySolve(
-    const Game &p_game, int p_stopAfter, double p_maxregret,
-    EnumPolyMixedStrategyObserverFunctionType p_onEquilibrium = EnumPolyNullMixedStrategyObserver,
-    EnumPolyStrategySupportObserverFunctionType p_onSupport = EnumPolyNullStrategySupportObserver);
+template <class Support> void NullEnumPolyEventCallback(const EnumPolyEvent<Support> &) {}
 
-using EnumPolyMixedBehaviorObserverFunctionType =
-    std::function<void(const MixedBehaviorProfile<double> &)>;
+std::list<MixedStrategyProfile<double>>
+EnumPolyStrategySolve(const Game &p_game, int p_stopAfter, double p_maxregret,
+                      StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>,
+                      EnumPolyEventCallbackType<StrategySupportProfile> p_onEvent =
+                          NullEnumPolyEventCallback<StrategySupportProfile>);
 
-inline void EnumPolyNullMixedBehaviorObserver(const MixedBehaviorProfile<double> &) {}
-
-using EnumPolyBehaviorSupportObserverFunctionType =
-    std::function<void(const std::string &, const BehaviorSupportProfile &)>;
-
-inline void EnumPolyNullBehaviorSupportObserver(const std::string &,
-                                                const BehaviorSupportProfile &)
-{
-}
-
-std::list<MixedBehaviorProfile<double>> EnumPolyBehaviorSolve(
-    const Game &, int p_stopAfter, double p_maxregret,
-    EnumPolyMixedBehaviorObserverFunctionType p_onEquilibrium = EnumPolyNullMixedBehaviorObserver,
-    EnumPolyBehaviorSupportObserverFunctionType p_onSupport = EnumPolyNullBehaviorSupportObserver);
+std::list<MixedBehaviorProfile<double>>
+EnumPolyBehaviorSolve(const Game &, int p_stopAfter, double p_maxregret,
+                      BehaviorCallbackType<double> p_onEquilibrium = NullBehaviorCallback<double>,
+                      EnumPolyEventCallbackType<BehaviorSupportProfile> p_onEvent =
+                          NullEnumPolyEventCallback<BehaviorSupportProfile>);
 
 } // namespace Gambit::Nash
 

--- a/src/solvers/enumpoly/nfgpoly.cc
+++ b/src/solvers/enumpoly/nfgpoly.cc
@@ -158,7 +158,7 @@ EnumPolyStrategySolve(const Game &p_game, int p_stopAfter, double p_maxregret,
              support, is_singular, std::max(p_stopAfter - static_cast<int>(ret.size()), 0))) {
       const MixedStrategyProfile<double> fullProfile = solution.ToFullSupport();
       if (fullProfile.GetMaxRegret() < p_maxregret) {
-        p_onEquilibrium(fullProfile, "NE");
+        p_onEquilibrium(fullProfile);
         ret.push_back(fullProfile);
       }
     }

--- a/src/solvers/enumpoly/nfgpoly.cc
+++ b/src/solvers/enumpoly/nfgpoly.cc
@@ -140,8 +140,8 @@ EnumPolyStrategySupportSolve(const StrategySupportProfile &support, bool &is_sin
 
 std::list<MixedStrategyProfile<double>>
 EnumPolyStrategySolve(const Game &p_game, int p_stopAfter, double p_maxregret,
-                      EnumPolyMixedStrategyObserverFunctionType p_onEquilibrium,
-                      EnumPolyStrategySupportObserverFunctionType p_onSupport)
+                      StrategyCallbackType<double> p_onEquilibrium,
+                      EnumPolyEventCallbackType<StrategySupportProfile> p_onEvent)
 {
   const double scale = p_game->GetMaxPayoff() - p_game->GetMinPayoff();
   if (scale != 0.0) {
@@ -152,19 +152,19 @@ EnumPolyStrategySolve(const Game &p_game, int p_stopAfter, double p_maxregret,
   auto possible_supports = PossibleNashStrategySupports(p_game);
 
   for (auto support : possible_supports->m_supports) {
-    p_onSupport("candidate", support);
+    p_onEvent(EnumPolyCandidateSupportEvent<StrategySupportProfile>{support});
     bool is_singular;
     for (auto solution : EnumPolyStrategySupportSolve(
              support, is_singular, std::max(p_stopAfter - static_cast<int>(ret.size()), 0))) {
       const MixedStrategyProfile<double> fullProfile = solution.ToFullSupport();
       if (fullProfile.GetMaxRegret() < p_maxregret) {
-        p_onEquilibrium(fullProfile);
+        p_onEquilibrium(fullProfile, "NE");
         ret.push_back(fullProfile);
       }
     }
 
     if (is_singular) {
-      p_onSupport("singular", support);
+      p_onEvent(EnumPolySingularSupportEvent<StrategySupportProfile>{support});
     }
     if (p_stopAfter > 0 && static_cast<int>(ret.size()) >= p_stopAfter) {
       break;

--- a/src/solvers/enumpure/enumpure.h
+++ b/src/solvers/enumpure/enumpure.h
@@ -56,7 +56,7 @@ inline std::list<MixedStrategyProfile<Rational>> EnumPureStrategySolve(
   for (const auto &profile : StrategyContingencies(p_game)) {
     if (IsNash(profile)) {
       solutions.push_back(profile->ToMixedStrategyProfile());
-      p_onEquilibrium(solutions.back(), "NE");
+      p_onEquilibrium(solutions.back());
     }
   }
   return solutions;
@@ -95,7 +95,7 @@ EnumPureAgentSolve(const Game &p_game,
   for (auto citer : BehaviorContingencies(BehaviorSupportProfile(p_game))) {
     if (IsAgentNash(citer)) {
       solutions.push_back(citer.ToMixedBehaviorProfile());
-      p_onEquilibrium(solutions.back(), "NE");
+      p_onEquilibrium(solutions.back());
     }
   }
   return solutions;

--- a/src/solvers/gnm/gnm.cc
+++ b/src/solvers/gnm/gnm.cc
@@ -33,7 +33,7 @@ namespace {
 std::list<MixedStrategyProfile<double>>
 Solve(const Game &p_game, const std::shared_ptr<gnmgame> &p_rep, const cvector &p_pert,
       double p_lambdaEnd, int p_steps, int p_localNewtonInterval, int p_localNewtonMaxits,
-      std::function<void(const MixedStrategyProfile<double> &, const std::string &)> &p_callback)
+      Nash::StrategyCallbackType<double> p_onEquilibrium, Nash::GNMEventCallbackType p_onEvent)
 {
   const double FUZZ = 1e-12;
   const bool WOBBLE = false;
@@ -49,12 +49,23 @@ Solve(const Game &p_game, const std::shared_ptr<gnmgame> &p_rep, const cvector &
     throw UndefinedException("Perturbation vector must have at least one nonzero component.");
   }
   std::list<MixedStrategyProfile<double>> eqa;
-  p_callback(ToProfile(p_game, p_pert), "pert");
+  const auto perturbation = ToProfile(p_game, p_pert);
+  p_onEvent(Nash::GNMPerturbationEvent{perturbation});
   cvector norm_pert = p_pert / p_pert.norm();
   std::list<cvector> answers;
   std::string return_message;
-  auto callback = [p_game, p_callback](const std::string &label, const cvector &sigma) {
-    p_callback(ToProfile(p_game, sigma), label);
+  auto callback = [p_game, p_onEquilibrium, p_onEvent](const std::string &label,
+                                                       const cvector &sigma) {
+    const auto profile = ToProfile(p_game, sigma);
+    if (label == "NE") {
+      p_onEquilibrium(profile, label);
+    }
+    else if (label == "start") {
+      p_onEvent(Nash::GNMStartEvent{profile});
+    }
+    else {
+      p_onEvent(Nash::GNMStepEvent{profile, std::stod(label)});
+    }
   };
   GNM(*p_rep, norm_pert, answers, p_steps, FUZZ, p_localNewtonInterval, p_localNewtonMaxits,
       p_lambdaEnd, WOBBLE, THRESHOLD, callback, return_message);
@@ -68,10 +79,10 @@ Solve(const Game &p_game, const std::shared_ptr<gnmgame> &p_rep, const cvector &
 
 namespace Gambit::Nash {
 
-std::list<MixedStrategyProfile<double>> GNMStrategySolve(const Game &p_game, double p_lambdaEnd,
-                                                         int p_steps, int p_localNewtonInterval,
-                                                         int p_localNewtonMaxits,
-                                                         StrategyCallbackType<double> p_callback)
+std::list<MixedStrategyProfile<double>>
+GNMStrategySolve(const Game &p_game, double p_lambdaEnd, int p_steps, int p_localNewtonInterval,
+                 int p_localNewtonMaxits, StrategyCallbackType<double> p_onEquilibrium,
+                 GNMEventCallbackType p_onEvent)
 {
   if (!p_game->IsPerfectRecall()) {
     throw UndefinedException(
@@ -88,13 +99,13 @@ std::list<MixedStrategyProfile<double>> GNMStrategySolve(const Game &p_game, dou
     pert[player->GetStrategies().front()] = 1.0;
   }
   return Solve(p_game, A, ToPerturbation(pert), p_lambdaEnd, p_steps, p_localNewtonInterval,
-               p_localNewtonMaxits, p_callback);
+               p_localNewtonMaxits, p_onEquilibrium, p_onEvent);
 }
 
 std::list<MixedStrategyProfile<double>>
 GNMStrategySolve(const MixedStrategyProfile<double> &p_pert, double p_lambdaEnd, int p_steps,
                  int p_localNewtonInterval, int p_localNewtonMaxits,
-                 StrategyCallbackType<double> p_callback)
+                 StrategyCallbackType<double> p_onEquilibrium, GNMEventCallbackType p_onEvent)
 {
   if (!p_pert.GetGame()->IsPerfectRecall()) {
     throw UndefinedException(
@@ -102,7 +113,7 @@ GNMStrategySolve(const MixedStrategyProfile<double> &p_pert, double p_lambdaEnd,
   }
   const std::shared_ptr<gnmgame> A = BuildGame(p_pert.GetGame(), true);
   return Solve(p_pert.GetGame(), A, ToPerturbation(p_pert), p_lambdaEnd, p_steps,
-               p_localNewtonInterval, p_localNewtonMaxits, p_callback);
+               p_localNewtonInterval, p_localNewtonMaxits, p_onEquilibrium, p_onEvent);
 }
 
 } // end namespace Gambit::Nash

--- a/src/solvers/gnm/gnm.cc
+++ b/src/solvers/gnm/gnm.cc
@@ -58,7 +58,7 @@ Solve(const Game &p_game, const std::shared_ptr<gnmgame> &p_rep, const cvector &
                                                        const cvector &sigma) {
     const auto profile = ToProfile(p_game, sigma);
     if (label == "NE") {
-      p_onEquilibrium(profile, label);
+      p_onEquilibrium(profile);
     }
     else if (label == "start") {
       p_onEvent(Nash::GNMStartEvent{profile});

--- a/src/solvers/gnm/gnm.h
+++ b/src/solvers/gnm/gnm.h
@@ -23,6 +23,8 @@
 #ifndef GAMBIT_NASH_GNM_H
 #define GAMBIT_NASH_GNM_H
 
+#include <variant>
+
 #include "games/nash.h"
 #include "solvers/gtracer/gtracer.h"
 
@@ -33,17 +35,37 @@ const int GNM_LOCAL_NEWTON_INTERVAL_DEFAULT = 3;
 const int GNM_LOCAL_NEWTON_MAXITS_DEFAULT = 10;
 const int GNM_STEPS_DEFAULT = 100;
 
+struct GNMPerturbationEvent {
+  const MixedStrategyProfile<double> &profile;
+};
+
+struct GNMStartEvent {
+  const MixedStrategyProfile<double> &profile;
+};
+
+struct GNMStepEvent {
+  const MixedStrategyProfile<double> &profile;
+  double lambda;
+};
+
+using GNMEvent = std::variant<GNMPerturbationEvent, GNMStartEvent, GNMStepEvent>;
+using GNMEventCallbackType = std::function<void(const GNMEvent &)>;
+
+inline void NullGNMEventCallback(const GNMEvent &) {}
+
 std::list<MixedStrategyProfile<double>>
 GNMStrategySolve(const Game &p_game, double p_lambdaEnd, int p_steps, int p_localNewtonInterval,
                  int p_localNewtonMaxits,
-                 StrategyCallbackType<double> p_callback = NullStrategyCallback<double>);
+                 StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>,
+                 GNMEventCallbackType p_onEvent = NullGNMEventCallback);
 
 /// @brief Compute the mixed strategy equilibria accessible via the initial ray determined
 ///        by \p p_profile using the Global Newton method
 std::list<MixedStrategyProfile<double>>
 GNMStrategySolve(const MixedStrategyProfile<double> &p_profile, double p_lambdaEnd, int p_steps,
                  int p_localNewtonInterval, int p_localNewtonMaxits,
-                 StrategyCallbackType<double> p_callback = NullStrategyCallback<double>);
+                 StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>,
+                 GNMEventCallbackType p_onEvent = NullGNMEventCallback);
 
 } // end namespace Gambit::Nash
 

--- a/src/solvers/ipa/ipa.cc
+++ b/src/solvers/ipa/ipa.cc
@@ -67,7 +67,7 @@ IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
 
   std::list<MixedStrategyProfile<double>> solutions;
   solutions.push_back(ToProfile(p_pert.GetGame(), ans));
-  p_onEquilibrium(solutions.back(), "NE");
+  p_onEquilibrium(solutions.back());
   return solutions;
 }
 

--- a/src/solvers/ipa/ipa.cc
+++ b/src/solvers/ipa/ipa.cc
@@ -29,8 +29,8 @@ using namespace Gambit::gametracer;
 
 namespace Gambit::Nash {
 
-std::list<MixedStrategyProfile<double>> IPAStrategySolve(const Game &p_game,
-                                                         StrategyCallbackType<double> p_callback)
+std::list<MixedStrategyProfile<double>>
+IPAStrategySolve(const Game &p_game, StrategyCallbackType<double> p_onEquilibrium)
 {
   MixedStrategyProfile<double> pert = p_game->NewMixedStrategyProfile(0.0);
   for (const auto &player : p_game->GetPlayers()) {
@@ -41,12 +41,12 @@ std::list<MixedStrategyProfile<double>> IPAStrategySolve(const Game &p_game,
   for (auto player : p_game->GetPlayers()) {
     pert[player->GetStrategies().front()] = 1.0;
   }
-  return IPAStrategySolve(pert, p_callback);
+  return IPAStrategySolve(pert, p_onEquilibrium);
 }
 
 std::list<MixedStrategyProfile<double>>
 IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
-                 StrategyCallbackType<double> p_callback)
+                 StrategyCallbackType<double> p_onEquilibrium)
 {
   if (!p_pert.GetGame()->IsPerfectRecall()) {
     throw UndefinedException(
@@ -67,7 +67,7 @@ IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
 
   std::list<MixedStrategyProfile<double>> solutions;
   solutions.push_back(ToProfile(p_pert.GetGame(), ans));
-  p_callback(solutions.back(), "NE");
+  p_onEquilibrium(solutions.back(), "NE");
   return solutions;
 }
 

--- a/src/solvers/ipa/ipa.h
+++ b/src/solvers/ipa/ipa.h
@@ -29,11 +29,11 @@ namespace Gambit::Nash {
 
 std::list<MixedStrategyProfile<double>>
 IPAStrategySolve(const Game &p_game,
-                 StrategyCallbackType<double> p_callback = NullStrategyCallback<double>);
+                 StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>);
 
 std::list<MixedStrategyProfile<double>>
 IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
-                 StrategyCallbackType<double> p_callback = NullStrategyCallback<double>);
+                 StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>);
 
 } // namespace Gambit::Nash
 

--- a/src/solvers/lcp/efglcp.cc
+++ b/src/solvers/lcp/efglcp.cc
@@ -152,7 +152,7 @@ std::list<MixedBehaviorProfile<T>> NashLcpBehaviorSolver<T>::Solve(const Game &p
   GetProfile(tab, profile, sol, p_game->GetRoot(), 1, 1, solution);
   profile.UndefinedToCentroid();
   solution.m_equilibria.push_back(profile);
-  this->m_onEquilibrium(profile, "NE");
+  this->m_onEquilibrium(profile);
   return solution.m_equilibria;
 }
 

--- a/src/solvers/lcp/nfglcp.cc
+++ b/src/solvers/lcp/nfglcp.cc
@@ -203,7 +203,7 @@ NashLcpStrategySolver<T>::OnBFS(const Game &p_game, linalg::LHTableau<T> &p_tabl
     }
   }
 
-  m_onEquilibrium(profile, "NE");
+  m_onEquilibrium(profile);
   p_solution.m_equilibria.push_back(profile);
 
   if (m_stopAfter > 0 && p_solution.EquilibriumCount() >= m_stopAfter) {

--- a/src/solvers/liap/efgliap.cc
+++ b/src/solvers/liap/efgliap.cc
@@ -127,9 +127,10 @@ MixedBehaviorProfile<double> EnforceNonnegativity(const MixedBehaviorProfile<dou
 
 } // namespace
 
-std::list<MixedBehaviorProfile<double>> LiapAgentSolve(const MixedBehaviorProfile<double> &p_start,
-                                                       double p_maxregret, int p_maxitsN,
-                                                       BehaviorCallbackType<double> p_callback)
+std::list<MixedBehaviorProfile<double>>
+LiapAgentSolve(const MixedBehaviorProfile<double> &p_start, double p_maxregret, int p_maxitsN,
+               BehaviorCallbackType<double> p_onEquilibrium,
+               LiapEventCallbackType<MixedBehaviorProfile<double>> p_onEvent)
 {
   if (!p_start.GetGame()->IsPerfectRecall()) {
     throw UndefinedException(
@@ -139,7 +140,7 @@ std::list<MixedBehaviorProfile<double>> LiapAgentSolve(const MixedBehaviorProfil
   std::list<MixedBehaviorProfile<double>> solutions;
 
   MixedBehaviorProfile<double> p(p_start);
-  p_callback(p, "start");
+  p_onEvent(LiapStartEvent<MixedBehaviorProfile<double>>{p});
 
   const AgentLyapunovFunction F(p);
   const Matrix<double> xi(p.BehaviorProfileLength(), p.BehaviorProfileLength());
@@ -160,12 +161,13 @@ std::list<MixedBehaviorProfile<double>> LiapAgentSolve(const MixedBehaviorProfil
   }
 
   auto p2 = EnforceNonnegativity(p);
-  if (p2.GetAgentMaxRegret() * F.GetScale() < p_maxregret) {
-    p_callback(p2, "NE");
+  const double regret = p2.GetAgentMaxRegret() * F.GetScale();
+  if (regret < p_maxregret) {
+    p_onEquilibrium(p2, "NE");
     solutions.push_back(p2);
   }
   else {
-    p_callback(p2, "end");
+    p_onEvent(LiapEndEvent<MixedBehaviorProfile<double>>{p2, regret});
   }
   return solutions;
 }

--- a/src/solvers/liap/efgliap.cc
+++ b/src/solvers/liap/efgliap.cc
@@ -163,7 +163,7 @@ LiapAgentSolve(const MixedBehaviorProfile<double> &p_start, double p_maxregret, 
   auto p2 = EnforceNonnegativity(p);
   const double regret = p2.GetAgentMaxRegret() * F.GetScale();
   if (regret < p_maxregret) {
-    p_onEquilibrium(p2, "NE");
+    p_onEquilibrium(p2);
     solutions.push_back(p2);
   }
   else {

--- a/src/solvers/liap/liap.h
+++ b/src/solvers/liap/liap.h
@@ -23,17 +23,39 @@
 #ifndef GAMBIT_NASH_LIAP_H
 #define GAMBIT_NASH_LIAP_H
 
+#include <variant>
 #include "games/nash.h"
 
 namespace Gambit::Nash {
 
+template <class Profile> struct LiapStartEvent {
+  const Profile &profile;
+};
+
+template <class Profile> struct LiapEndEvent {
+  const Profile &profile;
+  double regret;
+};
+
+template <class Profile>
+using LiapEvent = std::variant<LiapStartEvent<Profile>, LiapEndEvent<Profile>>;
+
+template <class Profile>
+using LiapEventCallbackType = std::function<void(const LiapEvent<Profile> &)>;
+
+template <class Profile> void NullLiapEventCallback(const LiapEvent<Profile> &) {}
+
 std::list<MixedBehaviorProfile<double>>
 LiapAgentSolve(const MixedBehaviorProfile<double> &p_start, double p_maxregret, int p_maxitsN,
-               BehaviorCallbackType<double> p_callback = NullBehaviorCallback<double>);
+               BehaviorCallbackType<double> p_onEquilibrium = NullBehaviorCallback<double>,
+               LiapEventCallbackType<MixedBehaviorProfile<double>> p_onEvent =
+                   NullLiapEventCallback<MixedBehaviorProfile<double>>);
 
 std::list<MixedStrategyProfile<double>>
 LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregret, int p_maxitsN,
-                  StrategyCallbackType<double> p_callback = NullStrategyCallback<double>);
+                  StrategyCallbackType<double> p_onEquilibrium = NullStrategyCallback<double>,
+                  LiapEventCallbackType<MixedStrategyProfile<double>> p_onEvent =
+                      NullLiapEventCallback<MixedStrategyProfile<double>>);
 
 } // namespace Gambit::Nash
 

--- a/src/solvers/liap/nfgliap.cc
+++ b/src/solvers/liap/nfgliap.cc
@@ -135,7 +135,8 @@ MixedStrategyProfile<double> EnforceNonnegativity(const MixedStrategyProfile<dou
 
 std::list<MixedStrategyProfile<double>>
 LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregret, int p_maxitsN,
-                  StrategyCallbackType<double> p_callback)
+                  StrategyCallbackType<double> p_onEquilibrium,
+                  LiapEventCallbackType<MixedStrategyProfile<double>> p_onEvent)
 {
   if (!p_start.GetGame()->IsPerfectRecall()) {
     throw UndefinedException(
@@ -145,7 +146,7 @@ LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregre
   std::list<MixedStrategyProfile<double>> solutions;
 
   MixedStrategyProfile<double> p(p_start);
-  p_callback(p, "start");
+  p_onEvent(LiapStartEvent<MixedStrategyProfile<double>>{p});
 
   const StrategicLyapunovFunction F(p);
   ConjugatePRMinimizer minimizer(p.MixedProfileLength());
@@ -165,12 +166,13 @@ LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregre
   }
 
   p = EnforceNonnegativity(p);
-  if (p.GetMaxRegret() * F.GetScale() < p_maxregret) {
-    p_callback(p, "NE");
+  const double regret = p.GetMaxRegret() * F.GetScale();
+  if (regret < p_maxregret) {
+    p_onEquilibrium(p, "NE");
     solutions.push_back(p);
   }
   else {
-    p_callback(p, "end");
+    p_onEvent(LiapEndEvent<MixedStrategyProfile<double>>{p, regret});
   }
 
   return solutions;

--- a/src/solvers/liap/nfgliap.cc
+++ b/src/solvers/liap/nfgliap.cc
@@ -168,7 +168,7 @@ LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregre
   p = EnforceNonnegativity(p);
   const double regret = p.GetMaxRegret() * F.GetScale();
   if (regret < p_maxregret) {
-    p_onEquilibrium(p, "NE");
+    p_onEquilibrium(p);
     solutions.push_back(p);
   }
   else {

--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -244,8 +244,9 @@ void EquationSystem::GetJacobian(const Vector<double> &p_point, Matrix<double> &
 
 class TracingCallbackFunction {
 public:
-  TracingCallbackFunction(const Game &p_game, MixedBehaviorObserverFunctionType p_observer)
-    : m_game(p_game), m_observer(p_observer)
+  TracingCallbackFunction(const Game &p_game,
+                          LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
+    : m_game(p_game), m_onEvent(p_onEvent)
   {
   }
   ~TracingCallbackFunction() = default;
@@ -255,7 +256,7 @@ public:
 
 private:
   Game m_game;
-  MixedBehaviorObserverFunctionType m_observer;
+  LogitEventCallbackType<LogitQREMixedBehaviorProfile> m_onEvent;
   std::list<LogitQREMixedBehaviorProfile> m_profiles;
 };
 
@@ -263,13 +264,13 @@ void TracingCallbackFunction::AppendPoint(const Vector<double> &p_point)
 {
   const MixedBehaviorProfile<double> profile(PointToProfile(m_game, p_point));
   m_profiles.emplace_back(profile, p_point.back(), 1.0);
-  m_observer(m_profiles.back());
+  m_onEvent(LogitPathEvent<LogitQREMixedBehaviorProfile>{m_profiles.back()});
 }
 
 class EstimatorCallbackFunction {
 public:
   EstimatorCallbackFunction(const Game &p_game, const Vector<double> &p_frequencies,
-                            MixedBehaviorObserverFunctionType p_observer);
+                            LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent);
   ~EstimatorCallbackFunction() = default;
 
   void EvaluatePoint(const Vector<double> &p_point);
@@ -278,14 +279,14 @@ public:
 private:
   Game m_game;
   const Vector<double> &m_frequencies;
-  MixedBehaviorObserverFunctionType m_observer;
+  LogitEventCallbackType<LogitQREMixedBehaviorProfile> m_onEvent;
   LogitQREMixedBehaviorProfile m_bestProfile;
 };
 
-EstimatorCallbackFunction::EstimatorCallbackFunction(const Game &p_game,
-                                                     const Vector<double> &p_frequencies,
-                                                     MixedBehaviorObserverFunctionType p_observer)
-  : m_game(p_game), m_frequencies(p_frequencies), m_observer(p_observer),
+EstimatorCallbackFunction::EstimatorCallbackFunction(
+    const Game &p_game, const Vector<double> &p_frequencies,
+    LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
+  : m_game(p_game), m_frequencies(p_frequencies), m_onEvent(p_onEvent),
     m_bestProfile(MixedBehaviorProfile<double>(p_game), 0.0,
                   LogLike(p_frequencies, static_cast<const Vector<double> &>(
                                              MixedBehaviorProfile<double>(p_game))))
@@ -298,7 +299,7 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
   auto qre = LogitQREMixedBehaviorProfile(
       profile, p_point.back(),
       LogLike(m_frequencies, static_cast<const Vector<double> &>(profile)));
-  m_observer(qre);
+  m_onEvent(LogitPathEvent<LogitQREMixedBehaviorProfile>{qre});
   if (qre.GetLogLike() > m_bestProfile.GetLogLike()) {
     m_bestProfile = qre;
   }
@@ -311,7 +312,8 @@ namespace Gambit {
 std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
                    double p_firstStep, double p_maxAccel,
-                   MixedBehaviorObserverFunctionType p_observer)
+                   Nash::BehaviorCallbackType<double> p_onEquilibrium,
+                   LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -326,7 +328,7 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
   }
   const Game game = p_start.GetGame();
   Vector<double> x(ProfileToPoint(p_start));
-  TracingCallbackFunction callback(game, p_observer);
+  TracingCallbackFunction callback(game, p_onEvent);
   EquationSystem system(game);
   tracer.TracePath(
       [&system](const Vector<double> &p_point, Vector<double> &p_lhs) {
@@ -340,14 +342,16 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
         return RegretTerminationFunction(game, p_point, p_regret);
       },
       [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
-  return callback.GetProfiles();
+  const auto &profiles = callback.GetProfiles();
+  p_onEquilibrium(profiles.back().GetProfile(), "NE");
+  return profiles;
 }
 
 std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
                          const std::list<double> &p_targetLambda, double p_omega,
                          double p_firstStep, double p_maxAccel,
-                         MixedBehaviorObserverFunctionType p_observer)
+                         LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -358,7 +362,7 @@ LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
 
   const Game game = p_start.GetGame();
   Vector<double> x(ProfileToPoint(p_start));
-  TracingCallbackFunction callback(game, p_observer);
+  TracingCallbackFunction callback(game, p_onEvent);
   EquationSystem system(game);
   std::list<LogitQREMixedBehaviorProfile> ret;
   for (auto lam : p_targetLambda) {
@@ -382,7 +386,7 @@ LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
 LogitQREMixedBehaviorProfile
 LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double p_maxLambda,
                       double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
-                      MixedBehaviorObserverFunctionType p_observer)
+                      LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
 {
   const LogitQREMixedBehaviorProfile start(p_frequencies.GetGame());
   if (start.size() == 0) {
@@ -395,7 +399,7 @@ LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double 
   Vector<double> x(ProfileToPoint(start)), restart(x);
   const Vector<double> freq_vector(static_cast<const Vector<double> &>(p_frequencies));
   EstimatorCallbackFunction callback(
-      start.GetGame(), static_cast<const Vector<double> &>(p_frequencies), p_observer);
+      start.GetGame(), static_cast<const Vector<double> &>(p_frequencies), p_onEvent);
   EquationSystem system(start.GetGame());
   while (true) {
     tracer.TracePath(

--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -343,7 +343,7 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
       },
       [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
   const auto &profiles = callback.GetProfiles();
-  p_onEquilibrium(profiles.back().GetProfile(), "NE");
+  p_onEquilibrium(profiles.back().GetProfile());
   return profiles;
 }
 

--- a/src/solvers/logit/logit.h
+++ b/src/solvers/logit/logit.h
@@ -24,6 +24,9 @@
 #define SOLVERS_LOGIT_H
 
 #include <functional>
+#include <variant>
+
+#include "games/nash.h"
 
 namespace Gambit {
 
@@ -79,48 +82,56 @@ template <> inline size_t LogitQRE<MixedBehaviorProfile<double>>::size() const
 
 using LogitQREMixedStrategyProfile = LogitQRE<MixedStrategyProfile<double>>;
 
-using MixedStrategyObserverFunctionType =
-    std::function<void(const LogitQREMixedStrategyProfile &)>;
+template <class QRE> struct LogitPathEvent {
+  const QRE &qre;
+};
 
-inline void NullMixedStrategyObserver(const LogitQREMixedStrategyProfile &) {}
+template <class QRE> using LogitEvent = std::variant<LogitPathEvent<QRE>>;
+template <class QRE> using LogitEventCallbackType = std::function<void(const LogitEvent<QRE> &)>;
+
+template <class QRE> void NullLogitEventCallback(const LogitEvent<QRE> &) {}
 
 std::list<LogitQREMixedStrategyProfile> LogitStrategySolve(
     const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
     double p_firstStep, double p_maxAccel,
-    const MixedStrategyObserverFunctionType &p_observer = NullMixedStrategyObserver);
+    Nash::StrategyCallbackType<double> p_onEquilibrium = Nash::NullStrategyCallback<double>,
+    LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent =
+        NullLogitEventCallback<LogitQREMixedStrategyProfile>);
 
-std::list<LogitQREMixedStrategyProfile> LogitStrategySolveLambda(
-    const LogitQREMixedStrategyProfile &p_start, const std::list<double> &p_targetLambda,
-    double p_omega, double p_firstStep, double p_maxAccel,
-    const MixedStrategyObserverFunctionType &p_observer = NullMixedStrategyObserver);
+std::list<LogitQREMixedStrategyProfile>
+LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
+                         const std::list<double> &p_targetLambda, double p_omega,
+                         double p_firstStep, double p_maxAccel,
+                         LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent =
+                             NullLogitEventCallback<LogitQREMixedStrategyProfile>);
 
 LogitQREMixedStrategyProfile
 LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double p_maxLambda,
                       double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
-                      MixedStrategyObserverFunctionType p_observer = NullMixedStrategyObserver);
+                      LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent =
+                          NullLogitEventCallback<LogitQREMixedStrategyProfile>);
 
 using LogitQREMixedBehaviorProfile = LogitQRE<MixedBehaviorProfile<double>>;
 
-using MixedBehaviorObserverFunctionType =
-    std::function<void(const LogitQREMixedBehaviorProfile &)>;
-
-inline void NullMixedBehaviorObserver(const LogitQREMixedBehaviorProfile &) {}
-
-std::list<LogitQREMixedBehaviorProfile>
-LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
-                   MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
+std::list<LogitQREMixedBehaviorProfile> LogitBehaviorSolve(
+    const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
+    double p_firstStep, double p_maxAccel,
+    Nash::BehaviorCallbackType<double> p_onEquilibrium = Nash::NullBehaviorCallback<double>,
+    LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent =
+        NullLogitEventCallback<LogitQREMixedBehaviorProfile>);
 
 std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
                          const std::list<double> &p_targetLambda, double p_omega,
                          double p_firstStep, double p_maxAccel,
-                         MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
+                         LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent =
+                             NullLogitEventCallback<LogitQREMixedBehaviorProfile>);
 
 LogitQREMixedBehaviorProfile
 LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double p_maxLambda,
                       double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
-                      MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
+                      LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent =
+                          NullLogitEventCallback<LogitQREMixedBehaviorProfile>);
 
 } // namespace Gambit
 

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -283,8 +283,9 @@ void EquationSystem::GetJacobian(const Vector<double> &p_point, Matrix<double> &
 
 class TracingCallbackFunction {
 public:
-  TracingCallbackFunction(const Game &p_game, const MixedStrategyObserverFunctionType &p_observer)
-    : m_game(p_game), m_observer(p_observer)
+  TracingCallbackFunction(const Game &p_game,
+                          LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
+    : m_game(p_game), m_onEvent(p_onEvent)
   {
   }
   ~TracingCallbackFunction() = default;
@@ -294,7 +295,7 @@ public:
 
 private:
   Game m_game;
-  MixedStrategyObserverFunctionType m_observer;
+  LogitEventCallbackType<LogitQREMixedStrategyProfile> m_onEvent;
   std::list<LogitQREMixedStrategyProfile> m_profiles;
 };
 
@@ -303,13 +304,13 @@ void TracingCallbackFunction::AppendPoint(const Vector<double> &p_point)
   MixedStrategyProfile<double> profile(m_game->NewMixedStrategyProfile(0.0));
   PointToProfile(profile, p_point);
   m_profiles.emplace_back(profile, p_point.back(), 1.0);
-  m_observer(m_profiles.back());
+  m_onEvent(LogitPathEvent<LogitQREMixedStrategyProfile>{m_profiles.back()});
 }
 
 class EstimatorCallbackFunction {
 public:
   EstimatorCallbackFunction(const Game &p_game, const Vector<double> &p_frequencies,
-                            const MixedStrategyObserverFunctionType &p_observer);
+                            LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent);
   ~EstimatorCallbackFunction() = default;
 
   void EvaluatePoint(const Vector<double> &p_point);
@@ -319,14 +320,14 @@ public:
 private:
   Game m_game;
   const Vector<double> &m_frequencies;
-  MixedStrategyObserverFunctionType m_observer;
+  LogitEventCallbackType<LogitQREMixedStrategyProfile> m_onEvent;
   LogitQREMixedStrategyProfile m_bestProfile;
 };
 
 EstimatorCallbackFunction::EstimatorCallbackFunction(
     const Game &p_game, const Vector<double> &p_frequencies,
-    const MixedStrategyObserverFunctionType &p_observer)
-  : m_game(p_game), m_frequencies(p_frequencies), m_observer(p_observer),
+    LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
+  : m_game(p_game), m_frequencies(p_frequencies), m_onEvent(p_onEvent),
     m_bestProfile(p_game->NewMixedStrategyProfile(0.0), 0.0,
                   LogLike(p_frequencies, p_game->NewMixedStrategyProfile(0.0).GetProbVector()))
 {
@@ -338,7 +339,7 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
   PointToProfile(profile, p_point);
   auto qre = LogitQREMixedStrategyProfile(profile, p_point.back(),
                                           LogLike(m_frequencies, profile.GetProbVector()));
-  m_observer(qre);
+  m_onEvent(LogitPathEvent<LogitQREMixedStrategyProfile>{qre});
   if (qre.GetLogLike() > m_bestProfile.GetLogLike()) {
     m_bestProfile = qre;
   }
@@ -349,7 +350,8 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
 std::list<LogitQREMixedStrategyProfile>
 LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
                    double p_firstStep, double p_maxAccel,
-                   const MixedStrategyObserverFunctionType &p_observer)
+                   Nash::StrategyCallbackType<double> p_onEquilibrium,
+                   LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -365,7 +367,7 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
 
   const Game game = p_start.GetGame();
   Vector<double> x(ProfileToPoint(p_start));
-  TracingCallbackFunction callback(game, p_observer);
+  TracingCallbackFunction callback(game, p_onEvent);
   EquationSystem system(game);
   tracer.TracePath(
       [&system](const Vector<double> &p_point, Vector<double> &p_lhs) {
@@ -379,14 +381,16 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
         return RegretTerminationFunction(p_start.GetGame(), p_point, p_regret);
       },
       [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
-  return callback.GetProfiles();
+  const auto &profiles = callback.GetProfiles();
+  p_onEquilibrium(profiles.back().GetProfile(), "NE");
+  return profiles;
 }
 
 std::list<LogitQREMixedStrategyProfile>
 LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
                          const std::list<double> &p_targetLambda, double p_omega,
                          double p_firstStep, double p_maxAccel,
-                         const MixedStrategyObserverFunctionType &p_observer)
+                         LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -397,7 +401,7 @@ LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
 
   const Game game = p_start.GetGame();
   Vector x(ProfileToPoint(p_start));
-  TracingCallbackFunction callback(game, p_observer);
+  TracingCallbackFunction callback(game, p_onEvent);
   std::list<LogitQREMixedStrategyProfile> ret;
   EquationSystem system(game);
   for (auto lam : p_targetLambda) {
@@ -421,7 +425,7 @@ LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
 LogitQREMixedStrategyProfile
 LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double p_maxLambda,
                       double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
-                      MixedStrategyObserverFunctionType p_observer)
+                      LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
 {
   const LogitQREMixedStrategyProfile start(p_frequencies.GetGame());
   if (start.size() == 0) {
@@ -434,7 +438,7 @@ LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double 
   const Game game = start.GetGame();
   Vector<double> x(ProfileToPoint(start)), restart(x);
   const Vector freq_vector(p_frequencies.GetProbVector());
-  EstimatorCallbackFunction callback(game, p_frequencies.GetProbVector(), p_observer);
+  EstimatorCallbackFunction callback(game, p_frequencies.GetProbVector(), p_onEvent);
   EquationSystem system(game);
   while (true) {
     tracer.TracePath(

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -382,7 +382,7 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
       },
       [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
   const auto &profiles = callback.GetProfiles();
-  p_onEquilibrium(profiles.back().GetProfile(), "NE");
+  p_onEquilibrium(profiles.back().GetProfile());
   return profiles;
 }
 

--- a/src/solvers/lp/lp.cc
+++ b/src/solvers/lp/lp.cc
@@ -201,7 +201,7 @@ std::list<MixedBehaviorProfile<T>> LpBehaviorSolve(const Game &p_game,
   MixedBehaviorProfile<T> profile(p_game);
   data.GetBehavior(profile, primal, dual, p_game->GetRoot(), 1, 1);
   profile.UndefinedToCentroid();
-  p_onEquilibrium(profile, "NE");
+  p_onEquilibrium(profile);
   solution.push_back(profile);
   return solution;
 }
@@ -264,7 +264,7 @@ std::list<MixedStrategyProfile<T>> LpStrategySolve(const Game &p_game,
   for (int j = 1; j <= k; j++) {
     eqm[p_game->GetPlayer(2)->GetStrategy(j)] = dual[j];
   }
-  p_onEquilibrium(eqm, "NE");
+  p_onEquilibrium(eqm);
   std::list<MixedStrategyProfile<T>> solution;
   solution.push_back(eqm);
   return solution;

--- a/src/solvers/simpdiv/simpdiv.cc
+++ b/src/solvers/simpdiv/simpdiv.cc
@@ -31,9 +31,10 @@ public:
   explicit NashSimpdivStrategySolver(
       int p_gridResize = 2, int p_leashLength = 0,
       const Rational &p_maxregret = Rational(1, 1000000),
-      StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>)
+      StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>,
+      SimpdivEventCallbackType p_onEvent = NullSimpdivEventCallback)
     : m_gridResize(p_gridResize), m_leashLength((p_leashLength > 0) ? p_leashLength : 32000),
-      m_maxregret(p_maxregret), m_onEquilibrium(p_onEquilibrium)
+      m_maxregret(p_maxregret), m_onEquilibrium(p_onEquilibrium), m_onEvent(p_onEvent)
   {
   }
   ~NashSimpdivStrategySolver() = default;
@@ -46,6 +47,7 @@ private:
   int m_gridResize, m_leashLength;
   Rational m_maxregret;
   StrategyCallbackType<Rational> m_onEquilibrium;
+  SimpdivEventCallbackType m_onEvent;
 
   class State;
 
@@ -506,12 +508,12 @@ NashSimpdivStrategySolver::Solve(const MixedStrategyProfile<Rational> &p_start) 
   const Rational scale = p_start.GetGame()->GetMaxPayoff() - p_start.GetGame()->GetMinPayoff();
 
   MixedStrategyProfile<Rational> y(p_start);
-  m_onEquilibrium(y, "start");
+  m_onEvent(SimpdivStartEvent{y});
 
   while (true) {
     d /= Rational(m_gridResize);
     const Rational regret = Simplex(y, d);
-    m_onEquilibrium(y, std::to_string(d));
+    m_onEvent(SimpdivRefinementEvent{y, d, regret});
     if (regret <= m_maxregret * scale) {
       break;
     }
@@ -549,9 +551,11 @@ NashSimpdivStrategySolver::Solve(const Game &p_game) const
 std::list<MixedStrategyProfile<Rational>>
 SimpdivStrategySolve(const MixedStrategyProfile<Rational> &p_start, const Rational &p_maxregret,
                      int p_gridResize, int p_leashLength,
-                     StrategyCallbackType<Rational> p_onEquilibrium)
+                     StrategyCallbackType<Rational> p_onEquilibrium,
+                     SimpdivEventCallbackType p_onEvent)
 {
-  return NashSimpdivStrategySolver(p_gridResize, p_leashLength, p_maxregret, p_onEquilibrium)
+  return NashSimpdivStrategySolver(p_gridResize, p_leashLength, p_maxregret, p_onEquilibrium,
+                                   p_onEvent)
       .Solve(p_start);
 }
 

--- a/src/solvers/simpdiv/simpdiv.cc
+++ b/src/solvers/simpdiv/simpdiv.cc
@@ -519,7 +519,7 @@ NashSimpdivStrategySolver::Solve(const MixedStrategyProfile<Rational> &p_start) 
     }
   }
 
-  m_onEquilibrium(y, "NE");
+  m_onEquilibrium(y);
   std::list<MixedStrategyProfile<Rational>> sol;
   sol.push_back(y);
   return sol;

--- a/src/solvers/simpdiv/simpdiv.h
+++ b/src/solvers/simpdiv/simpdiv.h
@@ -23,9 +23,25 @@
 #ifndef GAMBIT_NASH_SIMPDIV_H
 #define GAMBIT_NASH_SIMPDIV_H
 
+#include <variant>
 #include "games/nash.h"
 
 namespace Gambit::Nash {
+
+struct SimpdivStartEvent {
+  const MixedStrategyProfile<Rational> &profile;
+};
+
+struct SimpdivRefinementEvent {
+  const MixedStrategyProfile<Rational> &profile;
+  Rational gridSize;
+  Rational regret;
+};
+
+using SimpdivEvent = std::variant<SimpdivStartEvent, SimpdivRefinementEvent>;
+using SimpdivEventCallbackType = std::function<void(const SimpdivEvent &)>;
+
+inline void NullSimpdivEventCallback(const SimpdivEvent &) {}
 
 ///
 /// This is a simplicial subdivision algorithm with restart, for finding
@@ -36,7 +52,8 @@ std::list<MixedStrategyProfile<Rational>> SimpdivStrategySolve(
     const MixedStrategyProfile<Rational> &p_start,
     const Rational &p_maxregret = Rational(1, 1000000), int p_gridResize = 2,
     int p_leashLength = 0,
-    StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>);
+    StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>,
+    SimpdivEventCallbackType p_onEvent = NullSimpdivEventCallback);
 
 } // end namespace Gambit::Nash
 

--- a/src/tools/enummixed/enummixed.cc
+++ b/src/tools/enummixed/enummixed.cc
@@ -132,9 +132,7 @@ int main(int argc, char *argv[])
     if (useFloat) {
       auto renderer = MakeMixedStrategyProfileRenderer<double>(std::cout, numDecimals, false);
       auto solution = EnumMixedStrategySolveDetailed<double>(
-          game, [&](const MixedStrategyProfile<double> &p, const std::string &label) {
-            renderer->Render(p, label);
-          });
+          game, [&](const MixedStrategyProfile<double> &p) { renderer->Render(p); });
       if (showConnect) {
         PrintCliques(solution->GetCliques(), renderer);
       }
@@ -142,9 +140,7 @@ int main(int argc, char *argv[])
     else {
       auto renderer = MakeMixedStrategyProfileRenderer<Rational>(std::cout, numDecimals, false);
       auto solution = EnumMixedStrategySolveDetailed<Rational>(
-          game, [&](const MixedStrategyProfile<Rational> &p, const std::string &label) {
-            renderer->Render(p, label);
-          });
+          game, [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); });
       if (showConnect) {
         PrintCliques(solution->GetCliques(), renderer);
       }

--- a/src/tools/enumpoly/enumpoly.cc
+++ b/src/tools/enumpoly/enumpoly.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <getopt.h>
+#include <type_traits>
 #include "gambit.h"
 #include "solvers/enumpoly/enumpoly.h"
 
@@ -117,6 +118,21 @@ void PrintSupport(std::ostream &p_stream, const std::string &p_label,
   p_stream << std::endl;
 }
 
+template <class Support> void PrintEnumPolyEvent(const EnumPolyEvent<Support> &p_event)
+{
+  std::visit(
+      [](const auto &event) {
+        using Event = std::decay_t<decltype(event)>;
+        if constexpr (std::is_same_v<Event, EnumPolyCandidateSupportEvent<Support>>) {
+          PrintSupport(std::cout, "candidate", event.support);
+        }
+        else if constexpr (std::is_same_v<Event, EnumPolySingularSupportEvent<Support>>) {
+          PrintSupport(std::cout, "singular", event.support);
+        }
+      },
+      p_event);
+}
+
 int main(int argc, char *argv[])
 {
   opterr = 0;
@@ -198,18 +214,18 @@ int main(int argc, char *argv[])
     if (!game->IsTree() || useStrategic) {
       EnumPolyStrategySolve(
           game, stopAfter, maxregret,
-          [](const MixedStrategyProfile<double> &eqm) { PrintProfile(std::cout, "NE", eqm); },
-          [](const std::string &label, const StrategySupportProfile &support) {
-            PrintSupport(std::cout, label, support);
-          });
+          [](const MixedStrategyProfile<double> &eqm, const std::string &label) {
+            PrintProfile(std::cout, label, eqm);
+          },
+          [](const EnumPolyEvent<StrategySupportProfile> &event) { PrintEnumPolyEvent(event); });
     }
     else {
       EnumPolyBehaviorSolve(
           game, stopAfter, maxregret,
-          [](const MixedBehaviorProfile<double> &eqm) { PrintProfile(std::cout, "NE", eqm); },
-          [](const std::string &label, const BehaviorSupportProfile &support) {
-            PrintSupport(std::cout, label, support);
-          });
+          [](const MixedBehaviorProfile<double> &eqm, const std::string &label) {
+            PrintProfile(std::cout, label, eqm);
+          },
+          [](const EnumPolyEvent<BehaviorSupportProfile> &event) { PrintEnumPolyEvent(event); });
     }
     return 0;
   }

--- a/src/tools/enumpoly/enumpoly.cc
+++ b/src/tools/enumpoly/enumpoly.cc
@@ -214,17 +214,13 @@ int main(int argc, char *argv[])
     if (!game->IsTree() || useStrategic) {
       EnumPolyStrategySolve(
           game, stopAfter, maxregret,
-          [](const MixedStrategyProfile<double> &eqm, const std::string &label) {
-            PrintProfile(std::cout, label, eqm);
-          },
+          [](const MixedStrategyProfile<double> &eqm) { PrintProfile(std::cout, "NE", eqm); },
           [](const EnumPolyEvent<StrategySupportProfile> &event) { PrintEnumPolyEvent(event); });
     }
     else {
       EnumPolyBehaviorSolve(
           game, stopAfter, maxregret,
-          [](const MixedBehaviorProfile<double> &eqm, const std::string &label) {
-            PrintProfile(std::cout, label, eqm);
-          },
+          [](const MixedBehaviorProfile<double> &eqm) { PrintProfile(std::cout, "NE", eqm); },
           [](const EnumPolyEvent<BehaviorSupportProfile> &event) { PrintEnumPolyEvent(event); });
     }
     return 0;

--- a/src/tools/enumpure/enumpure.cc
+++ b/src/tools/enumpure/enumpure.cc
@@ -125,12 +125,12 @@ int main(int argc, char *argv[])
     }
 
     if (game->IsTree() && solveAgent) {
-      EnumPureAgentSolve(game, [&](const MixedBehaviorProfile<Rational> &p,
-                                   const std::string &label) { renderer->Render(p, label); });
+      EnumPureAgentSolve(game,
+                         [&](const MixedBehaviorProfile<Rational> &p) { renderer->Render(p); });
     }
     else {
-      EnumPureStrategySolve(game, [&](const MixedStrategyProfile<Rational> &p,
-                                      const std::string &label) { renderer->Render(p, label); });
+      EnumPureStrategySolve(game,
+                            [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); });
     }
     return 0;
   }

--- a/src/tools/gt/nfggnm.cc
+++ b/src/tools/gt/nfggnm.cc
@@ -24,12 +24,36 @@
 #include <cmath>
 #include <iostream>
 #include <fstream>
+#include <type_traits>
 #include "gambit.h"
 #include "tools/util.h"
 #include "solvers/gnm/gnm.h"
 
 using namespace Gambit;
 using namespace Gambit::Nash;
+
+namespace {
+
+void RenderGNMEvent(const GNMEvent &p_event,
+                    const std::shared_ptr<MixedProfileRenderer<double>> &p_renderer)
+{
+  std::visit(
+      [p_renderer](const auto &event) {
+        using Event = std::decay_t<decltype(event)>;
+        if constexpr (std::is_same_v<Event, GNMPerturbationEvent>) {
+          p_renderer->Render(event.profile, "pert");
+        }
+        else if constexpr (std::is_same_v<Event, GNMStartEvent>) {
+          p_renderer->Render(event.profile, "start");
+        }
+        else if constexpr (std::is_same_v<Event, GNMStepEvent>) {
+          p_renderer->Render(event.profile, lexical_cast<std::string>(event.lambda));
+        }
+      },
+      p_event);
+}
+
+} // namespace
 
 extern Array<MixedStrategyProfile<double>> ReadStrategyPerturbations(const Game &p_game,
                                                                      std::istream &p_stream);
@@ -184,13 +208,16 @@ int main(int argc, char *argv[])
       perts = RandomStrategyPerturbations(game, numVectors);
     }
     for (auto pert : perts) {
-      GNMStrategySolve(pert, lambdaEnd, steps, localNewtonInterval, localNewtonMaxits,
-                       [renderer, verbose](const MixedStrategyProfile<double> &p_profile,
-                                           const std::string &p_label) {
-                         if (p_label == "NE" || verbose) {
-                           renderer->Render(p_profile, p_label);
-                         }
-                       });
+      GNMStrategySolve(
+          pert, lambdaEnd, steps, localNewtonInterval, localNewtonMaxits,
+          [renderer](const MixedStrategyProfile<double> &p_profile, const std::string &p_label) {
+            renderer->Render(p_profile, p_label);
+          },
+          [renderer, verbose](const GNMEvent &p_event) {
+            if (verbose) {
+              RenderGNMEvent(p_event, renderer);
+            }
+          });
     }
     return 0;
   }

--- a/src/tools/gt/nfggnm.cc
+++ b/src/tools/gt/nfggnm.cc
@@ -210,8 +210,8 @@ int main(int argc, char *argv[])
     for (auto pert : perts) {
       GNMStrategySolve(
           pert, lambdaEnd, steps, localNewtonInterval, localNewtonMaxits,
-          [renderer](const MixedStrategyProfile<double> &p_profile, const std::string &p_label) {
-            renderer->Render(p_profile, p_label);
+          [renderer](const MixedStrategyProfile<double> &p_profile) {
+            renderer->Render(p_profile);
           },
           [renderer, verbose](const GNMEvent &p_event) {
             if (verbose) {

--- a/src/tools/gt/nfgipa.cc
+++ b/src/tools/gt/nfgipa.cc
@@ -132,11 +132,8 @@ int main(int argc, char *argv[])
     }
 
     for (auto pert : perts) {
-      IPAStrategySolve(pert, [renderer](const MixedStrategyProfile<double> &p_profile,
-                                        const std::string &p_label) {
-        if (p_label == "NE") {
-          renderer->Render(p_profile, p_label);
-        }
+      IPAStrategySolve(pert, [renderer](const MixedStrategyProfile<double> &p_profile) {
+        renderer->Render(p_profile);
       });
     }
     return 0;

--- a/src/tools/lcp/lcp.cc
+++ b/src/tools/lcp/lcp.cc
@@ -133,32 +133,30 @@ int main(int argc, char *argv[])
       if (useFloat) {
         auto renderer =
             MakeMixedStrategyProfileRenderer<double>(std::cout, numDecimals, printDetail);
-        LcpStrategySolve<double>(game, stopAfter, maxDepth,
-                                 [&](const MixedStrategyProfile<double> &p,
-                                     const std::string &label) { renderer->Render(p, label); });
+        LcpStrategySolve<double>(
+            game, stopAfter, maxDepth,
+            [&](const MixedStrategyProfile<double> &p) { renderer->Render(p); });
       }
       else {
         auto renderer =
             MakeMixedStrategyProfileRenderer<Rational>(std::cout, numDecimals, printDetail);
-        LcpStrategySolve<Rational>(game, stopAfter, maxDepth,
-                                   [&](const MixedStrategyProfile<Rational> &p,
-                                       const std::string &label) { renderer->Render(p, label); });
+        LcpStrategySolve<Rational>(
+            game, stopAfter, maxDepth,
+            [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); });
       }
     }
     else {
       if (useFloat) {
         auto renderer =
             MakeMixedBehaviorProfileRenderer<double>(std::cout, numDecimals, printDetail);
-        LcpBehaviorSolve<double>(game,
-                                 [&](const MixedBehaviorProfile<double> &p,
-                                     const std::string &label) { renderer->Render(p, label); });
+        LcpBehaviorSolve<double>(
+            game, [&](const MixedBehaviorProfile<double> &p) { renderer->Render(p); });
       }
       else {
         auto renderer =
             MakeMixedBehaviorProfileRenderer<Rational>(std::cout, numDecimals, printDetail);
-        LcpBehaviorSolve<Rational>(game,
-                                   [&](const MixedBehaviorProfile<Rational> &p,
-                                       const std::string &label) { renderer->Render(p, label); });
+        LcpBehaviorSolve<Rational>(
+            game, [&](const MixedBehaviorProfile<Rational> &p) { renderer->Render(p); });
       }
     }
     return 0;

--- a/src/tools/liap/liap.cc
+++ b/src/tools/liap/liap.cc
@@ -240,8 +240,8 @@ int main(int argc, char *argv[])
         auto renderer = MakeMixedStrategyProfileRenderer<double>(std::cout, numDecimals, false);
         LiapStrategySolve(
             starts[i], maxregret, maxitsN,
-            [renderer](const MixedStrategyProfile<double> &p_profile, const std::string &p_label) {
-              renderer->Render(p_profile, p_label);
+            [renderer](const MixedStrategyProfile<double> &p_profile) {
+              renderer->Render(p_profile);
             },
             [renderer, verbose](const LiapEvent<MixedStrategyProfile<double>> &event) {
               if (verbose) {
@@ -265,8 +265,8 @@ int main(int argc, char *argv[])
         auto renderer = MakeMixedBehaviorProfileRenderer<double>(std::cout, numDecimals, false);
         LiapAgentSolve(
             starts[i], maxregret, maxitsN,
-            [renderer](const MixedBehaviorProfile<double> &p_profile, const std::string &p_label) {
-              renderer->Render(p_profile, p_label);
+            [renderer](const MixedBehaviorProfile<double> &p_profile) {
+              renderer->Render(p_profile);
             },
             [renderer, verbose](const LiapEvent<MixedBehaviorProfile<double>> &event) {
               if (verbose) {

--- a/src/tools/liap/liap.cc
+++ b/src/tools/liap/liap.cc
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <type_traits>
 #include <getopt.h>
 #include "gambit.h"
 #include "tools/util.h"
@@ -29,6 +30,22 @@
 
 using namespace Gambit;
 using namespace Gambit::Nash;
+
+template <class Renderer, class Profile>
+void RenderLiapEvent(const Renderer &p_renderer, const LiapEvent<Profile> &p_event)
+{
+  std::visit(
+      [&](const auto &event) {
+        using EventType = std::decay_t<decltype(event)>;
+        if constexpr (std::is_same_v<EventType, LiapStartEvent<Profile>>) {
+          p_renderer->Render(event.profile, "start");
+        }
+        else if constexpr (std::is_same_v<EventType, LiapEndEvent<Profile>>) {
+          p_renderer->Render(event.profile, "end");
+        }
+      },
+      p_event);
+}
 
 void PrintBanner(std::ostream &p_stream)
 {
@@ -221,13 +238,16 @@ int main(int argc, char *argv[])
 
       for (size_t i = 1; i <= starts.size(); i++) {
         auto renderer = MakeMixedStrategyProfileRenderer<double>(std::cout, numDecimals, false);
-        LiapStrategySolve(starts[i], maxregret, maxitsN,
-                          [renderer, verbose](const MixedStrategyProfile<double> &p_profile,
-                                              const std::string &p_label) {
-                            if (p_label == "NE" || verbose) {
-                              renderer->Render(p_profile, p_label);
-                            }
-                          });
+        LiapStrategySolve(
+            starts[i], maxregret, maxitsN,
+            [renderer](const MixedStrategyProfile<double> &p_profile, const std::string &p_label) {
+              renderer->Render(p_profile, p_label);
+            },
+            [renderer, verbose](const LiapEvent<MixedStrategyProfile<double>> &event) {
+              if (verbose) {
+                RenderLiapEvent(renderer, event);
+              }
+            });
       }
     }
     else {
@@ -243,13 +263,16 @@ int main(int argc, char *argv[])
 
       for (size_t i = 1; i <= starts.size(); i++) {
         auto renderer = MakeMixedBehaviorProfileRenderer<double>(std::cout, numDecimals, false);
-        LiapAgentSolve(starts[i], maxregret, maxitsN,
-                       [renderer, verbose](const MixedBehaviorProfile<double> &p_profile,
-                                           const std::string &p_label) {
-                         if (p_label == "NE" || verbose) {
-                           renderer->Render(p_profile, p_label);
-                         }
-                       });
+        LiapAgentSolve(
+            starts[i], maxregret, maxitsN,
+            [renderer](const MixedBehaviorProfile<double> &p_profile, const std::string &p_label) {
+              renderer->Render(p_profile, p_label);
+            },
+            [renderer, verbose](const LiapEvent<MixedBehaviorProfile<double>> &event) {
+              if (verbose) {
+                RenderLiapEvent(renderer, event);
+              }
+            });
       }
     }
     return 0;

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -200,9 +200,11 @@ int main(int argc, char *argv[])
       std::ifstream mleData(mleFile.c_str());
       ReadProfile(mleData, frequencies);
 
-      auto printer = [fullGraph, decimals](const LogitQREMixedStrategyProfile &p) {
+      auto printer = [fullGraph,
+                      decimals](const LogitEvent<LogitQREMixedStrategyProfile> &p_event) {
         if (fullGraph) {
-          PrintProfile(std::cout, decimals, p);
+          PrintProfile(std::cout, decimals,
+                       std::get<LogitPathEvent<LogitQREMixedStrategyProfile>>(p_event).qre);
         }
       };
       auto result =
@@ -212,9 +214,11 @@ int main(int argc, char *argv[])
     }
 
     if (!game->IsTree() || useStrategic) {
-      auto printer = [fullGraph, decimals](const LogitQREMixedStrategyProfile &p) {
+      auto printer = [fullGraph,
+                      decimals](const LogitEvent<LogitQREMixedStrategyProfile> &p_event) {
         if (fullGraph) {
-          PrintProfile(std::cout, decimals, p);
+          PrintProfile(std::cout, decimals,
+                       std::get<LogitPathEvent<LogitQREMixedStrategyProfile>>(p_event).qre);
         }
       };
       const LogitQREMixedStrategyProfile start(game);
@@ -226,14 +230,17 @@ int main(int argc, char *argv[])
         }
       }
       else {
-        auto result = LogitStrategySolve(start, maxregret, 1.0, hStart, maxDecel, printer);
+        auto result = LogitStrategySolve(start, maxregret, 1.0, hStart, maxDecel,
+                                         Nash::NullStrategyCallback<double>, printer);
         PrintProfile(std::cout, decimals, result.back(), true);
       }
     }
     else {
-      auto printer = [fullGraph, decimals](const LogitQREMixedBehaviorProfile &p) {
+      auto printer = [fullGraph,
+                      decimals](const LogitEvent<LogitQREMixedBehaviorProfile> &p_event) {
         if (fullGraph) {
-          PrintProfile(std::cout, decimals, p);
+          PrintProfile(std::cout, decimals,
+                       std::get<LogitPathEvent<LogitQREMixedBehaviorProfile>>(p_event).qre);
         }
       };
       const LogitQREMixedBehaviorProfile start(game);
@@ -245,7 +252,8 @@ int main(int argc, char *argv[])
         }
       }
       else {
-        auto result = LogitBehaviorSolve(start, maxregret, 1.0, hStart, maxDecel, printer);
+        auto result = LogitBehaviorSolve(start, maxregret, 1.0, hStart, maxDecel,
+                                         Nash::NullBehaviorCallback<double>, printer);
         PrintProfile(std::cout, decimals, result.back(), true);
       }
     }

--- a/src/tools/lp/lp.cc
+++ b/src/tools/lp/lp.cc
@@ -123,32 +123,28 @@ int main(int argc, char *argv[])
       if (useFloat) {
         auto renderer =
             MakeMixedStrategyProfileRenderer<double>(std::cout, numDecimals, printDetail);
-        LpStrategySolve<double>(game,
-                                [&](const MixedStrategyProfile<double> &p,
-                                    const std::string &label) { renderer->Render(p, label); });
+        LpStrategySolve<double>(
+            game, [&](const MixedStrategyProfile<double> &p) { renderer->Render(p); });
       }
       else {
         auto renderer =
             MakeMixedStrategyProfileRenderer<Rational>(std::cout, numDecimals, printDetail);
-        LpStrategySolve<Rational>(game,
-                                  [&](const MixedStrategyProfile<Rational> &p,
-                                      const std::string &label) { renderer->Render(p, label); });
+        LpStrategySolve<Rational>(
+            game, [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); });
       }
     }
     else {
       if (useFloat) {
         auto renderer =
             MakeMixedBehaviorProfileRenderer<double>(std::cout, numDecimals, printDetail);
-        LpBehaviorSolve<double>(game,
-                                [&](const MixedBehaviorProfile<double> &p,
-                                    const std::string &label) { renderer->Render(p, label); });
+        LpBehaviorSolve<double>(
+            game, [&](const MixedBehaviorProfile<double> &p) { renderer->Render(p); });
       }
       else {
         auto renderer =
             MakeMixedBehaviorProfileRenderer<Rational>(std::cout, numDecimals, printDetail);
-        LpBehaviorSolve<Rational>(game,
-                                  [&](const MixedBehaviorProfile<Rational> &p,
-                                      const std::string &label) { renderer->Render(p, label); });
+        LpBehaviorSolve<Rational>(
+            game, [&](const MixedBehaviorProfile<Rational> &p) { renderer->Render(p); });
       }
     }
     return 0;

--- a/src/tools/simpdiv/nfgsimpdiv.cc
+++ b/src/tools/simpdiv/nfgsimpdiv.cc
@@ -239,9 +239,7 @@ int main(int argc, char *argv[])
         auto renderer = std::make_shared<MixedStrategyCSVAsFloatRenderer>(std::cout, decimals);
         SimpdivStrategySolve(
             start, maxregret, gridResize, 0,
-            [&](const MixedStrategyProfile<Rational> &p, const std::string &label) {
-              renderer->Render(p, label);
-            },
+            [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); },
             [&](const SimpdivEvent &event) {
               if (verbose) {
                 RenderSimpdivEvent(renderer, event);
@@ -252,9 +250,7 @@ int main(int argc, char *argv[])
         auto renderer = std::make_shared<MixedStrategyProfileCSVRenderer<Rational>>(std::cout);
         SimpdivStrategySolve(
             start, maxregret, gridResize, 0,
-            [&](const MixedStrategyProfile<Rational> &p, const std::string &label) {
-              renderer->Render(p, label);
-            },
+            [&](const MixedStrategyProfile<Rational> &p) { renderer->Render(p); },
             [&](const SimpdivEvent &event) {
               if (verbose) {
                 RenderSimpdivEvent(renderer, event);

--- a/src/tools/simpdiv/nfgsimpdiv.cc
+++ b/src/tools/simpdiv/nfgsimpdiv.cc
@@ -23,12 +23,29 @@
 #include <getopt.h>
 #include <iostream>
 #include <fstream>
+#include <type_traits>
 #include "gambit.h"
 #include "tools/util.h"
 #include "solvers/simpdiv/simpdiv.h"
 
 using namespace Gambit;
 using namespace Gambit::Nash;
+
+template <class Renderer>
+void RenderSimpdivEvent(const Renderer &p_renderer, const SimpdivEvent &p_event)
+{
+  std::visit(
+      [&](const auto &event) {
+        using EventType = std::decay_t<decltype(event)>;
+        if constexpr (std::is_same_v<EventType, SimpdivStartEvent>) {
+          p_renderer->Render(event.profile, "start");
+        }
+        else if constexpr (std::is_same_v<EventType, SimpdivRefinementEvent>) {
+          p_renderer->Render(event.profile, std::to_string(event.gridSize));
+        }
+      },
+      p_event);
+}
 
 Array<MixedStrategyProfile<Rational>> ReadProfiles(const Game &p_game, std::istream &p_stream)
 {
@@ -223,8 +240,11 @@ int main(int argc, char *argv[])
         SimpdivStrategySolve(
             start, maxregret, gridResize, 0,
             [&](const MixedStrategyProfile<Rational> &p, const std::string &label) {
-              if (label == "NE" || verbose) {
-                renderer->Render(p, label);
+              renderer->Render(p, label);
+            },
+            [&](const SimpdivEvent &event) {
+              if (verbose) {
+                RenderSimpdivEvent(renderer, event);
               }
             });
       }
@@ -233,8 +253,11 @@ int main(int argc, char *argv[])
         SimpdivStrategySolve(
             start, maxregret, gridResize, 0,
             [&](const MixedStrategyProfile<Rational> &p, const std::string &label) {
-              if (label == "NE" || verbose) {
-                renderer->Render(p, label);
+              renderer->Render(p, label);
+            },
+            [&](const SimpdivEvent &event) {
+              if (verbose) {
+                RenderSimpdivEvent(renderer, event);
               }
             });
       }


### PR DESCRIPTION
This standardises the structure of callbacks for Nash equilibrium methods:
* All methods call an "on equilibrium" callback, immediately upon identifying a profile as an equilibrium (to within given tolerances as appropriate)
* Methods for which progress updates are meaningful/useful define one or more event types, which are emitted (via a callback) when they occur.  These are method-specific.


Closes #340 - as this now standardises to the extent sensible calling conventions across all methods.