### PR TITLE
Add make_chance_event and remove set_chance_probs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 ## [17.0.0-alpha.1] - unreleased
 
 ### Added
+- Added `Game.make_infoset`, forming a collection of personal decision nodes into a single
+  information set; the primitive operation for editing information structures.  (#999)
 - Added `Game.make_chance_event`, which forms a collection of nodes into a single chance event with a
   specified probability distribution over its actions. (#1009)
 
@@ -19,13 +21,7 @@
   removes dependency on tinyxml.  (#897)
 - Enumeration of candidate supports for a totally-mixed Nash equilibrium is now done by a
   lazy generator algorithm rather than materialising all as a single list up front.
-- Introduced `Game.make_infoset`, which subsumes operations previously written as `Game.leave_infoset`,
-  `Game.set_infoset`, and `Game.set_player`.
 - `Game.reveal` now raises at absent-minded information sets; previously the result was undefined.  (#999)
-
-### Added
-- Added `Game.make_infoset`, forming a collection of personal decision nodes into a single
-  information set; the primitive operation for editing information structures.  (#999)
 
 ### Fixed
 - Converting a behavior profile to a strategy profile, and computing pure-strategy payoffs

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
 ### Added
 - Added `Game.make_infoset`, forming a collection of personal decision nodes into a single
   information set; the primitive operation for editing information structures.  (#999)
-- Added `Game.make_chance_event`, which forms a collection of nodes into a single chance event with a
+- Added `Game.make_event`, which forms a collection of nodes into a single event with a
   specified probability distribution over its actions. (#1009)
 
 ### Changed
@@ -32,7 +32,7 @@
   information set and the new player.  (#999)
 - `Game.sort_infosets` has been removed; it was deprecated in 16.5.0, as the iteration order of
   information sets and their members is now maintained automatically.  (#999)
-- `Game.set_chance_probs` has been removed; use `Game.make_chance_event`, which expresses a change of
+- `Game.set_chance_probs` has been removed; use `Game.make_event`, which expresses a change of
   probabilities as forming the nodes of the event with the required distribution.  (#1009)
 
 ## [16.7.0] - 2026-07-11

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 ## [17.0.0] - unreleased
 
+### Added
+- Added `Game.make_chance_event`, which forms a collection of nodes into a single chance event with a
+  specified probability distribution over its actions. (#1009)
+
 ### Changed
 - `lcp_solve` no longer silently absorbs internal exceptions if they occur, but instead these propagate out
   to match the behaviour of all other Nash equilibrium solvers.  (#996)
@@ -11,6 +15,10 @@
 ### Fixed
 - Converting a behavior profile to a strategy profile, and computing pure-strategy payoffs
   no longer inserts spurious entries into a strategy's internal action map.
+
+### Removed
+- `Game.set_chance_probs` has been removed; use `Game.make_chance_event`, which expresses a change of
+  probabilities as forming the nodes of the event with the required distribution.  (#1009)
 
 ## [16.7.0] - 2026-07-11
 

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -71,7 +71,7 @@ Transforming game information structure
    Game.make_infoset
    Game.set_infoset
    Game.leave_infoset
-   Game.make_chance_event
+   Game.make_event
    Game.reveal
 
 

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -71,7 +71,7 @@ Transforming game information structure
    Game.set_player
    Game.set_infoset
    Game.leave_infoset
-   Game.set_chance_probs
+   Game.make_chance_event
    Game.reveal
    Game.sort_infosets
 

--- a/doc/tutorials/03_stripped_down_poker.ipynb
+++ b/doc/tutorials/03_stripped_down_poker.ipynb
@@ -933,7 +933,7 @@
    "source": [
     "## Representation of numerical data of a game\n",
     "\n",
-    "Payoffs to players and probabilities of actions at chance information sets are specified as numbers.\n",
+    "Payoffs to players and probabilities of actions at chance events are specified as numbers.\n",
     "Gambit represents the numerical values in a game in exact precision, using either decimal or rational representations.\n",
     "\n",
     "To illustrate, consider a trivial game which just has one move for the chance player:"
@@ -959,7 +959,9 @@
     "The default when creating a new move for chance is that all actions are chosen with equal probability.\n",
     "These probabilities are represented as rational numbers, using `pygambit`'s `Rational` class, which is derived from Python's `fractions.Fraction`.\n",
     "\n",
-    "Numerical data can be set as rational numbers. Here we update the chance action probabilities with `Rational` numbers:"
+    "Numerical data can be set as rational numbers.\n",
+    "`make_chance_event` forms a collection of nodes into a chance event with a given distribution; applied to a single node which is already a chance move, it simply sets the probabilities.\n",
+    "Here we set them with `Rational` numbers:"
    ]
   },
   {
@@ -969,8 +971,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_game.set_chance_probs(\n",
-    "    small_game.root.infoset,\n",
+    "small_game.make_chance_event(\n",
+    "    [small_game.root],\n",
     "    [gbt.Rational(1, 4), gbt.Rational(1, 2), gbt.Rational(1, 4)]\n",
     ")\n",
     "[act.prob for act in small_game.root.infoset.actions]"
@@ -991,8 +993,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_game.set_chance_probs(\n",
-    "    small_game.root.infoset,\n",
+    "small_game.make_chance_event(\n",
+    "    [small_game.root],\n",
     "    [gbt.Decimal(\".25\"), gbt.Decimal(\".50\"), gbt.Decimal(\".25\")]\n",
     ")\n",
     "[act.prob for act in small_game.root.infoset.actions]"
@@ -1017,7 +1019,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_game.set_chance_probs(small_game.root.infoset, [\"1/4\", \"1/2\", \"1/4\"])\n",
+    "small_game.make_chance_event([small_game.root], [\"1/4\", \"1/2\", \"1/4\"])\n",
     "[act.prob for act in small_game.root.infoset.actions]"
    ]
   },
@@ -1028,7 +1030,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_game.set_chance_probs(small_game.root.infoset, [\".25\", \".50\", \".25\"])\n",
+    "small_game.make_chance_event([small_game.root], [\".25\", \".50\", \".25\"])\n",
     "[act.prob for act in small_game.root.infoset.actions]"
    ]
   },
@@ -1052,7 +1054,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_game.set_chance_probs(small_game.root.infoset, [.25, .50, .25])\n",
+    "small_game.make_chance_event([small_game.root], [.25, .50, .25])\n",
     "[act.prob for act in small_game.root.infoset.actions]"
    ]
   },
@@ -1072,7 +1074,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    small_game.set_chance_probs(small_game.root.infoset, [1/3, 1/3, 1/3])\n",
+    "    small_game.make_chance_event([small_game.root], [1/3, 1/3, 1/3])\n",
     "except ValueError as e:\n",
     "    print(\"ValueError:\", e)\n"
    ]

--- a/doc/tutorials/03_stripped_down_poker.ipynb
+++ b/doc/tutorials/03_stripped_down_poker.ipynb
@@ -930,14 +930,7 @@
    "cell_type": "markdown",
    "id": "5f1f66e0",
    "metadata": {},
-   "source": [
-    "## Representation of numerical data of a game\n",
-    "\n",
-    "Payoffs to players and probabilities of actions at chance events are specified as numbers.\n",
-    "Gambit represents the numerical values in a game in exact precision, using either decimal or rational representations.\n",
-    "\n",
-    "To illustrate, consider a trivial game which just has one move for the chance player:"
-   ]
+   "source": "## Representation of numerical data of a game\n\nPayoffs to players and probabilities of actions at events are specified as numbers.\nGambit represents the numerical values in a game in exact precision, using either decimal or rational representations.\n\nTo illustrate, consider a trivial game which just has one move for the chance player:"
   },
   {
    "cell_type": "code",
@@ -955,14 +948,7 @@
    "cell_type": "markdown",
    "id": "dc4522b5",
    "metadata": {},
-   "source": [
-    "The default when creating a new move for chance is that all actions are chosen with equal probability.\n",
-    "These probabilities are represented as rational numbers, using `pygambit`'s `Rational` class, which is derived from Python's `fractions.Fraction`.\n",
-    "\n",
-    "Numerical data can be set as rational numbers.\n",
-    "`make_chance_event` forms a collection of nodes into a chance event with a given distribution; applied to a single node which is already a chance move, it simply sets the probabilities.\n",
-    "Here we set them with `Rational` numbers:"
-   ]
+   "source": "The default when creating a new move for chance is that all actions are chosen with equal probability.\nThese probabilities are represented as rational numbers, using `pygambit`'s `Rational` class, which is derived from Python's `fractions.Fraction`.\n\nNumerical data can be set as rational numbers.\n`make_event` forms a collection of nodes into an event with a given distribution; applied to a single node which is already an event, it simply sets the probabilities.\nHere we set them with `Rational` numbers:"
   },
   {
    "cell_type": "code",
@@ -970,13 +956,7 @@
    "id": "5de6acb2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "small_game.make_chance_event(\n",
-    "    [small_game.root],\n",
-    "    [gbt.Rational(1, 4), gbt.Rational(1, 2), gbt.Rational(1, 4)]\n",
-    ")\n",
-    "[act.prob for act in small_game.root.infoset.actions]"
-   ]
+   "source": "small_game.make_event(\n    [small_game.root],\n    [gbt.Rational(1, 4), gbt.Rational(1, 2), gbt.Rational(1, 4)]\n)\n[act.prob for act in small_game.root.infoset.actions]"
   },
   {
    "cell_type": "markdown",
@@ -992,13 +972,7 @@
    "id": "c47d2ab6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "small_game.make_chance_event(\n",
-    "    [small_game.root],\n",
-    "    [gbt.Decimal(\".25\"), gbt.Decimal(\".50\"), gbt.Decimal(\".25\")]\n",
-    ")\n",
-    "[act.prob for act in small_game.root.infoset.actions]"
-   ]
+   "source": "small_game.make_event(\n    [small_game.root],\n    [gbt.Decimal(\".25\"), gbt.Decimal(\".50\"), gbt.Decimal(\".25\")]\n)\n[act.prob for act in small_game.root.infoset.actions]"
   },
   {
    "cell_type": "markdown",
@@ -1018,10 +992,7 @@
    "id": "04329084",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "small_game.make_chance_event([small_game.root], [\"1/4\", \"1/2\", \"1/4\"])\n",
-    "[act.prob for act in small_game.root.infoset.actions]"
-   ]
+   "source": "small_game.make_event([small_game.root], [\"1/4\", \"1/2\", \"1/4\"])\n[act.prob for act in small_game.root.infoset.actions]"
   },
   {
    "cell_type": "code",
@@ -1029,10 +1000,7 @@
    "id": "9015e129",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "small_game.make_chance_event([small_game.root], [\".25\", \".50\", \".25\"])\n",
-    "[act.prob for act in small_game.root.infoset.actions]"
-   ]
+   "source": "small_game.make_event([small_game.root], [\".25\", \".50\", \".25\"])\n[act.prob for act in small_game.root.infoset.actions]"
   },
   {
    "cell_type": "markdown",
@@ -1053,10 +1021,7 @@
    "id": "0a019aa5",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "small_game.make_chance_event([small_game.root], [.25, .50, .25])\n",
-    "[act.prob for act in small_game.root.infoset.actions]"
-   ]
+   "source": "small_game.make_event([small_game.root], [.25, .50, .25])\n[act.prob for act in small_game.root.infoset.actions]"
   },
   {
    "cell_type": "markdown",
@@ -1072,12 +1037,7 @@
    "id": "1991d288",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    small_game.make_chance_event([small_game.root], [1/3, 1/3, 1/3])\n",
-    "except ValueError as e:\n",
-    "    print(\"ValueError:\", e)\n"
-   ]
+   "source": "try:\n    small_game.make_event([small_game.root], [1/3, 1/3, 1/3])\nexcept ValueError as e:\n    print(\"ValueError:\", e)\n"
   },
   {
    "cell_type": "markdown",

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -1426,11 +1426,11 @@ public:
   //@{
   /// Set the probability distribution of actions at a chance node
   virtual Game SetChanceProbs(const GameInfoset &, const Array<Number> &) = 0;
-  /// Form the collection of nodes into a single chance event carrying the given
+  /// Form the collection of nodes into a single event carrying the given
   /// probability distribution over its actions.  The nodes need not currently be
   /// chance nodes; personal decision nodes are converted.
-  virtual GameInfoset MakeChanceEvent(const std::vector<GameNode> &, const std::vector<Number> &,
-                                      const std::string &)
+  virtual GameInfoset MakeEvent(const std::vector<GameNode> &, const std::vector<Number> &,
+                                const std::string &)
   {
     throw UndefinedException();
   }

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -23,11 +23,13 @@
 #ifndef LIBGAMBIT_GAME_H
 #define LIBGAMBIT_GAME_H
 
+#include <algorithm>
 #include <list>
+#include <memory>
+#include <numeric>
+#include <queue>
 #include <set>
 #include <stack>
-#include <queue>
-#include <memory>
 
 #include "number.h"
 #include "gameobject.h"
@@ -676,19 +678,33 @@ inline GameNodeRep::Actions::iterator::iterator(GameInfosetRep::Actions::iterato
 
 inline GameNode GameNodeRep::Actions::iterator::GetOwner() const { return m_child_it.GetOwner(); }
 
-template <class C> void ValidateDistribution(const C &p_probs, const bool p_normalized = true)
+inline void ValidateDistribution(std::vector<Number>::const_iterator p_begin,
+                                 std::vector<Number>::const_iterator p_end,
+                                 const bool p_normalized)
 {
-  if (std::any_of(p_probs.begin(), p_probs.end(),
+  if (std::any_of(p_begin, p_end,
                   [](const Number &x) { return static_cast<Rational>(x) < Rational(0); })) {
     throw ValueException("Probabilities must be non-negative numbers");
   }
   if (!p_normalized) {
     return;
   }
-  if (sum_function(p_probs, [](const Number &n) { return static_cast<Rational>(n); }) !=
-      Rational(1)) {
+  if (std::accumulate(p_begin, p_end, Rational(0), [](const Rational &s, const Number &n) {
+        return s + static_cast<Rational>(n);
+      }) != Rational(1)) {
     throw ValueException("Probabilities must sum to exactly one");
   }
+}
+
+inline void ValidateDistribution(const Array<Number> &p_probs, const bool p_normalized = true)
+{
+  ValidateDistribution(p_probs.begin(), p_probs.end(), p_normalized);
+}
+
+inline void ValidateDistribution(const std::vector<Number> &p_probs,
+                                 const bool p_normalized = true)
+{
+  ValidateDistribution(p_probs.begin(), p_probs.end(), p_normalized);
 }
 
 class GameSubgameRep : public std::enable_shared_from_this<GameSubgameRep> {

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -481,6 +481,11 @@ public:
   GameInfoset GetInfoset(int p_index) const;
   /// Returns the information sets for the player
   Infosets GetInfosets() const;
+  /// Validate that p_label is a valid label for an information set of this player,
+  /// disregarding any information sets in p_ignore.
+  void CheckInfosetLabel(const std::string &p_label,
+                         const std::set<const GameInfosetRep *> &p_ignore) const;
+  //@}
 
   /// @name Strategies
   //@{
@@ -1349,6 +1354,22 @@ inline void GamePlayerRep::CheckStrategyLabel(const std::string &p_label) const
   }
 }
 
+inline void
+GamePlayerRep::CheckInfosetLabel(const std::string &p_label,
+                                 const std::set<const GameInfosetRep *> &p_ignore) const
+{
+  CheckLabel(p_label);
+  // Infoset labels may be empty; a nonempty label must be unique among the infosets of the player.
+  if (p_label.empty()) {
+    return;
+  }
+  for (const auto &infoset : m_infosets) {
+    if (p_ignore.count(infoset.get()) == 0 && infoset->GetLabel() == p_label) {
+      throw ValueException("Infoset label must be unique for the player");
+    }
+  }
+}
+
 inline Game GameSequenceRep::GetGame() const { return m_player->GetGame(); }
 inline GamePlayer GameSequenceRep::GetPlayer() const { return m_player->shared_from_this(); }
 
@@ -1361,16 +1382,7 @@ inline void GameInfosetRep::SetLabel(const std::string &p_label)
   if (p_label == m_label) {
     return;
   }
-  CheckLabel(p_label);
-  // Infoset labels may be empty, but a non-empty label must be unique among
-  // the infosets of the same player.
-  if (!p_label.empty()) {
-    for (const auto &infoset : GetPlayer()->GetInfosets()) {
-      if (infoset.get() != this && infoset->GetLabel() == p_label) {
-        throw ValueException("Infoset label must be unique for the player");
-      }
-    }
-  }
+  m_player->CheckInfosetLabel(p_label, {this});
   m_label = p_label;
 }
 inline void GameRep::CheckPlayerLabel(const std::string &p_label) const

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -676,7 +676,7 @@ inline GameNodeRep::Actions::iterator::iterator(GameInfosetRep::Actions::iterato
 
 inline GameNode GameNodeRep::Actions::iterator::GetOwner() const { return m_child_it.GetOwner(); }
 
-inline void ValidateDistribution(const Array<Number> &p_probs, const bool p_normalized = true)
+template <class C> void ValidateDistribution(const C &p_probs, const bool p_normalized = true)
 {
   if (std::any_of(p_probs.begin(), p_probs.end(),
                   [](const Number &x) { return static_cast<Rational>(x) < Rational(0); })) {
@@ -1270,6 +1270,14 @@ public:
   //@{
   /// Set the probability distribution of actions at a chance node
   virtual Game SetChanceProbs(const GameInfoset &, const Array<Number> &) = 0;
+  /// Form the collection of nodes into a single chance event carrying the given
+  /// probability distribution over its actions.  The nodes need not currently be
+  /// chance nodes; personal decision nodes are converted.
+  virtual GameInfoset MakeChanceEvent(const std::vector<GameNode> &, const std::vector<Number> &,
+                                      const std::string &)
+  {
+    throw UndefinedException();
+  }
   //@}
 
   /// Ensure the reduced-form strategies have been derived and indexed

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -1689,9 +1689,8 @@ Game GameTreeRep::SetChanceProbs(const GameInfoset &p_infoset, const Array<Numbe
   return shared_from_this();
 }
 
-GameInfoset GameTreeRep::MakeChanceEvent(const std::vector<GameNode> &p_nodes,
-                                         const std::vector<Number> &p_probs,
-                                         const std::string &p_label)
+GameInfoset GameTreeRep::MakeEvent(const std::vector<GameNode> &p_nodes,
+                                   const std::vector<Number> &p_probs, const std::string &p_label)
 {
   if (p_nodes.empty()) {
     throw ValueException("At least one node must be specified");
@@ -1702,13 +1701,13 @@ GameInfoset GameTreeRep::MakeChanceEvent(const std::vector<GameNode> &p_nodes,
       throw MismatchException();
     }
     if (node->IsTerminal()) {
-      throw UndefinedException("All nodes must be decision nodes");
+      throw UndefinedException("All nodes must be nonterminal");
     }
     if (!selected.insert(node.get()).second) {
       throw ValueException("Each node may be referenced only once");
     }
   }
-  // The first member defines the action labels and their order of the new chance event.
+  // The first member defines the action labels and their order of the new event.
   const auto &reference = p_nodes.front()->m_infoset->m_actions;
   for (const auto &node : p_nodes) {
     const auto &actions = node->m_infoset->m_actions;
@@ -1726,7 +1725,7 @@ GameInfoset GameTreeRep::MakeChanceEvent(const std::vector<GameNode> &p_nodes,
   }
   ValidateDistribution(p_probs);
   const GamePlayer chance = GetChance();
-  // Destroy a chance event all of whose members are absorbed; its label can then be reused.
+  // Destroy an event all of whose members are absorbed; its label can then be reused.
   std::set<const GameInfosetRep *> absorbed;
   if (!p_label.empty()) {
     for (const auto &infoset : chance->m_infosets) {

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -1614,6 +1614,79 @@ Game GameTreeRep::SetChanceProbs(const GameInfoset &p_infoset, const Array<Numbe
   return shared_from_this();
 }
 
+GameInfoset GameTreeRep::MakeChanceEvent(const std::vector<GameNode> &p_nodes,
+                                         const std::vector<Number> &p_probs,
+                                         const std::string &p_label)
+{
+  if (p_nodes.empty()) {
+    throw ValueException("At least one node must be specified");
+  }
+  std::set<GameNodeRep *> selected;
+  for (const auto &node : p_nodes) {
+    if (node->m_game != this) {
+      throw MismatchException();
+    }
+    if (node->IsTerminal()) {
+      throw UndefinedException("All nodes must be decision nodes");
+    }
+    if (!selected.insert(node.get()).second) {
+      throw ValueException("Each node may be referenced only once");
+    }
+  }
+  // The first member defines the action labels and their order of the new chance event.
+  const auto &reference = p_nodes.front()->m_infoset->m_actions;
+  for (const auto &node : p_nodes) {
+    const auto &actions = node->m_infoset->m_actions;
+    if (!std::equal(
+            actions.begin(), actions.end(), reference.begin(), reference.end(),
+            [](const std::shared_ptr<GameActionRep> &a, const std::shared_ptr<GameActionRep> &b) {
+              return a->GetLabel() == b->GetLabel();
+            })) {
+      throw ValueException(
+          "All nodes must have the same actions, with the same labels in the same order");
+    }
+  }
+  if (p_probs.size() != reference.size()) {
+    throw DimensionException("The number of probabilities given must match the number of actions");
+  }
+  ValidateDistribution(p_probs);
+  const GamePlayer chance = GetChance();
+  // Destroy a chance event all of whose members are absorbed; its label can then be reused.
+  std::set<const GameInfosetRep *> absorbed;
+  if (!p_label.empty()) {
+    for (const auto &infoset : chance->m_infosets) {
+      if (infoset->GetLabel() == p_label &&
+          std::all_of(infoset->m_members.begin(), infoset->m_members.end(),
+                      [&selected](const std::shared_ptr<GameNodeRep> &m) {
+                        return contains(selected, m.get());
+                      })) {
+        absorbed.insert(infoset.get());
+      }
+    }
+  }
+  chance->CheckInfosetLabel(p_label, absorbed);
+
+  IncrementVersion();
+  auto newEvent = std::make_shared<GameInfosetRep>(this, chance->m_infosets.size() + 1,
+                                                   chance.get(), reference.size());
+  auto dest = newEvent->m_actions.begin();
+  for (const auto &action : reference) {
+    (*dest)->SetLabel(action->GetLabel());
+    ++dest;
+  }
+  std::copy(p_probs.begin(), p_probs.end(), newEvent->m_probs.begin());
+  chance->m_infosets.push_back(newEvent);
+  for (const auto &node : p_nodes) {
+    RemoveMember(node->m_infoset, node.get());
+    newEvent->m_members.push_back(node);
+    node->m_infoset = newEvent.get();
+  }
+  newEvent->SetLabel(p_label);
+  ClearComputedValues();
+  InvalidateInfosetOrdering();
+  return newEvent;
+}
+
 Game GameTreeRep::NormalizeChanceProbs(GameInfosetRep *p_infoset)
 {
   if (p_infoset->m_game != this) {

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -182,8 +182,8 @@ public:
   void SetInfoset(GameNode, GameInfoset) override;
   GameInfoset LeaveInfoset(GameNode) override;
   Game SetChanceProbs(const GameInfoset &, const Array<Number> &) override;
-  GameInfoset MakeChanceEvent(const std::vector<GameNode> &, const std::vector<Number> &,
-                              const std::string &) override;
+  GameInfoset MakeEvent(const std::vector<GameNode> &, const std::vector<Number> &,
+                        const std::string &) override;
   GameAction InsertAction(GameInfoset, GameAction p_where = nullptr) override;
   void DeleteAction(GameAction) override;
   void SetOutcome(const GameNode &p_node, const GameOutcome &p_outcome) override;

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -180,6 +180,8 @@ public:
   void SetInfoset(GameNode, GameInfoset) override;
   GameInfoset LeaveInfoset(GameNode) override;
   Game SetChanceProbs(const GameInfoset &, const Array<Number> &) override;
+  GameInfoset MakeChanceEvent(const std::vector<GameNode> &, const std::vector<Number> &,
+                              const std::string &) override;
   GameAction InsertAction(GameInfoset, GameAction p_where = nullptr) override;
   void DeleteAction(GameAction) override;
   void SetOutcome(const GameNode &p_node, const GameOutcome &p_outcome) override;

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -370,6 +370,8 @@ cdef extern from "games/game.h":
         void DeleteAction(c_GameAction) except +ValueError
         void SetOutcome(c_GameNode, c_GameOutcome) except +
         c_Game SetChanceProbs(c_GameInfoset, Array[c_Number]) except +
+        c_GameInfoset MakeChanceEvent(stdvector[c_GameNode], stdvector[c_Number],
+                                      string) except +ValueError
 
         c_PureStrategyProfile NewPureStrategyProfile()  # except + doesn't compile
         c_MixedStrategyProfile[T] NewMixedStrategyProfile[T](T)  # except + doesn't compile

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -371,8 +371,8 @@ cdef extern from "games/game.h":
         void DeleteAction(c_GameAction) except +ValueError
         void SetOutcome(c_GameNode, c_GameOutcome) except +
         c_Game SetChanceProbs(c_GameInfoset, Array[c_Number]) except +
-        c_GameInfoset MakeChanceEvent(stdvector[c_GameNode], stdvector[c_Number],
-                                      string) except +ValueError
+        c_GameInfoset MakeEvent(stdvector[c_GameNode], stdvector[c_Number],
+                                string) except +ValueError
 
         c_PureStrategyProfile NewPureStrategyProfile()  # except + doesn't compile
         c_MixedStrategyProfile[T] NewMixedStrategyProfile[T](T)  # except + doesn't compile

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -951,46 +951,6 @@ class Game:
             self.game.deref().GetMinimalSubgame(cython.cast(Infoset, resolved_infoset).infoset)
         )
 
-    def set_chance_probs(self, infoset: Infoset | str,
-                         probs: typing.Sequence | typing.Mapping):
-        """Set the action probabilities at chance information set `infoset`.
-
-        Parameters
-        ----------
-        infoset : Infoset or str
-            The chance information set at which to set the action probabilities.
-            If a string is passed, the information set is determined by finding the chance
-            information set with that label, if any.
-        probs : array-like
-            The action probabilities to set
-
-        .. versionchanged:: 17.0.0
-            Implemented in terms of `Game.make_chance_event`, and now also accepts a mapping
-            from action labels to probabilities.  The chance event is reconstituted, so the
-            ``Infoset`` passed as `infoset`, and its ``Action`` objects, are invalidated by a
-            successful call; refer to the event as ``node.infoset``.
-
-        Raises
-        ------
-        MismatchError
-            If `infoset` is not an information set in this game
-        UndefinedOperationError
-            If `infoset` is not an information set of the chance player
-        IndexError
-            If the length of `probs` is not the same as the number of actions at the
-            information set
-        ValueError
-            If any of the elements of `probs` are not interpretable as numbers, or the values of
-            `probs` are not non-negative numbers that sum to exactly one.
-        """
-        resolved_infoset = self._resolve_infoset(infoset, "set_chance_probs")
-        if not resolved_infoset.is_chance:
-            raise UndefinedOperationError(
-                "set_chance_probs() first argument must be a chance infoset"
-            )
-        self.make_chance_event(list(resolved_infoset.members), probs,
-                               resolved_infoset.label or None)
-
     def _get_contingency(self, *args):
         psp: shared_ptr[c_PureStrategyProfile] = make_shared[c_PureStrategyProfile](
             self.game.deref().NewPureStrategyProfile()

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1707,7 +1707,7 @@ class Game:
         )
 
     def _resolve_probs(self,
-                       probs: typing.Any,
+                       probs: typing.Sequence | typing.Mapping,
                        action_labels: list[str],
                        funcname: str) -> list:
         """Resolve a probability specification against an ordered list of action labels.
@@ -1716,7 +1716,7 @@ class Game:
         or a mapping from action labels to values (may be sparse; omitted labels are
         assigned zero).  Returns a dense list of values in action order.
         """
-        if hasattr(probs, "keys"):
+        if isinstance(probs, typing.Mapping):
             unknown = [k for k in probs if k not in action_labels]
             if unknown:
                 raise KeyError(f"{funcname}(): no action with label '{unknown[0]}'")

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -951,7 +951,8 @@ class Game:
             self.game.deref().GetMinimalSubgame(cython.cast(Infoset, resolved_infoset).infoset)
         )
 
-    def set_chance_probs(self, infoset: Infoset | str, probs: typing.Sequence):
+    def set_chance_probs(self, infoset: Infoset | str,
+                         probs: typing.Sequence | typing.Mapping):
         """Set the action probabilities at chance information set `infoset`.
 
         Parameters
@@ -962,6 +963,12 @@ class Game:
             information set with that label, if any.
         probs : array-like
             The action probabilities to set
+
+        .. versionchanged:: 17.0.0
+            Implemented in terms of `Game.make_chance_event`, and now also accepts a mapping
+            from action labels to probabilities.  The chance event is reconstituted, so the
+            ``Infoset`` passed as `infoset`, and its ``Action`` objects, are invalidated by a
+            successful call; refer to the event as ``node.infoset``.
 
         Raises
         ------
@@ -976,22 +983,13 @@ class Game:
             If any of the elements of `probs` are not interpretable as numbers, or the values of
             `probs` are not non-negative numbers that sum to exactly one.
         """
-        infoset = self._resolve_infoset(infoset, "set_chance_probs")
-        if not infoset.is_chance:
+        resolved_infoset = self._resolve_infoset(infoset, "set_chance_probs")
+        if not resolved_infoset.is_chance:
             raise UndefinedOperationError(
                 "set_chance_probs() first argument must be a chance infoset"
             )
-        if len(infoset.actions) != len(probs):
-            raise IndexError("set_chance_probs(): must specify exactly one probability per action")
-        numbers = Array[c_Number](len(probs))
-        for i in range(1, len(probs)+1):
-            setitem_array_number(numbers, i, _to_number(probs[i-1]))
-        try:
-            self.game.deref().SetChanceProbs(cython.cast(Infoset, infoset).infoset, numbers)
-        except RuntimeError:
-            raise ValueError(
-                "set_chance_probs(): must specify non-negative probabilities that sum to one"
-            ) from None
+        self.make_chance_event(list(resolved_infoset.members), probs,
+                               resolved_infoset.label or None)
 
     def _get_contingency(self, *args):
         psp: shared_ptr[c_PureStrategyProfile] = make_shared[c_PureStrategyProfile](
@@ -1740,6 +1738,26 @@ class Game:
             f"{funcname}(): {argname} must be Action or str, not {action.__class__.__name__}"
         )
 
+    def _resolve_probs(self,
+                       probs: typing.Any,
+                       action_labels: list[str],
+                       funcname: str) -> list:
+        """Resolve a probability specification against an ordered list of action labels.
+
+        `probs` may be a sequence (positional; must have exactly one entry per action)
+        or a mapping from action labels to values (may be sparse; omitted labels are
+        assigned zero).  Returns a dense list of values in action order.
+        """
+        if hasattr(probs, "keys"):
+            unknown = [k for k in probs if k not in action_labels]
+            if unknown:
+                raise KeyError(f"{funcname}(): no action with label '{unknown[0]}'")
+            return [probs.get(label, 0) for label in action_labels]
+        probs = list(probs)
+        if len(probs) != len(action_labels):
+            raise IndexError(f"{funcname}(): must specify exactly one probability per action")
+        return probs
+
     def append_move(self, nodes: Node | NodeReferenceSet,
                     player: Player | str,
                     actions: list[str]) -> None:
@@ -1971,6 +1989,77 @@ class Game:
                 "delete_action(): cannot delete the only action at an information set"
             )
         self.game.deref().DeleteAction(resolved_action.action)
+
+    def make_chance_event(self,
+                          nodes: Node | NodeReferenceSet,
+                          probs: typing.Sequence | typing.Mapping,
+                          label: str | None = None) -> None:
+        """Form `nodes` into a single chance event with distribution `probs`.
+
+        The nodes must all be decision nodes of this game with the same actions, with the same
+        labels in the same order.  They need not be chance nodes; personal decision nodes are
+        converted, and the move is thereafter resolved by chance.  Nodes are removed from
+        whatever information sets or chance events they currently belong to; any of those which
+        retain members survive, keeping their labels, and those left with no members are deleted.
+        Any ``Infoset`` object, and any of its ``Action`` objects, referring to a deleted one
+        becomes invalid, and subsequent use raises ``RuntimeError``.
+        The resulting chance event is accessible as ``node.infoset`` for any node in `nodes`.
+
+        The first node in `nodes` determines the action order of the event,
+        and is the frame against which mapping keys in `probs` are resolved.
+
+        .. versionadded:: 17.0.0
+
+        Parameters
+        ----------
+        nodes : Node or NodeReferenceSet
+            The nonempty set of decision nodes to place in the chance event.
+        probs : sequence or mapping
+            The probability distribution over the actions of the event.  A sequence must specify
+            one probability per action, in action order.  A mapping from action labels
+            to probabilities may be sparse; omitted actions are assigned probability zero.
+            Probabilities are non-negative and sum to exactly one.
+        label : str, optional
+            The label of the new chance event.  If specified, must be unique among the chance
+            events of the game after the operation.  A label currently held by another chance
+            event may be reused only if all members of that event are among `nodes`.
+
+        Raises
+        ------
+        MismatchError
+            If any of `nodes` is from a different game.
+        KeyError
+            If a node reference matches no node, or a key of `probs` matches no
+            action label of the event.
+        IndexError
+            If a sequence `probs` does not have exactly one entry per action.
+        UndefinedOperationError
+            If any of `nodes` is a terminal node, or the game is not a tree.
+        ValueError
+            If `nodes` is empty or contains a repeated node; if the nodes do not
+            all have the same actions in the same order; if `probs` are not
+            non-negative numbers summing to exactly one; or if `label` is not
+            unique among the game's chance events after the operation.
+        """
+        if not self.is_tree:
+            raise UndefinedOperationError(
+                "make_chance_event(): operation only defined for games with a tree representation"
+            )
+        resolved_nodes = self._resolve_nodes(nodes, "make_chance_event")
+        if any(n.is_terminal for n in resolved_nodes):
+            raise UndefinedOperationError(
+                "make_chance_event(): all nodes must be decision nodes"
+            )
+        resolved_node = cython.cast(Node, resolved_nodes[0])
+        action_labels = [a.label for a in resolved_node.infoset.actions]
+        resolved_probs = self._resolve_probs(probs, action_labels, "make_chance_event")
+        c_nodes = stdvector[c_GameNode]()
+        for n in resolved_nodes:
+            c_nodes.push_back(cython.cast(Node, n).node)
+        c_probs = stdvector[c_Number]()
+        for p in resolved_probs:
+            c_probs.push_back(_to_number(p))
+        self.game.deref().MakeChanceEvent(c_nodes, c_probs, (label or "").encode("ascii"))
 
     def leave_infoset(self, node: Node | str):
         """Remove this node from its information set. If this node is the only node

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1958,20 +1958,20 @@ class Game:
             )
         self.game.deref().DeleteAction(resolved_action.action)
 
-    def make_chance_event(self,
-                          nodes: Node | NodeReferenceSet,
-                          probs: typing.Sequence | typing.Mapping,
-                          label: str | None = None) -> None:
-        """Form `nodes` into a single chance event with distribution `probs`.
+    def make_event(self,
+                   nodes: Node | NodeReferenceSet,
+                   probs: typing.Sequence | typing.Mapping,
+                   label: str | None = None) -> None:
+        """Form `nodes` into a single event with distribution `probs`.
 
         `nodes` must all be nonterminal nodes of this game with the same actions, with the same
         labels in the same order.  They need not be chance nodes; personal nodes are
         converted, and the move is thereafter resolved by chance.  Nodes are removed from
-        whatever information sets or chance events they currently belong to; any of those which
+        whatever information sets or events they currently belong to; any of those which
         retain members survive, keeping their labels, and those left with no members are deleted.
         Any ``Infoset`` object, and any of its ``Action`` objects, referring to a deleted one
         becomes invalid, and subsequent use raises ``RuntimeError``.
-        The resulting chance event is accessible as ``node.infoset`` for any node in `nodes`.
+        The resulting event is accessible as ``node.infoset`` for any node in `nodes`.
 
         The first node in `nodes` determines the action order of the event,
         and is the frame against which mapping keys in `probs` are resolved.
@@ -1981,16 +1981,16 @@ class Game:
         Parameters
         ----------
         nodes : Node or NodeReferenceSet
-            The nonempty set of nonterminal nodes to place in the chance event.
+            The nonempty set of nonterminal nodes to place in the event.
         probs : sequence or mapping
             The probability distribution over the actions of the event.  A sequence must specify
             one probability per action, in action order.  A mapping from action labels
             to probabilities may be sparse; omitted actions are assigned probability zero.
             Probabilities are non-negative and sum to exactly one.
         label : str, optional
-            The label of the new chance event.  If specified, must be unique among the chance
-            events of the game after the operation.  A label currently held by another chance
-            event may be reused only if all members of that event are among `nodes`.
+            The label of the new event.  If specified, must be unique among the events
+            of the game after the operation.  A label currently held by another event
+            may be reused only if all members of that event are among `nodes`.
 
         Raises
         ------
@@ -2007,33 +2007,33 @@ class Game:
             If `nodes` is empty or contains a repeated node; if the nodes do not
             all have the same actions in the same order; if `probs` are not
             non-negative numbers summing to exactly one; or if `label` is not
-            unique among the game's chance events after the operation.
+            unique among the game's events after the operation.
         """
         if not self.is_tree:
             raise UndefinedOperationError(
-                "make_chance_event(): operation only defined for games with a tree representation"
+                "make_event(): operation only defined for games with a tree representation"
             )
-        resolved_nodes = self._resolve_nodes(nodes, "make_chance_event")
+        resolved_nodes = self._resolve_nodes(nodes, "make_event")
         if any(n.is_terminal for n in resolved_nodes):
             raise UndefinedOperationError(
-                "make_chance_event(): all nodes must be nonterminal"
+                "make_event(): all nodes must be nonterminal"
             )
         resolved_node = cython.cast(Node, resolved_nodes[0])
         action_labels = [a.label for a in resolved_node.infoset.actions]
         if any([a.label for a in n.infoset.actions] != action_labels
                for n in resolved_nodes[1:]):
             raise ValueError(
-                "make_chance_event(): all nodes must have the same actions, "
+                "make_event(): all nodes must have the same actions, "
                 "with the same labels in the same order"
             )
-        resolved_probs = self._resolve_probs(probs, action_labels, "make_chance_event")
+        resolved_probs = self._resolve_probs(probs, action_labels, "make_event")
         c_nodes = stdvector[c_GameNode]()
         for n in resolved_nodes:
             c_nodes.push_back(cython.cast(Node, n).node)
         c_probs = stdvector[c_Number]()
         for p in resolved_probs:
             c_probs.push_back(_to_number(p))
-        self.game.deref().MakeChanceEvent(c_nodes, c_probs, (label or "").encode("utf-8"))
+        self.game.deref().MakeEvent(c_nodes, c_probs, (label or "").encode("utf-8"))
 
     def make_infoset(self,
                      nodes: Node | NodeReferenceSet,

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -2014,8 +2014,6 @@ class Game:
                 "make_chance_event(): operation only defined for games with a tree representation"
             )
         resolved_nodes = self._resolve_nodes(nodes, "make_chance_event")
-        if not resolved_nodes:
-            raise ValueError("make_chance_event(): `nodes` must not be empty")
         if any(n.is_terminal for n in resolved_nodes):
             raise UndefinedOperationError(
                 "make_chance_event(): all nodes must be nonterminal"

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1956,8 +1956,8 @@ class Game:
                           label: str | None = None) -> None:
         """Form `nodes` into a single chance event with distribution `probs`.
 
-        The nodes must all be decision nodes of this game with the same actions, with the same
-        labels in the same order.  They need not be chance nodes; personal decision nodes are
+        `nodes` must all be nonterminal nodes of this game with the same actions, with the same
+        labels in the same order.  They need not be chance nodes; personal nodes are
         converted, and the move is thereafter resolved by chance.  Nodes are removed from
         whatever information sets or chance events they currently belong to; any of those which
         retain members survive, keeping their labels, and those left with no members are deleted.
@@ -1973,7 +1973,7 @@ class Game:
         Parameters
         ----------
         nodes : Node or NodeReferenceSet
-            The nonempty set of decision nodes to place in the chance event.
+            The nonempty set of nonterminal nodes to place in the chance event.
         probs : sequence or mapping
             The probability distribution over the actions of the event.  A sequence must specify
             one probability per action, in action order.  A mapping from action labels
@@ -2006,12 +2006,20 @@ class Game:
                 "make_chance_event(): operation only defined for games with a tree representation"
             )
         resolved_nodes = self._resolve_nodes(nodes, "make_chance_event")
+        if not resolved_nodes:
+            raise ValueError("make_chance_event(): `nodes` must not be empty")
         if any(n.is_terminal for n in resolved_nodes):
             raise UndefinedOperationError(
-                "make_chance_event(): all nodes must be decision nodes"
+                "make_chance_event(): all nodes must be nonterminal"
             )
         resolved_node = cython.cast(Node, resolved_nodes[0])
         action_labels = [a.label for a in resolved_node.infoset.actions]
+        if any([a.label for a in n.infoset.actions] != action_labels
+               for n in resolved_nodes[1:]):
+            raise ValueError(
+                "make_chance_event(): all nodes must have the same actions, "
+                "with the same labels in the same order"
+            )
         resolved_probs = self._resolve_probs(probs, action_labels, "make_chance_event")
         c_nodes = stdvector[c_GameNode]()
         for n in resolved_nodes:
@@ -2019,7 +2027,7 @@ class Game:
         c_probs = stdvector[c_Number]()
         for p in resolved_probs:
             c_probs.push_back(_to_number(p))
-        self.game.deref().MakeChanceEvent(c_nodes, c_probs, (label or "").encode("ascii"))
+        self.game.deref().MakeChanceEvent(c_nodes, c_probs, (label or "").encode("utf-8"))
 
     def leave_infoset(self, node: Node | str):
         """Remove this node from its information set. If this node is the only node

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -2104,7 +2104,7 @@ class Game:
         for n in resolved_nodes:
             c_nodes.push_back(cython.cast(Node, n).node)
         self.game.deref().MakeInfoset(c_nodes, resolved_player.player,
-                                      (label or "").encode("ascii"))
+                                      (label or "").encode())
 
     def leave_infoset(self, node: Node | str):
         """Remove `node` from its information set, placing it in a new singleton.

--- a/src/pygambit/infoset.pxi
+++ b/src/pygambit/infoset.pxi
@@ -126,7 +126,13 @@ class InfosetActions:
 
 @cython.cclass
 class Infoset:
-    """An information set in a ``Game``."""
+    """An information set in a ``Game``.
+
+    An information set belonging to a personal player is a decision: the point at
+    which that player chooses an action, and so the object of potential optimisation.
+    An information set belonging to the chance player is instead called an event: its
+    probability distribution over actions is exogenously specified, not chosen.
+    """
     infoset = cython.declare(c_GameInfoset)
 
     def __init__(self, *args, **kwargs) -> None:
@@ -187,7 +193,9 @@ class Infoset:
 
     @property
     def is_chance(self) -> bool:
-        """Whether the information set belongs to the chance player."""
+        """Whether the information set belongs to the chance player, i.e. is an event
+        rather than a decision.
+        """
         return self.infoset.deref().IsChanceInfoset()
 
     @property

--- a/src/pygambit/node.pxi
+++ b/src/pygambit/node.pxi
@@ -260,7 +260,8 @@ class NodeOutcome:
 
 @cython.cclass
 class NodePlayer:
-    """The player who makes the decision at a node.
+    """The player associated with a node: the one who makes the decision, if the node
+    is personal, or the chance player, if the node is an event.
 
     A lazy, node-anchored view: holds the node and resolves its player on each access,
     so the value reflects the current state of the game even after the game is mutated.
@@ -408,7 +409,8 @@ class Node:
 
     @property
     def player(self) -> NodePlayer:
-        """The player who makes the decision at this node.
+        """The player associated with this node: the one who makes the decision, if this is
+        a personal node, or the chance player, if this is an event.
 
         Returns a lazy, node-anchored view resolved on each access, so the value reflects
         the current state of the game even if the game is mutated after this property is read.

--- a/src/pygambit/player.pxi
+++ b/src/pygambit/player.pxi
@@ -24,7 +24,9 @@ import cython
 
 @cython.cclass
 class PlayerInfosets:
-    """The set of information sets at which a player has the decision."""
+    """The set of information sets belonging to a player: decisions for a personal
+    player, or events for the chance player.
+    """
     player = cython.declare(c_GamePlayer)
 
     def __init__(self, *args, **kwargs) -> None:
@@ -41,7 +43,7 @@ class PlayerInfosets:
         return f"PlayerInfosets(player={Player.wrap(self.player)})"
 
     def __len__(self) -> int:
-        """The number of information sets at which the player has the decision."""
+        """The number of information sets belonging to the player."""
         return self.player.deref().GetInfosets().size()
 
     def __iter__(self) -> typing.Iterator[Infoset]:
@@ -284,7 +286,8 @@ class Player:
 
     @property
     def infosets(self) -> PlayerInfosets:
-        """Returns the set of information sets at which the player has the decision.
+        """Returns the set of information sets belonging to the player: decisions for
+        a personal player, or events for the chance player.
 
         The iteration order of information sets is the order in which they
         are encountered in the pre-order depth first traversal of the game tree.

--- a/tests/games.py
+++ b/tests/games.py
@@ -162,7 +162,7 @@ def _create_kuhn_poker_efg_without_outcomes():
         return [d for d in deals if d[player_idx] == card]
 
     g.append_move(g.root, g.players.chance, deals)
-    g.make_chance_event([g.root], [gbt.Rational(1, 6)] * 6)
+    g.make_event([g.root], [gbt.Rational(1, 6)] * 6)
     for alice_card in cards:
         # Alice's first move
         term_nodes = [g.root.children[d] for d in deals_by_infoset("Alice", alice_card)]

--- a/tests/games.py
+++ b/tests/games.py
@@ -149,7 +149,7 @@ def _create_kuhn_poker_efg_without_outcomes():
         return [d for d in deals if d[player_idx] == card]
 
     g.append_move(g.root, g.players.chance, deals)
-    g.set_chance_probs(g.root.infoset, [gbt.Rational(1, 6)] * 6)
+    g.make_chance_event([g.root], [gbt.Rational(1, 6)] * 6)
     for alice_card in cards:
         # Alice's first move
         term_nodes = [g.root.children[d] for d in deals_by_infoset("Alice", alice_card)]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -42,36 +42,6 @@ def test_action_label_non_ascii_rejected(label: str):
         action.label = label
 
 
-@pytest.mark.parametrize(
-    "game,inprobs,outprobs",
-    [
-        (games.create_stripped_down_poker_efg(), [0.75, 0.25], [0.75, 0.25]),
-        (
-            games.create_stripped_down_poker_efg(),
-            ["16/17", "1/17"],
-            [gbt.Rational("16/17"), gbt.Rational("1/17")],
-        ),
-    ],
-)
-def test_set_chance_valid_probability(game: gbt.Game, inprobs: list, outprobs: list):
-    game.set_chance_probs(game.root.infoset, inprobs)
-    for action, prob in zip(game.root.infoset.actions, outprobs, strict=True):
-        assert action.prob == prob
-
-
-@pytest.mark.parametrize(
-    "game,inprobs",
-    [
-        (games.create_stripped_down_poker_efg(), [0.75, -0.10]),
-        (games.create_stripped_down_poker_efg(), [0.75, 0.40]),
-        (games.create_stripped_down_poker_efg(), ["foo", "bar"]),
-    ],
-)
-def test_set_chance_improper_probability(game: gbt.Game, inprobs: list):
-    with pytest.raises(ValueError):
-        game.set_chance_probs(game.root.infoset, inprobs)
-
-
 @pytest.mark.parametrize("game", [games.create_stripped_down_poker_efg()])
 def test_action_precedes(game: gbt.Game):
     child = game.root.children["King"]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -72,25 +72,6 @@ def test_set_chance_improper_probability(game: gbt.Game, inprobs: list):
         game.set_chance_probs(game.root.infoset, inprobs)
 
 
-@pytest.mark.parametrize(
-    "game,inprobs",
-    [
-        (games.create_stripped_down_poker_efg(), [0.25, 0.75, 0.25]),
-        (games.create_stripped_down_poker_efg(), [1.00]),
-    ],
-)
-def test_set_chance_bad_dimension(game: gbt.Game, inprobs: list):
-    with pytest.raises(IndexError):
-        game.set_chance_probs(game.root.infoset, inprobs)
-
-
-@pytest.mark.parametrize("game", [games.create_stripped_down_poker_efg()])
-def test_set_chance_personal(game: gbt.Game):
-    with pytest.raises(gbt.UndefinedOperationError):
-        personal_infoset = next(iter(game.players["Alice"].infosets))
-        game.set_chance_probs(personal_infoset, [0.75, 0.25])
-
-
 @pytest.mark.parametrize("game", [games.create_stripped_down_poker_efg()])
 def test_action_precedes(game: gbt.Game):
     child = game.root.children["King"]

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -113,6 +113,9 @@ def test_infoset_plays():
     ],
 )
 def test_make_chance_event_sets_probabilities(inprobs, outprobs):
+    """Probabilities may be given positionally, or as a mapping in which omitted
+    actions are assigned zero.
+    """
     game = games.read_from_file("stripped_down_poker.efg")
     game.make_chance_event([game.root], inprobs, "Deal")
     for action, prob in zip(game.root.infoset.actions, outprobs, strict=True):
@@ -140,13 +143,6 @@ def test_make_chance_event_requires_matching_action_labels():
         game.make_chance_event([alice_node, bob_node], ["1/2", "1/2"])
 
 
-def test_make_chance_event_accepts_sparse_mapping():
-    """Actions omitted from a mapping are assigned probability zero."""
-    game = games.read_from_file("stripped_down_poker.efg")
-    game.make_chance_event([game.root], {"King": 1}, "Deal")
-    assert [a.prob for a in game.root.infoset.actions] == [1, 0]
-
-
 def test_make_chance_event_converts_personal_node():
     """A personal decision node becomes a chance node carrying the probabilities given."""
     game = games.read_from_file("stripped_down_poker.efg")
@@ -157,8 +153,9 @@ def test_make_chance_event_converts_personal_node():
                                                       gbt.Rational("3/4")]
 
 
-@pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40]])
-def test_make_chance_event_invalid_distribution_raises(probs):
+@pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40], ["foo", "bar"]])
+def test_make_chance_event_invalid_probs_raises(probs):
+    """Values must be numbers, non-negative, and sum to exactly one."""
     game = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(ValueError):
         game.make_chance_event([game.root], probs)

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -118,21 +118,21 @@ def test_infoset_plays():
         ({"King": 1}, [1, 0]),
     ],
 )
-def test_make_chance_event_sets_probabilities(inprobs, outprobs):
+def test_make_event_sets_probabilities(inprobs, outprobs):
     """Probabilities may be given positionally, or as a mapping in which omitted
     actions are assigned zero.
     """
     game = games.read_from_file("stripped_down_poker.efg")
-    game.make_chance_event([game.root], inprobs, "Deal")
+    game.make_event([game.root], inprobs, "Deal")
     for action, prob in zip(game.root.infoset.actions, outprobs, strict=True):
         assert action.prob == prob
 
 
-def test_make_chance_event_pools_nodes_from_different_infosets():
-    """Nodes in distinct information sets are formed into a single chance event."""
+def test_make_event_pools_nodes_from_different_infosets():
+    """Nodes in distinct information sets are formed into a single event."""
     game = games.read_from_file("stripped_down_poker.efg")
     nodes = [game.root.children["King"], game.root.children["Queen"]]
-    game.make_chance_event(nodes, ["1/4", "3/4"], "Coin")
+    game.make_event(nodes, ["1/4", "3/4"], "Coin")
     assert nodes[0].infoset == nodes[1].infoset
     assert nodes[0].infoset.is_chance
     assert [a.prob for a in nodes[0].infoset.actions] == [gbt.Rational("1/4"),
@@ -141,7 +141,7 @@ def test_make_chance_event_pools_nodes_from_different_infosets():
 
 
 @pytest.mark.parametrize("probs", [["1/2", "1/2"], {"Call": 1}])
-def test_make_chance_event_requires_matching_action_labels(probs):
+def test_make_event_requires_matching_action_labels(probs):
     """Nodes must have the same actions, with the same labels in the same order.
 
     The mapping case was previously reported as an unknown action label.
@@ -150,70 +150,70 @@ def test_make_chance_event_requires_matching_action_labels(probs):
     alice_node = game.root.children["King"]        # actions Bet, Fold
     bob_node = alice_node.children["Bet"]          # actions Call, Fold
     with pytest.raises(ValueError):
-        game.make_chance_event([alice_node, bob_node], probs)
+        game.make_event([alice_node, bob_node], probs)
 
 
-def test_make_chance_event_converts_personal_node():
+def test_make_event_converts_personal_node():
     """A personal decision node becomes a chance node carrying the probabilities given."""
     game = games.read_from_file("stripped_down_poker.efg")
     node = next(iter(game.players["Alice"].infosets["Alice has King"].members))
-    game.make_chance_event([node], ["1/4", "3/4"])
+    game.make_event([node], ["1/4", "3/4"])
     assert node.infoset.is_chance
     assert [a.prob for a in node.infoset.actions] == [gbt.Rational("1/4"),
                                                       gbt.Rational("3/4")]
 
 
-def test_make_chance_event_terminal_node_raises():
+def test_make_event_terminal_node_raises():
     game = games.read_from_file("stripped_down_poker.efg")
     terminal = game.root.children["King"].children["Fold"]
     with pytest.raises(gbt.UndefinedOperationError):
-        game.make_chance_event([terminal], ["1/2", "1/2"])
+        game.make_event([terminal], ["1/2", "1/2"])
 
 
-def test_make_chance_event_repeated_node_raises():
+def test_make_event_repeated_node_raises():
     game = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(ValueError):
-        game.make_chance_event([game.root, game.root], ["1/2", "1/2"])
+        game.make_event([game.root, game.root], ["1/2", "1/2"])
 
 
-def test_make_chance_event_mismatch_raises():
+def test_make_event_mismatch_raises():
     game = games.read_from_file("stripped_down_poker.efg")
     other = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(gbt.MismatchError):
-        game.make_chance_event([other.root], ["1/2", "1/2"])
+        game.make_event([other.root], ["1/2", "1/2"])
 
 
-def test_make_chance_event_strategic_game_raises():
+def test_make_event_strategic_game_raises():
     game = gbt.Game.new_table([2, 2])
     with pytest.raises(gbt.UndefinedOperationError):
-        game.make_chance_event([], [1])
+        game.make_event([], [1])
 
 
-def test_make_chance_event_empty_nodes_raises():
+def test_make_event_empty_nodes_raises():
     game = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(ValueError):
-        game.make_chance_event([], ["1/2", "1/2"])
+        game.make_event([], ["1/2", "1/2"])
 
 
-def test_make_chance_event_label_held_by_rump_raises():
+def test_make_event_label_held_by_rump_raises():
     """A label may be reused only if all members of the event holding it are absorbed."""
     game = games.read_from_file("stripped_down_poker.efg")
     nodes = [game.root.children["King"], game.root.children["Queen"]]
-    game.make_chance_event(nodes, ["1/2", "1/2"], "Coin")
+    game.make_event(nodes, ["1/2", "1/2"], "Coin")
     before = game.to_efg()
     with pytest.raises(ValueError):
-        game.make_chance_event([nodes[0]], ["1/2", "1/2"], "Coin")
+        game.make_event([nodes[0]], ["1/2", "1/2"], "Coin")
     assert game.to_efg() == before
 
 
-def test_make_chance_event_label_reused_when_fully_absorbed():
-    """A label held by an existing chance event may be reused once all of that
+def test_make_event_label_reused_when_fully_absorbed():
+    """A label held by an existing event may be reused once all of that
     event's members are absorbed into the new one; the old event is not left behind.
     """
     game = games.read_from_file("stripped_down_poker.efg")
     nodes = [game.root.children["King"], game.root.children["Queen"]]
-    game.make_chance_event(nodes, ["1/2", "1/2"], "Coin")
-    game.make_chance_event(nodes, ["1/4", "3/4"], "Coin")
+    game.make_event(nodes, ["1/2", "1/2"], "Coin")
+    game.make_event(nodes, ["1/4", "3/4"], "Coin")
     assert nodes[0].infoset == nodes[1].infoset
     assert nodes[0].infoset.label == "Coin"
     assert [a.prob for a in nodes[0].infoset.actions] == [gbt.Rational("1/4"),
@@ -222,21 +222,21 @@ def test_make_chance_event_label_reused_when_fully_absorbed():
 
 
 @pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40], ["foo", "bar"]])
-def test_make_chance_event_invalid_probs_raises(probs):
+def test_make_event_invalid_probs_raises(probs):
     """Values must be numbers, non-negative, and sum to exactly one."""
     game = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(ValueError):
-        game.make_chance_event([game.root], probs)
+        game.make_event([game.root], probs)
 
 
 @pytest.mark.parametrize(
     "probs,error",
     [(["1/2"], IndexError), (["1/3", "1/3", "1/3"], IndexError), ({"Jack": 1}, KeyError)],
 )
-def test_make_chance_event_malformed_probs_raises(probs, error):
+def test_make_event_malformed_probs_raises(probs, error):
     game = games.read_from_file("stripped_down_poker.efg")
     with pytest.raises(error):
-        game.make_chance_event([game.root], probs)
+        game.make_event([game.root], probs)
 
 
 @dataclasses.dataclass

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -206,6 +206,21 @@ def test_make_chance_event_label_held_by_rump_raises():
     assert game.to_efg() == before
 
 
+def test_make_chance_event_label_reused_when_fully_absorbed():
+    """A label held by an existing chance event may be reused once all of that
+    event's members are absorbed into the new one; the old event is not left behind.
+    """
+    game = games.read_from_file("stripped_down_poker.efg")
+    nodes = [game.root.children["King"], game.root.children["Queen"]]
+    game.make_chance_event(nodes, ["1/2", "1/2"], "Coin")
+    game.make_chance_event(nodes, ["1/4", "3/4"], "Coin")
+    assert nodes[0].infoset == nodes[1].infoset
+    assert nodes[0].infoset.label == "Coin"
+    assert [a.prob for a in nodes[0].infoset.actions] == [gbt.Rational("1/4"),
+                                                          gbt.Rational("3/4")]
+    assert [infoset.label for infoset in game.players.chance.infosets].count("Coin") == 1
+
+
 @pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40], ["foo", "bar"]])
 def test_make_chance_event_invalid_probs_raises(probs):
     """Values must be numbers, non-negative, and sum to exactly one."""

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -104,6 +104,76 @@ def test_infoset_plays():
     assert set(test_infoset.plays) == expected_set_of_plays
 
 
+@pytest.mark.parametrize(
+    "inprobs,outprobs",
+    [
+        (["1/4", "3/4"], [gbt.Rational("1/4"), gbt.Rational("3/4")]),
+        ([0.75, 0.25], [0.75, 0.25]),
+        ({"King": 1}, [1, 0]),
+    ],
+)
+def test_make_chance_event_sets_probabilities(inprobs, outprobs):
+    game = games.read_from_file("stripped_down_poker.efg")
+    game.make_chance_event([game.root], inprobs, "Deal")
+    for action, prob in zip(game.root.infoset.actions, outprobs, strict=True):
+        assert action.prob == prob
+
+
+def test_make_chance_event_pools_nodes_from_different_infosets():
+    """Nodes in distinct information sets are formed into a single chance event."""
+    game = games.read_from_file("stripped_down_poker.efg")
+    nodes = [game.root.children["King"], game.root.children["Queen"]]
+    game.make_chance_event(nodes, ["1/4", "3/4"], "Coin")
+    assert nodes[0].infoset == nodes[1].infoset
+    assert nodes[0].infoset.is_chance
+    assert [a.prob for a in nodes[0].infoset.actions] == [gbt.Rational("1/4"),
+                                                          gbt.Rational("3/4")]
+    assert not list(game.players["Alice"].infosets)
+
+
+def test_make_chance_event_requires_matching_action_labels():
+    """Nodes must have the same actions, with the same labels in the same order."""
+    game = games.read_from_file("stripped_down_poker.efg")
+    alice_node = game.root.children["King"]        # actions Bet, Fold
+    bob_node = alice_node.children["Bet"]          # actions Call, Fold
+    with pytest.raises(ValueError):
+        game.make_chance_event([alice_node, bob_node], ["1/2", "1/2"])
+
+
+def test_make_chance_event_accepts_sparse_mapping():
+    """Actions omitted from a mapping are assigned probability zero."""
+    game = games.read_from_file("stripped_down_poker.efg")
+    game.make_chance_event([game.root], {"King": 1}, "Deal")
+    assert [a.prob for a in game.root.infoset.actions] == [1, 0]
+
+
+def test_make_chance_event_converts_personal_node():
+    """A personal decision node becomes a chance node carrying the probabilities given."""
+    game = games.read_from_file("stripped_down_poker.efg")
+    node = next(iter(game.players["Alice"].infosets["Alice has King"].members))
+    game.make_chance_event([node], ["1/4", "3/4"])
+    assert node.infoset.is_chance
+    assert [a.prob for a in node.infoset.actions] == [gbt.Rational("1/4"),
+                                                      gbt.Rational("3/4")]
+
+
+@pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40]])
+def test_make_chance_event_invalid_distribution_raises(probs):
+    game = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(ValueError):
+        game.make_chance_event([game.root], probs)
+
+
+@pytest.mark.parametrize(
+    "probs,error",
+    [(["1/2"], IndexError), (["1/3", "1/3", "1/3"], IndexError), ({"Jack": 1}, KeyError)],
+)
+def test_make_chance_event_malformed_probs_raises(probs, error):
+    game = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(error):
+        game.make_chance_event([game.root], probs)
+
+
 @dataclasses.dataclass
 class PriorActionsTestCase:
     """TestCase for testing own_prior_actions."""

--- a/tests/test_infosets.py
+++ b/tests/test_infosets.py
@@ -134,13 +134,17 @@ def test_make_chance_event_pools_nodes_from_different_infosets():
     assert not list(game.players["Alice"].infosets)
 
 
-def test_make_chance_event_requires_matching_action_labels():
-    """Nodes must have the same actions, with the same labels in the same order."""
+@pytest.mark.parametrize("probs", [["1/2", "1/2"], {"Call": 1}])
+def test_make_chance_event_requires_matching_action_labels(probs):
+    """Nodes must have the same actions, with the same labels in the same order.
+
+    The mapping case was previously reported as an unknown action label.
+    """
     game = games.read_from_file("stripped_down_poker.efg")
     alice_node = game.root.children["King"]        # actions Bet, Fold
     bob_node = alice_node.children["Bet"]          # actions Call, Fold
     with pytest.raises(ValueError):
-        game.make_chance_event([alice_node, bob_node], ["1/2", "1/2"])
+        game.make_chance_event([alice_node, bob_node], probs)
 
 
 def test_make_chance_event_converts_personal_node():
@@ -151,6 +155,49 @@ def test_make_chance_event_converts_personal_node():
     assert node.infoset.is_chance
     assert [a.prob for a in node.infoset.actions] == [gbt.Rational("1/4"),
                                                       gbt.Rational("3/4")]
+
+
+def test_make_chance_event_terminal_node_raises():
+    game = games.read_from_file("stripped_down_poker.efg")
+    terminal = game.root.children["King"].children["Fold"]
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.make_chance_event([terminal], ["1/2", "1/2"])
+
+
+def test_make_chance_event_repeated_node_raises():
+    game = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(ValueError):
+        game.make_chance_event([game.root, game.root], ["1/2", "1/2"])
+
+
+def test_make_chance_event_mismatch_raises():
+    game = games.read_from_file("stripped_down_poker.efg")
+    other = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(gbt.MismatchError):
+        game.make_chance_event([other.root], ["1/2", "1/2"])
+
+
+def test_make_chance_event_strategic_game_raises():
+    game = gbt.Game.new_table([2, 2])
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.make_chance_event([], [1])
+
+
+def test_make_chance_event_empty_nodes_raises():
+    game = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(ValueError):
+        game.make_chance_event([], ["1/2", "1/2"])
+
+
+def test_make_chance_event_label_held_by_rump_raises():
+    """A label may be reused only if all members of the event holding it are absorbed."""
+    game = games.read_from_file("stripped_down_poker.efg")
+    nodes = [game.root.children["King"], game.root.children["Queen"]]
+    game.make_chance_event(nodes, ["1/2", "1/2"], "Coin")
+    before = game.to_efg()
+    with pytest.raises(ValueError):
+        game.make_chance_event([nodes[0]], ["1/2", "1/2"], "Coin")
+    assert game.to_efg() == before
 
 
 @pytest.mark.parametrize("probs", [["3/4", "-1/2"], [0.75, 0.40], ["foo", "bar"]])


### PR DESCRIPTION
### Issues closed by this PR
- Closes #1009

### Description of the changes in this PR

This PR adds `Game.make_chance_event(nodes, probs[, label])` and removes `Game.set_chance_probs`.

`MakeChanceEvent` is implemented in C++ as the parallel of `MakeInfoset` (#999). It additionally requires 
a probability distribution, given either as a list matching the actions in order or as a possibly-sparse mapping 
from action labels to numbers. Nodes need not already be chance nodes; personal decision nodes are converted. 

`set_chance_probs` is removed, subsumed by `make_chance_event`.

Depends on `GamePlayerRep::CheckInfosetLabel`, extracted here from `GameInfosetRep::SetLabel` with no behaviour change; the same commit is on the #999 branch and will drop out on rebase.