### PR TITLE
hp.cc modifications

### DIFF
--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -37,7 +37,7 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
 
   const PathTracer tracer;
   Vector<double> x;
-  const double p_omega = 1.0;
+  double p_omega = 1.0;
 
   const double t_target = 1.0;
   const double t_tol = 0.5;

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -34,37 +34,53 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
   std::list<MixedStrategyProfile<double>> equilibria;
 
   HPEquationSystem system(p_prior);
-  Vector<double> x = system.ComputeInitialPoint();
 
   const PathTracer tracer;
+  Vector<double> x;
   double omega = 1.0;
+  bool wrong_orientation = false;
 
-  auto termination_condition = [](const Vector<double> &point) { return point[1] >= 1.5; };
   auto criterion_function = [](const Vector<double> &point,
                                const Vector<double> &tangent) -> double { return point[1] - 1.0; };
 
-  const TracePathResult result = tracer.TracePath(
-      [&system](const Vector<double> &point, Vector<double> &lhs) { system.GetValue(point, lhs); },
-      [&system](const Vector<double> &point, Matrix<double> &jac) {
-        system.GetJacobian(point, jac);
-      },
-      x, omega, termination_condition,
-      [&system](const Vector<double> &point) {
-        std::cout << "[Path Tracer Step] t = " << point[1];
-        std::cout << " | Alfas: ";
-        for (size_t i = 2; i <= 5; ++i) {
-          std::cout << point[i] << " ";
-        }
-        std::cout << "| Mu: " << point[6] << " " << point[7] << std::endl;
+  for (int attemp = 0; attemp < 2; ++attemp) {
+    x = system.ComputeInitialPoint();
+    wrong_orientation = false;
 
-        std::cout << "Full point vector in probabilities: ";
-        Vector<double> prob_vector = system.ExtractEquilibrium(point).GetProbVector();
-        for (size_t i = 1; i <= prob_vector.size(); ++i) {
-          std::cout << prob_vector[i] << " ";
-        }
-        std::cout << std::endl;
-      },
-      criterion_function);
+    auto termination_condition = [&wrong_orientation](const Vector<double> &point) {
+      const double wrong_orientation_tol = -1.0e-4;
+      if (point[1] < wrong_orientation_tol) {
+        wrong_orientation = true;
+        return true;
+      }
+      return point[1] >= 1.5;
+    };
+
+    const TracePathResult result =
+        tracer.TracePath([&system](const Vector<double> &point,
+                                   Vector<double> &lhs) { system.GetValue(point, lhs); },
+                         [&system](const Vector<double> &point, Matrix<double> &jac) {
+                           system.GetJacobian(point, jac);
+                         },
+                         x, omega, termination_condition,
+                         [&system](const Vector<double> &point) {
+                           std::cout << "[Path Tracer Step] t = " << point[1] << std::endl;
+                           std::cout << "Full point vector in probabilities: ";
+                           Vector<double> prob_vector =
+                               system.ExtractEquilibrium(point).GetProbVector();
+                           for (size_t i = 1; i <= prob_vector.size(); ++i) {
+                             std::cout << prob_vector[i] << " ";
+                           }
+                           std::cout << std::endl;
+                         },
+                         criterion_function);
+    if (!wrong_orientation) {
+      break;
+    }
+
+    // Direction was wrong, flip the orientation and try again
+    omega = -1.0;
+  }
 
   equilibria.push_back(system.ExtractEquilibrium(x));
   return equilibria;

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -37,8 +37,7 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
 
   const PathTracer tracer;
   Vector<double> x;
-  double omega = 1.0;
-  bool wrong_orientation = false;
+  const double p_omega = 1.0;
 
   const double t_target = 1.0;
   const double t_tol = 0.5;
@@ -48,45 +47,29 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
     return point[1] - t_target;
   };
 
-  for (int attempt = 0; attempt < 2; ++attempt) {
-    x = system.ComputeInitialPoint();
-    wrong_orientation = false;
+  x = system.ComputeInitialPoint();
 
-    auto termination_condition = [&wrong_orientation, t_target,
-                                  t_tol](const Vector<double> &point) {
-      const double wrong_orientation_tol = -1.0e-4;
-      if (point[1] < wrong_orientation_tol) {
-        wrong_orientation = true;
-        return true;
-      }
-      return (point[1] >= t_target + t_tol);
-    };
+  auto termination_condition = [t_target, t_tol](const Vector<double> &point) {
+    return (point[1] >= t_target + t_tol);
+  };
 
-    const TracePathResult result =
-        tracer.TracePath([&system](const Vector<double> &point,
-                                   Vector<double> &lhs) { system.GetValue(point, lhs); },
-                         [&system](const Vector<double> &point, Matrix<double> &jac) {
-                           system.GetJacobian(point, jac);
-                         },
-                         x, omega, termination_condition,
-                         [&system](const Vector<double> &point) {
-                           std::cout << "[Path Tracer Step] t = " << point[1] << std::endl;
-                           std::cout << "Full point vector in probabilities: ";
-                           Vector<double> prob_vector =
-                               system.ExtractEquilibrium(point).GetProbVector();
-                           for (size_t i = 1; i <= prob_vector.size(); ++i) {
-                             std::cout << prob_vector[i] << " ";
-                           }
-                           std::cout << std::endl;
-                         },
-                         criterion_function);
-    if (!wrong_orientation) {
-      break;
-    }
+  const TracePathResult result = tracer.TracePath(
+      [&system](const Vector<double> &point, Vector<double> &lhs) { system.GetValue(point, lhs); },
+      [&system](const Vector<double> &point, Matrix<double> &jac) {
+        system.GetJacobian(point, jac);
+      },
+      x, p_omega, termination_condition,
+      [&system](const Vector<double> &point) {
+        std::cout << "[Path Tracer Step] t = " << point[1] << std::endl;
+        std::cout << "Full point vector in probabilities: ";
+        Vector<double> prob_vector = system.ExtractEquilibrium(point).GetProbVector();
+        for (size_t i = 1; i <= prob_vector.size(); ++i) {
+          std::cout << prob_vector[i] << " ";
+        }
+        std::cout << std::endl;
+      },
+      criterion_function);
 
-    // Direction was wrong, flip the orientation and try again
-    omega = -1.0;
-  }
   const MixedStrategyProfile<double> eq_profile = system.ExtractEquilibrium(x);
 
   equilibria.push_back(eq_profile);

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -40,20 +40,26 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
   double omega = 1.0;
   bool wrong_orientation = false;
 
-  auto criterion_function = [](const Vector<double> &point,
-                               const Vector<double> &tangent) -> double { return point[1] - 1.0; };
+  const double t_target = 1.0;
+  const double t_tol = 0.5;
 
-  for (int attemp = 0; attemp < 2; ++attemp) {
+  auto criterion_function = [t_target](const Vector<double> &point,
+                                       const Vector<double> &tangent) -> double {
+    return point[1] - t_target;
+  };
+
+  for (int attempt = 0; attempt < 2; ++attempt) {
     x = system.ComputeInitialPoint();
     wrong_orientation = false;
 
-    auto termination_condition = [&wrong_orientation](const Vector<double> &point) {
+    auto termination_condition = [&wrong_orientation, t_target,
+                                  t_tol](const Vector<double> &point) {
       const double wrong_orientation_tol = -1.0e-4;
       if (point[1] < wrong_orientation_tol) {
         wrong_orientation = true;
         return true;
       }
-      return point[1] >= 1.5;
+      return (point[1] >= t_target + t_tol);
     };
 
     const TracePathResult result =
@@ -81,8 +87,23 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
     // Direction was wrong, flip the orientation and try again
     omega = -1.0;
   }
+  const MixedStrategyProfile<double> eq_profile = system.ExtractEquilibrium(x);
 
-  equilibria.push_back(system.ExtractEquilibrium(x));
+  equilibria.push_back(eq_profile);
+
+  // Check that the profile is an equilibrium taking into account how far we are from the target t
+  // value
+  const double delta = std::abs(t_target - x[1]);
+  const double scale = p_prior.GetGame()->GetMaxPayoff() - p_prior.GetGame()->GetMinPayoff();
+  const double max_regret = eq_profile.GetMaxRegret();
+  // error tolerance <= delta * scale
+  const double error_tolerance =
+      (delta * scale) + 1e-6; // Add a small epsilon to account for numerical errors
+
+  // If it is not an equilibrium, return an empty list
+  if (max_regret > error_tolerance) {
+    return {};
+  }
   return equilibria;
 }
 } // namespace Gambit


### PR DESCRIPTION
### Description of the changes in this PR
This PR has two goals:
-**Adjust the orientation** that takes the tracer when hp algorithm begins.
-**Refactor the termination_condition** so that it does not rely on magical numbers, and it adapts to each game.

The first part is already complete. As mentioned in PR #1007, 8 games from `contrib/games` did not reach an equilibirum because in the first steps of the tracing procedure, the orientation was wrong and it started with negative values of `t`, leading to a wrong result, or an infinite loop. 

Now, if that happens, (`t <wrong_orientation_tol = -1.0e-4`), the tracer starts again from the beginning with the orientation inverted. This way it is ensured that `t` increases this second try. 

After doing this, only `wink3.nfg` fails to converge to an equilibrium, with a regret of 4.15e-05. 
This problem can be easily solved by adjusting `c_maxDist =0.2` , in `path.cc`. 

Callback function has been simplified to make it more legible.

### How to review this PR

Test some of the games from catalog and contrib and check whether they reach an equilibrium or not. 

