### PR TITLE
Introduce lazy abstraction for cached quantities derived inside game model

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -213,6 +213,7 @@ core_SOURCES = \
     src/core/core.h \
     src/core/util.h \
 	src/core/array.h \
+	src/core/lazy.h \
 	src/core/vector.h \
 	src/core/segment.h \
 	src/core/recarray.h \

--- a/src/core/lazy.h
+++ b/src/core/lazy.h
@@ -1,0 +1,149 @@
+//
+// This file is part of Gambit
+// Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
+//
+// FILE: src/core/lazy.h
+// Lazily-computed, invalidatable cached values and setup actions
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#ifndef GAMBIT_CORE_LAZY_H
+#define GAMBIT_CORE_LAZY_H
+
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace Gambit {
+
+/// @brief A lazily-computed value, rebuilt on demand after invalidation.
+///
+/// Get() runs `p_builder` at most once since construction or the last
+/// Invalidate() (std::call_once semantics), then returns the cached value on
+/// every subsequent call without re-running the builder.
+///
+/// Concurrent Get() calls race safely: the standard guarantees exactly one
+/// builder call completes before any Get() call returns, so multiple reader
+/// threads first-touching the same Lazy<T> is well-defined. Invalidate() is
+/// NOT safe to call concurrently with Get(); invalidation must happen only
+/// when no reader could be in flight (e.g. before handing the owning object
+/// to a reader thread, never while one is active).
+///
+/// Copyable, for embedding in value-type classes that are themselves copied
+/// (e.g. a support object held by value inside a profile class) — but a copy
+/// always starts un-built, regardless of the source's state. There is no
+/// way to safely transplant an already-fired std::once_flag, and a fast-path
+/// check of the source's cached value outside of call_once would reintroduce
+/// the exact data race call_once exists to prevent. Concretely: copying an
+/// already-built Lazy<T> does not carry the built value over; the copy
+/// recomputes it lazily on its own next Get().
+template <class T> class Lazy {
+public:
+  Lazy() = default;
+  Lazy(const Lazy &) {}
+  Lazy &operator=(const Lazy &)
+  {
+    Invalidate();
+    return *this;
+  }
+
+  /// Get the cached value, computing it via `p_builder` if not already built
+  /// (or if invalidated since the last build).
+  template <class F> const T &Get(F &&p_builder) const
+  {
+    std::call_once(*m_flag, [&] { m_value = std::forward<F>(p_builder)(); });
+    return *m_value;
+  }
+
+  /// Discard the cached value; the next Get() call recomputes it.
+  void Invalidate() const
+  {
+    m_flag.emplace();
+    m_value.reset();
+  }
+
+  /// If a value has been built, apply `p_visitor` to it; a no-op otherwise.
+  /// Useful for releasing resources the cached value owns (e.g. cascading to
+  /// invalidate objects it handed out) immediately before discarding it via
+  /// Invalidate(), without forcing a rebuild just to inspect the old value.
+  template <class F> void IfBuilt(F &&p_visitor) const
+  {
+    if (m_value) {
+      std::forward<F>(p_visitor)(*m_value);
+    }
+  }
+
+  /// Whether the value has been computed since the last invalidation.
+  bool IsBuilt() const { return m_value.has_value(); }
+
+private:
+  // std::once_flag is neither copyable nor movable, so it is wrapped in
+  // std::optional and reset via emplace() (placement-construct a fresh
+  // flag) rather than assignment.
+  mutable std::optional<std::once_flag> m_flag{std::in_place};
+  mutable std::optional<T> m_value;
+};
+
+/// @brief Like Lazy<T>, but for an idempotent setup action with no single
+/// value to hand back.
+///
+/// Some caches are populated by a routine that mutates several existing
+/// members as a side effect (e.g. numbering nodes in place) rather than
+/// producing one value to store. LazyAction captures the same "run once
+/// since the last invalidation" semantics for that shape, sharing Lazy<T>'s
+/// concurrency guarantees and its restriction against invalidating
+/// concurrently with a call to Ensure().
+///
+/// Copyable, with the same "a copy always starts un-built" semantics as
+/// Lazy<T> and for the same reason (see above).
+class LazyAction {
+public:
+  LazyAction() = default;
+  LazyAction(const LazyAction &) {}
+  LazyAction &operator=(const LazyAction &)
+  {
+    Invalidate();
+    return *this;
+  }
+
+  /// Run `p_action` if it has not already run since construction or the
+  /// last Invalidate().
+  template <class F> void Ensure(F &&p_action) const
+  {
+    std::call_once(*m_flag, [&] {
+      std::forward<F>(p_action)();
+      m_built = true;
+    });
+  }
+
+  /// Mark the action as needing to run again on the next Ensure() call.
+  void Invalidate() const
+  {
+    m_flag.emplace();
+    m_built = false;
+  }
+
+  /// Whether the action has run since the last invalidation.
+  bool IsBuilt() const { return m_built; }
+
+private:
+  mutable std::optional<std::once_flag> m_flag{std::in_place};
+  mutable bool m_built{false};
+};
+
+} // namespace Gambit
+
+#endif // GAMBIT_CORE_LAZY_H

--- a/src/games/behavmixed.cc
+++ b/src/games/behavmixed.cc
@@ -278,7 +278,7 @@ template <class T> MixedBehaviorProfile<T> MixedBehaviorProfile<T>::ToFullSuppor
 
 template <class T> T MixedBehaviorProfile<T>::GetLiapValue() const
 {
-  m_support.GetGame()->BuildComputedValues();
+  m_support.GetGame()->EnsureStrategies();
   return MixedStrategyProfile<T>(*this).GetLiapValue();
 }
 
@@ -402,7 +402,7 @@ template <class T> T MixedBehaviorProfile<T>::GetRegret(const GameInfoset &p_inf
 
 template <class T> T MixedBehaviorProfile<T>::GetMaxRegret() const
 {
-  m_support.GetGame()->BuildComputedValues();
+  m_support.GetGame()->EnsureStrategies();
   return MixedStrategyProfile<T>(*this).GetMaxRegret();
 }
 
@@ -619,7 +619,7 @@ template <class T> bool MixedBehaviorProfile<T>::IsDefinedAt(GameInfoset p_infos
 template <class T> MixedStrategyProfile<T> MixedBehaviorProfile<T>::ToMixedProfile() const
 {
   CheckVersion();
-  m_support.GetGame()->BuildComputedValues();
+  m_support.GetGame()->EnsureStrategies();
   return MixedStrategyProfile<T>(*this);
 }
 

--- a/src/games/behavspt.cc
+++ b/src/games/behavspt.cc
@@ -64,8 +64,8 @@ size_t BehaviorSupportProfile::BehaviorProfileLength() const
 
 void BehaviorSupportProfile::AddAction(const GameAction &p_action)
 {
-  m_reachableInfosets = nullptr;
-  m_sequences = nullptr;
+  m_reachableInfosets.Invalidate();
+  m_sequences.Invalidate();
   auto &support = m_actions.at(p_action->GetInfoset());
   auto pos = std::find_if(support.begin(), support.end(), [p_action](const GameAction &a) {
     return a->GetNumber() >= p_action->GetNumber();
@@ -83,8 +83,8 @@ void BehaviorSupportProfile::AddAction(const GameAction &p_action)
 
 bool BehaviorSupportProfile::RemoveAction(const GameAction &p_action)
 {
-  m_reachableInfosets = nullptr;
-  m_sequences = nullptr;
+  m_reachableInfosets.Invalidate();
+  m_sequences.Invalidate();
   auto &support = m_actions.at(p_action->GetInfoset());
   auto pos = std::find(support.begin(), support.end(), p_action);
   if (pos != support.end()) {
@@ -150,17 +150,17 @@ void BehaviorSupportProfile::DeactivateSubtree(const GameNode &n)
 
 std::shared_ptr<BehaviorSupportProfile::SequenceMap> BehaviorSupportProfile::GetSequenceMap() const
 {
-  if (!m_sequences) {
-    m_sequences = std::make_shared<SequenceMap>();
+  return m_sequences.Get([&] {
+    auto sequences = std::make_shared<SequenceMap>();
     for (const auto &player : GetGame()->GetPlayers()) {
       for (const auto &sequence : player->GetSequences()) {
         if (!sequence->GetAction() || Contains(sequence->GetAction())) {
-          (*m_sequences)[player].emplace_back(sequence);
+          (*sequences)[player].emplace_back(sequence);
         }
       }
     }
-  }
-  return m_sequences;
+    return sequences;
+  });
 }
 
 BehaviorSupportProfile::Sequences BehaviorSupportProfile::GetSequences() const { return {this}; }
@@ -290,19 +290,20 @@ size_t BehaviorSupportProfile::PlayerSequences::size() const
 //                 BehaviorSupportProfile: Reachable Information Sets
 //========================================================================
 
-void BehaviorSupportProfile::FindReachableInfosets(GameNode p_node) const
+void BehaviorSupportProfile::FindReachableInfosets(GameNode p_node,
+                                                   std::map<GameInfoset, bool> &p_reachable) const
 {
   if (!p_node->IsTerminal()) {
     auto infoset = p_node->GetInfoset();
-    (*m_reachableInfosets)[infoset] = true;
+    p_reachable[infoset] = true;
     if (p_node->GetPlayer()->IsChance()) {
       for (auto action : infoset->GetActions()) {
-        FindReachableInfosets(p_node->GetChild(action));
+        FindReachableInfosets(p_node->GetChild(action), p_reachable);
       }
     }
     else {
       for (auto action : GetActions(infoset)) {
-        FindReachableInfosets(p_node->GetChild(action));
+        FindReachableInfosets(p_node->GetChild(action), p_reachable);
       }
     }
   }
@@ -310,17 +311,17 @@ void BehaviorSupportProfile::FindReachableInfosets(GameNode p_node) const
 
 std::shared_ptr<std::map<GameInfoset, bool>> BehaviorSupportProfile::GetReachableInfosets() const
 {
-  if (!m_reachableInfosets) {
-    m_reachableInfosets = std::make_shared<std::map<GameInfoset, bool>>();
+  return m_reachableInfosets.Get([&] {
+    auto reachable = std::make_shared<std::map<GameInfoset, bool>>();
     for (size_t pl = 0; pl <= GetGame()->NumPlayers(); pl++) {
       const GamePlayer player = (pl == 0) ? GetGame()->GetChance() : GetGame()->GetPlayer(pl);
       for (const auto &infoset : player->GetInfosets()) {
-        (*m_reachableInfosets)[infoset] = false;
+        (*reachable)[infoset] = false;
       }
     }
-    FindReachableInfosets(GetGame()->GetRoot());
-  }
-  return m_reachableInfosets;
+    FindReachableInfosets(GetGame()->GetRoot(), *reachable);
+    return reachable;
+  });
 }
 
 } // end namespace Gambit

--- a/src/games/behavspt.h
+++ b/src/games/behavspt.h
@@ -25,6 +25,7 @@
 
 #include <list>
 #include <map>
+#include "core/lazy.h"
 #include "game.h"
 #include "seqpure.h"
 
@@ -46,8 +47,8 @@ public:
 private:
   Game m_efg;
   std::map<GameInfoset, std::vector<GameAction>> m_actions;
-  mutable std::shared_ptr<SequenceMap> m_sequences;
-  mutable std::shared_ptr<std::map<GameInfoset, bool>> m_reachableInfosets;
+  mutable Lazy<std::shared_ptr<SequenceMap>> m_sequences;
+  mutable Lazy<std::shared_ptr<std::map<GameInfoset, bool>>> m_reachableInfosets;
 
   std::map<GameInfoset, bool> m_infosetReachable;
   std::map<GameNode, bool> m_nonterminalReachable;
@@ -56,6 +57,7 @@ private:
   void ActivateSubtree(const GameNode &);
   void DeactivateSubtree(const GameNode &);
   std::shared_ptr<SequenceMap> GetSequenceMap() const;
+  void FindReachableInfosets(GameNode p_node, std::map<GameInfoset, bool> &p_reachable) const;
 
 public:
   class Support {
@@ -208,7 +210,6 @@ public:
   Infosets GetInfosets() const { return {this}; };
   SequenceContingencies GetSequenceContingencies() const;
 
-  void FindReachableInfosets(GameNode p_node) const;
   std::shared_ptr<std::map<GameInfoset, bool>> GetReachableInfosets() const;
 };
 

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -1174,7 +1174,7 @@ public:
   /// Returns the set of strategies in the game
   Strategies GetStrategies() const
   {
-    BuildComputedValues();
+    EnsureStrategies();
     return Strategies(std::const_pointer_cast<GameRep>(this->shared_from_this()));
   }
   /// Gets the i'th strategy in the game, numbered globally starting from 1
@@ -1267,8 +1267,8 @@ public:
   virtual Game SetChanceProbs(const GameInfoset &, const Array<Number> &) = 0;
   //@}
 
-  /// Build any computed values anew
-  virtual void BuildComputedValues() const {}
+  /// Ensure the reduced-form strategies have been derived and indexed
+  virtual void EnsureStrategies() const {}
   /// Ensure sequences have been computed
   virtual void EnsureSequences() const { throw UndefinedException(); }
 
@@ -1416,12 +1416,12 @@ inline void GamePlayerRep::SetLabel(const std::string &p_label)
 }
 inline GameStrategy GamePlayerRep::GetStrategy(int st) const
 {
-  m_game->BuildComputedValues();
+  m_game->EnsureStrategies();
   return m_strategies.at(st - 1);
 }
 inline GamePlayerRep::Strategies GamePlayerRep::GetStrategies() const
 {
-  m_game->BuildComputedValues();
+  m_game->EnsureStrategies();
   return Strategies(std::const_pointer_cast<GamePlayerRep>(shared_from_this()), &m_strategies);
 }
 inline GamePlayerRep::Sequences GamePlayerRep::GetSequences() const

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -382,7 +382,6 @@ void GameTreeRep::SetOutcome(const GameNode &p_node, const GameOutcome &p_outcom
   if (const auto newOutcome = p_outcome.get_shared().get(); newOutcome != p_node->m_outcome) {
     p_node->m_outcome = newOutcome;
     IncrementVersion();
-    ClearComputedValues();
   }
 }
 
@@ -402,20 +401,15 @@ bool GameNodeRep::IsSubgameRoot() const
   }
 
   auto *tree_game = static_cast<GameTreeRep *>(m_game);
-  tree_game->BuildSubgameRoots();
-  return tree_game->m_subgameData.m_subgameByRoot.count(const_cast<GameNodeRep *>(this)) > 0;
+  return tree_game->GetSubgameData().m_subgameByRoot.count(const_cast<GameNodeRep *>(this)) > 0;
 }
 
 bool GameNodeRep::IsStrategyReachable() const
 {
   auto tree_game = static_cast<GameTreeRep *>(m_game);
 
-  if (!tree_game->m_unreachableNodes) {
-    tree_game->BuildUnreachableNodes();
-  }
-
   // A node is reachable if it is NOT in the set of unreachable nodes.
-  return !contains(*tree_game->m_unreachableNodes, const_cast<GameNodeRep *>(this));
+  return !contains(tree_game->GetUnreachableNodes(), const_cast<GameNodeRep *>(this));
 }
 
 void GameTreeRep::DeleteParent(GameNode p_node)
@@ -851,9 +845,7 @@ Rational GameTreeRep::GetPlayerMaxPayoff(const GamePlayer &p_player) const
 
 bool GameTreeRep::IsPerfectRecall() const
 {
-  if (!m_ownPriorActionInfo && !m_root->IsTerminal()) {
-    BuildOwnPriorActions();
-  }
+  EnsureOwnPriorActions();
 
   if (GetRoot()->IsTerminal()) {
     return true;
@@ -869,9 +861,7 @@ bool GameTreeRep::IsAbsentMinded(const GameInfoset &p_infoset) const
   if (p_infoset->GetGame().get() != this) {
     throw MismatchException();
   }
-  if (!m_ownPriorActionInfo) {
-    BuildOwnPriorActions();
-  }
+  EnsureOwnPriorActions();
   return contains(m_absentMindedInfosets, p_infoset.get());
 }
 
@@ -880,21 +870,19 @@ GameSubgame GameTreeRep::GetMinimalSubgame(const GameInfoset &p_infoset) const
   if (p_infoset->GetGame().get() != this) {
     throw MismatchException();
   }
-  BuildSubgameRoots();
+  const auto &subgameData = GetSubgameData();
   auto *n = p_infoset->m_members.front().get();
-  auto it = m_subgameData.m_subgameByRoot.find(n);
-  while (it == m_subgameData.m_subgameByRoot.end()) {
+  auto it = subgameData.m_subgameByRoot.find(n);
+  while (it == subgameData.m_subgameByRoot.end()) {
     n = n->m_parent;
-    it = m_subgameData.m_subgameByRoot.find(n);
+    it = subgameData.m_subgameByRoot.find(n);
   }
   return it->second;
 }
 
 std::vector<std::pair<GameInfoset, GameNode>> GameTreeRep::GetAbsentMindedReentries() const
 {
-  if (!m_ownPriorActionInfo) {
-    BuildOwnPriorActions();
-  }
+  EnsureOwnPriorActions();
   if (m_absentMindedReentries.empty()) {
     return {};
   }
@@ -938,26 +926,22 @@ void GameTreeRep::RenumberInfosets(GamePlayerRep *p_player)
 
 void GameTreeRep::EnsureNodeOrdering() const
 {
-  if (m_nodesOrdered) {
-    return;
-  }
-  int nodeindex = 1;
-  for (const auto &node : GetNodes()) {
-    node->m_number = nodeindex++;
-  }
-  m_nodesOrdered = true;
+  m_nodeOrdering.Ensure([&] {
+    int nodeindex = 1;
+    for (const auto &node : GetNodes()) {
+      node->m_number = nodeindex++;
+    }
+  });
 }
 
 void GameTreeRep::EnsureInfosetOrdering() const
 {
-  if (m_infosetsOrdered) {
-    return;
-  }
-  EnsureNodeOrdering();
-  for (auto player : GetPlayersWithChance()) {
-    SortInfosets(player.get());
-  }
-  m_infosetsOrdered = true;
+  m_infosetOrdering.Ensure([&] {
+    EnsureNodeOrdering();
+    for (auto player : GetPlayersWithChance()) {
+      SortInfosets(player.get());
+    }
+  });
 }
 
 void GameTreeRep::ClearComputedValues() const
@@ -972,29 +956,32 @@ void GameTreeRep::ClearComputedValues() const
     }
     player->m_sequences.clear();
   }
-  m_hasSequences = false;
+  m_sequences.Invalidate();
   const_cast<GameTreeRep *>(this)->m_nodePlays.clear();
-  m_ownPriorActionInfo = nullptr;
-  const_cast<GameTreeRep *>(this)->m_unreachableNodes = nullptr;
+  m_ownPriorActions.Invalidate();
+  m_unreachableNodes.Invalidate();
   m_absentMindedInfosets.clear();
+  m_subgameData.IfBuilt([](const SubgameData &sd) {
+    for (const auto &[node, subgame] : sd.m_subgameByRoot) {
+      subgame->Invalidate();
+    }
+  });
   m_subgameData.Invalidate();
   m_absentMindedReentries.clear();
-  m_computedValues = false;
+  m_strategies.Invalidate();
 }
 
-void GameTreeRep::BuildComputedValues() const
+void GameTreeRep::EnsureStrategies() const
 {
-  if (m_computedValues) {
-    return;
-  }
-  EnsureInfosetOrdering();
-  for (const auto &player : m_players) {
-    std::map<GameInfosetRep *, int> behav;
-    std::map<GameNodeRep *, GameNodeRep *> ptr, whichbranch;
-    player->MakeReducedStrats(m_root.get(), nullptr, behav, ptr, whichbranch);
-  }
-  IndexStrategies();
-  m_computedValues = true;
+  m_strategies.Ensure([&] {
+    EnsureInfosetOrdering();
+    for (const auto &player : m_players) {
+      std::map<GameInfosetRep *, int> behav;
+      std::map<GameNodeRep *, GameNodeRep *> ptr, whichbranch;
+      player->MakeReducedStrats(m_root.get(), nullptr, behav, ptr, whichbranch);
+    }
+    IndexStrategies();
+  });
 }
 
 void GameTreeRep::BuildSequences(const GameNode &n, PureSequenceProfile &p_currentSequences) const
@@ -1033,17 +1020,15 @@ void GameTreeRep::BuildSequences(const GameNode &n, PureSequenceProfile &p_curre
 
 void GameTreeRep::EnsureSequences() const
 {
-  if (m_hasSequences) {
-    return;
-  }
-  PureSequenceProfile currentSequences(m_root->GetGame());
-  for (const auto &player : m_players) {
-    player->m_sequences = {std::make_shared<GameSequenceRep>(player.get(), nullptr, 1,
-                                                             std::weak_ptr<GameSequenceRep>())};
-    currentSequences.SetSequence(player->m_sequences.front());
-  }
-  BuildSequences(m_root, currentSequences);
-  m_hasSequences = true;
+  m_sequences.Ensure([&] {
+    PureSequenceProfile currentSequences(m_root->GetGame());
+    for (const auto &player : m_players) {
+      player->m_sequences = {std::make_shared<GameSequenceRep>(player.get(), nullptr, 1,
+                                                               std::weak_ptr<GameSequenceRep>())};
+      currentSequences.SetSequence(player->m_sequences.front());
+    }
+    BuildSequences(m_root, currentSequences);
+  });
 }
 
 void GameTreeRep::BuildConsistentPlays()
@@ -1069,87 +1054,87 @@ std::vector<GameNodeRep *> GameTreeRep::BuildConsistentPlaysRecursiveImpl(GameNo
   return consistent_plays;
 }
 
-void GameTreeRep::BuildOwnPriorActions() const
+void GameTreeRep::EnsureOwnPriorActions() const
 {
-  if (m_root->IsTerminal()) {
-    m_ownPriorActionInfo = std::make_shared<OwnPriorActionInfo>();
-    m_absentMindedInfosets.clear();
-    m_absentMindedReentries.clear();
-    return;
-  }
-
-  struct OwnPriorActionsVisitor {
-    std::shared_ptr<OwnPriorActionInfo> m_info;
-    std::map<GamePlayer, std::stack<GameAction>> m_priorActions;
-
-    // A node is a re-entry of its information set iff an ancestor on the current
-    // root-to-node path shares that information set.  m_pathMemberCount counts, per information
-    // set, how many nodes on the current path belong to it.
-    std::map<GameInfosetRep *, int> m_pathMemberCount;
-    std::set<GameInfosetRep *> m_absentMindedInfosets;
-    std::vector<std::pair<GameInfosetRep *, GameNodeRep *>> m_absentMindedReentries;
-
-    explicit OwnPriorActionsVisitor(const GameTreeRep *p_game)
-      : m_info(std::make_shared<OwnPriorActionInfo>())
-    {
-      for (const auto &player : p_game->GetPlayersWithChance()) {
-        m_priorActions[player].emplace(nullptr);
-      }
+  m_ownPriorActions.Ensure([&] {
+    if (m_root->IsTerminal()) {
+      m_ownPriorActionInfo = std::make_shared<OwnPriorActionInfo>();
+      m_absentMindedInfosets.clear();
+      m_absentMindedReentries.clear();
+      return;
     }
 
-    DFSCallbackResult OnEnter(GameNode p_node, int)
-    {
-      if (auto *infoset = p_node->m_infoset) {
-        auto &stack = m_priorActions.at(infoset->m_player->shared_from_this());
-        GameActionRep *raw_prior = stack.top() ? stack.top().get() : nullptr;
+    struct OwnPriorActionsVisitor {
+      std::shared_ptr<OwnPriorActionInfo> m_info;
+      std::map<GamePlayer, std::stack<GameAction>> m_priorActions;
 
-        m_info->node_map[p_node.get()] = raw_prior;
-        m_info->infoset_map[infoset].insert(raw_prior);
+      // A node is a re-entry of its information set iff an ancestor on the current
+      // root-to-node path shares that information set.  m_pathMemberCount counts, per information
+      // set, how many nodes on the current path belong to it.
+      std::map<GameInfosetRep *, int> m_pathMemberCount;
+      std::set<GameInfosetRep *> m_absentMindedInfosets;
+      std::vector<std::pair<GameInfosetRep *, GameNodeRep *>> m_absentMindedReentries;
 
-        stack.emplace(nullptr);
-
-        if (m_pathMemberCount[infoset]++ > 0) {
-          m_absentMindedInfosets.insert(infoset);
-          m_absentMindedReentries.emplace_back(infoset, p_node.get());
+      explicit OwnPriorActionsVisitor(const GameTreeRep *p_game)
+        : m_info(std::make_shared<OwnPriorActionInfo>())
+      {
+        for (const auto &player : p_game->GetPlayersWithChance()) {
+          m_priorActions[player].emplace(nullptr);
         }
       }
-      return DFSCallbackResult::Continue;
-    }
 
-    DFSCallbackResult OnAction(GameNode p_parent, GameNode p_child, int)
-    {
-      m_priorActions.at(p_parent->m_infoset->m_player->shared_from_this()).top() =
-          p_child->GetPriorAction();
-      return DFSCallbackResult::Continue;
-    }
+      DFSCallbackResult OnEnter(GameNode p_node, int)
+      {
+        if (auto *infoset = p_node->m_infoset) {
+          auto &stack = m_priorActions.at(infoset->m_player->shared_from_this());
+          GameActionRep *raw_prior = stack.top() ? stack.top().get() : nullptr;
 
-    DFSCallbackResult OnExit(const GameNode &p_node, int)
-    {
-      if (auto *infoset = p_node->m_infoset) {
-        m_priorActions.at(infoset->m_player->shared_from_this()).pop();
-        m_pathMemberCount[infoset]--;
+          m_info->node_map[p_node.get()] = raw_prior;
+          m_info->infoset_map[infoset].insert(raw_prior);
+
+          stack.emplace(nullptr);
+
+          if (m_pathMemberCount[infoset]++ > 0) {
+            m_absentMindedInfosets.insert(infoset);
+            m_absentMindedReentries.emplace_back(infoset, p_node.get());
+          }
+        }
+        return DFSCallbackResult::Continue;
       }
-      return DFSCallbackResult::Continue;
-    }
 
-    void OnVisit(GameNode, int) {}
-  };
+      DFSCallbackResult OnAction(GameNode p_parent, GameNode p_child, int)
+      {
+        m_priorActions.at(p_parent->m_infoset->m_player->shared_from_this()).top() =
+            p_child->GetPriorAction();
+        return DFSCallbackResult::Continue;
+      }
 
-  OwnPriorActionsVisitor visitor(this);
+      DFSCallbackResult OnExit(const GameNode &p_node, int)
+      {
+        if (auto *infoset = p_node->m_infoset) {
+          m_priorActions.at(infoset->m_player->shared_from_this()).pop();
+          m_pathMemberCount[infoset]--;
+        }
+        return DFSCallbackResult::Continue;
+      }
 
-  WalkDFS(const_cast<GameTreeRep *>(this)->shared_from_this(), m_root, TraversalOrder::Preorder,
-          visitor);
+      void OnVisit(GameNode, int) {}
+    };
 
-  m_ownPriorActionInfo = visitor.m_info;
-  m_absentMindedInfosets = std::move(visitor.m_absentMindedInfosets);
-  m_absentMindedReentries = std::move(visitor.m_absentMindedReentries);
+    OwnPriorActionsVisitor visitor(this);
+
+    WalkDFS(const_cast<GameTreeRep *>(this)->shared_from_this(), m_root, TraversalOrder::Preorder,
+            visitor);
+
+    m_ownPriorActionInfo = visitor.m_info;
+    m_absentMindedInfosets = std::move(visitor.m_absentMindedInfosets);
+    m_absentMindedReentries = std::move(visitor.m_absentMindedReentries);
+  });
 }
 
 GameAction GameTreeRep::GetOwnPriorAction(const GameNode &p_node) const
 {
-  if (!m_ownPriorActionInfo) {
-    BuildOwnPriorActions();
-  }
+  EnsureOwnPriorActions();
 
   auto it = m_ownPriorActionInfo->node_map.find(p_node.get());
   if (it != m_ownPriorActionInfo->node_map.end() && it->second) {
@@ -1160,9 +1145,7 @@ GameAction GameTreeRep::GetOwnPriorAction(const GameNode &p_node) const
 
 std::set<GameAction> GameTreeRep::GetOwnPriorActions(const GameInfoset &p_infoset) const
 {
-  if (!m_ownPriorActionInfo) {
-    BuildOwnPriorActions();
-  }
+  EnsureOwnPriorActions();
 
   std::set<GameAction> result;
   auto it = m_ownPriorActionInfo->infoset_map.find(p_infoset.get());
@@ -1175,264 +1158,267 @@ std::set<GameAction> GameTreeRep::GetOwnPriorActions(const GameInfoset &p_infose
   return result;
 }
 
-void GameTreeRep::BuildUnreachableNodes() const
+const std::set<GameNodeRep *> &GameTreeRep::GetUnreachableNodes() const
 {
-  m_unreachableNodes = std::make_unique<std::set<GameNodeRep *>>();
+  return m_unreachableNodes.Get([&] {
+    std::set<GameNodeRep *> result;
 
-  if (m_root->IsTerminal()) {
-    return;
-  }
+    if (m_root->IsTerminal()) {
+      return result;
+    }
 
-  using AbsentMindedEdge = std::pair<GameAction, GameNode>;
-  using ActiveEdge = std::variant<GameNodeRep::Actions::iterator, AbsentMindedEdge>;
+    using AbsentMindedEdge = std::pair<GameAction, GameNode>;
+    using ActiveEdge = std::variant<GameNodeRep::Actions::iterator, AbsentMindedEdge>;
 
-  std::stack<ActiveEdge> position;
-  std::map<GameInfoset, GameAction> path_choices;
-  position.emplace(m_root->GetActions().begin());
+    std::stack<ActiveEdge> position;
+    std::map<GameInfoset, GameAction> path_choices;
+    position.emplace(m_root->GetActions().begin());
 
-  while (!position.empty()) {
-    ActiveEdge &current_edge = position.top();
-    GameNode child, node;
-    GameAction action;
+    while (!position.empty()) {
+      ActiveEdge &current_edge = position.top();
+      GameNode child, node;
+      GameAction action;
 
-    if (std::holds_alternative<GameNodeRep::Actions::iterator>(current_edge)) {
-      auto &current_it = std::get<GameNodeRep::Actions::iterator>(current_edge);
-      node = current_it.GetOwner();
+      if (std::holds_alternative<GameNodeRep::Actions::iterator>(current_edge)) {
+        auto &current_it = std::get<GameNodeRep::Actions::iterator>(current_edge);
+        node = current_it.GetOwner();
 
-      if (current_it == node->GetActions().end()) {
-        position.pop();
-        path_choices.erase(node->m_infoset->shared_from_this());
-        continue;
+        if (current_it == node->GetActions().end()) {
+          position.pop();
+          path_choices.erase(node->m_infoset->shared_from_this());
+          continue;
+        }
+        else {
+          std::tie(action, child) = *current_it;
+          ++current_it;
+          path_choices[node->m_infoset->shared_from_this()] = action;
+        }
       }
       else {
-        std::tie(action, child) = *current_it;
-        ++current_it;
-        path_choices[node->m_infoset->shared_from_this()] = action;
+        std::tie(action, node) = std::get<AbsentMindedEdge>(current_edge);
+        position.pop();
+        child = node->GetChild(action);
       }
-    }
-    else {
-      std::tie(action, node) = std::get<AbsentMindedEdge>(current_edge);
-      position.pop();
-      child = node->GetChild(action);
-    }
 
-    if (!child->IsTerminal()) {
-      // On a re-entry, a pure strategy replays the action chosen at the earlier visit,
-      // so only that branch is reachable; prune the rest.
-      if (path_choices.find(child->m_infoset->shared_from_this()) != path_choices.end()) {
-        const GameAction replay_action = path_choices.at(child->m_infoset->shared_from_this());
-        position.emplace(AbsentMindedEdge{replay_action, child});
+      if (!child->IsTerminal()) {
+        // On a re-entry, a pure strategy replays the action chosen at the earlier visit,
+        // so only that branch is reachable; prune the rest.
+        if (path_choices.find(child->m_infoset->shared_from_this()) != path_choices.end()) {
+          const GameAction replay_action = path_choices.at(child->m_infoset->shared_from_this());
+          position.emplace(AbsentMindedEdge{replay_action, child});
 
-        // Mark siblings and the nodes in their subtrees as unreachable
-        for (const auto &[current_action, subtree_root] : child->GetActions()) {
-          if (current_action != replay_action) {
-            std::stack<GameNodeRep *> nodes_to_visit;
-            nodes_to_visit.push(subtree_root.get());
-            while (!nodes_to_visit.empty()) {
-              // NOLINTBEGIN(misc-const-correctness)
-              GameNodeRep *current_unreachable_node = nodes_to_visit.top();
-              // NOLINTEND(misc-const-correctness)
-              nodes_to_visit.pop();
-              m_unreachableNodes->insert(current_unreachable_node);
-              for (const auto &unreachable_child : current_unreachable_node->GetChildren()) {
-                nodes_to_visit.push(unreachable_child.get());
+          // Mark siblings and the nodes in their subtrees as unreachable
+          for (const auto &[current_action, subtree_root] : child->GetActions()) {
+            if (current_action != replay_action) {
+              std::stack<GameNodeRep *> nodes_to_visit;
+              nodes_to_visit.push(subtree_root.get());
+              while (!nodes_to_visit.empty()) {
+                // NOLINTBEGIN(misc-const-correctness)
+                GameNodeRep *current_unreachable_node = nodes_to_visit.top();
+                // NOLINTEND(misc-const-correctness)
+                nodes_to_visit.pop();
+                result.insert(current_unreachable_node);
+                for (const auto &unreachable_child : current_unreachable_node->GetChildren()) {
+                  nodes_to_visit.push(unreachable_child.get());
+                }
               }
             }
           }
         }
-      }
-      else {
-        position.emplace(child->GetActions().begin());
+        else {
+          position.emplace(child->GetActions().begin());
+        }
       }
     }
-  }
+
+    return result;
+  });
 }
 
-void GameTreeRep::BuildSubgameRoots() const
+const GameTreeRep::SubgameData &GameTreeRep::GetSubgameData() const
 {
-  if (m_subgameData.m_valid) {
-    return;
-  }
-  if (m_root->IsTerminal()) {
-    m_subgameData.m_valid = true;
-    return;
-  }
-
-  struct Range {
-    int m_min = std::numeric_limits<int>::max();
-    int m_max = 0;
-
-    void Merge(const Range &p_source)
-    {
-      m_min = std::min(m_min, p_source.m_min);
-      m_max = std::max(m_max, p_source.m_max);
+  return m_subgameData.Get([&] {
+    SubgameData sd;
+    if (m_root->IsTerminal()) {
+      return sd;
     }
 
-    bool operator==(const Range &p_other) const
-    {
-      return m_min == p_other.m_min && m_max == p_other.m_max;
-    }
-  };
+    struct Range {
+      int m_min = std::numeric_limits<int>::max();
+      int m_max = 0;
 
-  std::unordered_map<GameNodeRep *, Range> disc;
-  std::unordered_map<GameInfosetRep *, Range> hull;
-
-  // Phase 1: Compute subtree spans and infoset hulls
-  struct SpanVisitor {
-    std::unordered_map<GameNodeRep *, Range> &m_disc;
-    std::unordered_map<GameInfosetRep *, Range> &m_hull;
-    int m_counter = 0;
-
-    static DFSCallbackResult OnEnter(GameNode, int) { return DFSCallbackResult::Continue; }
-    static DFSCallbackResult OnAction(GameNode, GameNode, int)
-    {
-      return DFSCallbackResult::Continue;
-    }
-    static void OnVisit(GameNode, int) {}
-
-    DFSCallbackResult OnExit(const GameNode &p_node, int)
-    {
-      GameNodeRep *node = p_node.get();
-      if (p_node->IsTerminal()) {
-        m_counter++;
-        m_disc[node] = {m_counter, m_counter};
+      void Merge(const Range &p_source)
+      {
+        m_min = std::min(m_min, p_source.m_min);
+        m_max = std::max(m_max, p_source.m_max);
       }
-      else {
-        Range &node_disc = m_disc[node];
-        const auto &children = p_node->GetChildren();
-        node_disc.m_min = m_disc.at(children.front().get()).m_min;
-        node_disc.m_max = m_disc.at(children.back().get()).m_max;
-        m_hull[node->m_infoset].Merge(node_disc);
+
+      bool operator==(const Range &p_other) const
+      {
+        return m_min == p_other.m_min && m_max == p_other.m_max;
       }
-      return DFSCallbackResult::Continue;
-    }
-  };
+    };
 
-  // Phase 2: Reachability and detection
-  struct BridgeVisitor {
-    std::unordered_map<GameNodeRep *, Range> &m_disc;
-    const std::unordered_map<GameInfosetRep *, Range> &m_hull;
-    std::vector<GameNodeRep *> &m_subgames;
-    std::unordered_map<GameNodeRep *, Range> m_low;
+    std::unordered_map<GameNodeRep *, Range> disc;
+    std::unordered_map<GameInfosetRep *, Range> hull;
 
-    static DFSCallbackResult OnEnter(GameNode, int) { return DFSCallbackResult::Continue; }
-    static DFSCallbackResult OnAction(GameNode, GameNode, int)
-    {
-      return DFSCallbackResult::Continue;
-    }
-    static void OnVisit(GameNode, int) {}
+    // Phase 1: Compute subtree spans and infoset hulls
+    struct SpanVisitor {
+      std::unordered_map<GameNodeRep *, Range> &m_disc;
+      std::unordered_map<GameInfosetRep *, Range> &m_hull;
+      int m_counter = 0;
 
-    DFSCallbackResult OnExit(const GameNode &p_node, int)
-    {
-      GameNodeRep *node = p_node.get();
-      if (p_node->IsTerminal()) {
-        m_low[node] = m_disc.at(node);
+      static DFSCallbackResult OnEnter(GameNode, int) { return DFSCallbackResult::Continue; }
+      static DFSCallbackResult OnAction(GameNode, GameNode, int)
+      {
+        return DFSCallbackResult::Continue;
+      }
+      static void OnVisit(GameNode, int) {}
+
+      DFSCallbackResult OnExit(const GameNode &p_node, int)
+      {
+        GameNodeRep *node = p_node.get();
+        if (p_node->IsTerminal()) {
+          m_counter++;
+          m_disc[node] = {m_counter, m_counter};
+        }
+        else {
+          Range &node_disc = m_disc[node];
+          const auto &children = p_node->GetChildren();
+          node_disc.m_min = m_disc.at(children.front().get()).m_min;
+          node_disc.m_max = m_disc.at(children.back().get()).m_max;
+          m_hull[node->m_infoset].Merge(node_disc);
+        }
+        return DFSCallbackResult::Continue;
+      }
+    };
+
+    // Phase 2: Reachability and detection
+    struct BridgeVisitor {
+      std::unordered_map<GameNodeRep *, Range> &m_disc;
+      const std::unordered_map<GameInfosetRep *, Range> &m_hull;
+      std::vector<GameNodeRep *> &m_subgames;
+      std::unordered_map<GameNodeRep *, Range> m_low;
+
+      static DFSCallbackResult OnEnter(GameNode, int) { return DFSCallbackResult::Continue; }
+      static DFSCallbackResult OnAction(GameNode, GameNode, int)
+      {
+        return DFSCallbackResult::Continue;
+      }
+      static void OnVisit(GameNode, int) {}
+
+      DFSCallbackResult OnExit(const GameNode &p_node, int)
+      {
+        GameNodeRep *node = p_node.get();
+        if (p_node->IsTerminal()) {
+          m_low[node] = m_disc.at(node);
+          return DFSCallbackResult::Continue;
+        }
+
+        Range &low = m_low[node];
+        low = m_hull.at(node->m_infoset);
+
+        for (const auto &child : p_node->GetChildren()) {
+          low.Merge(m_low.at(child.get()));
+          m_low.erase(child.get());
+        }
+
+        if (low == m_disc.at(node)) {
+          // The `low == disc` test is exact only with distinct terminal spans. A single-action
+          // chain above a candidate node collapses the spans and can create false positives.
+          // Reject a node if some single-action ancestor's infoset (possibly the node's own)
+          // has a member in the node's subtree (possibly the node itself).
+          // Note that such an infoset is necessarily absent-minded.
+          bool spurious = false;
+          for (auto *anc = node->m_parent; anc && anc->m_children.size() == 1 && !spurious;
+               anc = anc->m_parent) {
+            const auto &members = anc->m_infoset->m_members;
+            spurious = members.size() >= 2 &&
+                       std::any_of(members.begin(), members.end(), [&](const auto &member) {
+                         return member.get() != anc && member->IsSuccessorOf(p_node);
+                       });
+          }
+          if (!spurious) {
+            m_subgames.push_back(node);
+          }
+        }
+
+        return DFSCallbackResult::Continue;
+      }
+    };
+
+    auto game = std::const_pointer_cast<GameRep>(shared_from_this());
+
+    SpanVisitor span_visitor{disc, hull};
+    WalkDFS(game, m_root, TraversalOrder::Postorder, span_visitor);
+
+    BridgeVisitor bridge_visitor{disc, hull, sd.m_subgamePostorder};
+    WalkDFS(game, m_root, TraversalOrder::Postorder, bridge_visitor);
+
+    // Phase 3: Build subgame tree with subgame differences
+    struct SubgameVisitor {
+      const std::unordered_set<GameNodeRep *> &m_roots;
+      std::unordered_map<GameNodeRep *, std::shared_ptr<GameSubgameRep>> &m_cache;
+      GameTreeRep *m_game;
+      // Subgame roots on the current DFS path, innermost at back
+      std::vector<GameNodeRep *> m_stack;
+      std::unordered_set<GameInfosetRep *> m_infosetVisited;
+
+      DFSCallbackResult OnEnter(const GameNode &p_node, int)
+      {
+        if (p_node->IsTerminal()) {
+          return DFSCallbackResult::Continue;
+        }
+        GameNodeRep *node = p_node.get();
+        if (contains(m_roots, node)) {
+          auto subgame = std::make_shared<GameSubgameRep>(m_game, node);
+          if (!m_stack.empty()) {
+            auto &parent_subgame = m_cache.at(m_stack.back());
+            subgame->m_parent = parent_subgame;
+            parent_subgame->m_children.push_back(subgame);
+          }
+          m_cache.emplace(node, std::move(subgame));
+          m_stack.push_back(node);
+        }
+        if (m_infosetVisited.insert(node->m_infoset).second) {
+          m_cache.at(m_stack.back())
+              ->m_subgameDifference.emplace_back(node->m_infoset->shared_from_this());
+        }
         return DFSCallbackResult::Continue;
       }
 
-      Range &low = m_low[node];
-      low = m_hull.at(node->m_infoset);
-
-      for (const auto &child : p_node->GetChildren()) {
-        low.Merge(m_low.at(child.get()));
-        m_low.erase(child.get());
-      }
-
-      if (low == m_disc.at(node)) {
-        // The `low == disc` test is exact only with distinct terminal spans. A single-action
-        // chain above a candidate node collapses the spans and can create false positives.
-        // Reject a node if some single-action ancestor's infoset (possibly the node's own)
-        // has a member in the node's subtree (possibly the node itself).
-        // Note that such an infoset is necessarily absent-minded.
-        bool spurious = false;
-        for (auto *anc = node->m_parent; anc && anc->m_children.size() == 1 && !spurious;
-             anc = anc->m_parent) {
-          const auto &members = anc->m_infoset->m_members;
-          spurious = members.size() >= 2 &&
-                     std::any_of(members.begin(), members.end(), [&](const auto &member) {
-                       return member.get() != anc && member->IsSuccessorOf(p_node);
-                     });
+      DFSCallbackResult OnExit(const GameNode &p_node, int)
+      {
+        if (!m_stack.empty() && m_stack.back() == p_node.get()) {
+          m_stack.pop_back();
         }
-        if (!spurious) {
-          m_subgames.push_back(node);
-        }
-      }
-
-      return DFSCallbackResult::Continue;
-    }
-  };
-
-  auto game = std::const_pointer_cast<GameRep>(shared_from_this());
-
-  SpanVisitor span_visitor{disc, hull};
-  WalkDFS(game, m_root, TraversalOrder::Postorder, span_visitor);
-
-  BridgeVisitor bridge_visitor{disc, hull, m_subgameData.m_subgamePostorder};
-  WalkDFS(game, m_root, TraversalOrder::Postorder, bridge_visitor);
-
-  // Phase 3: Build subgame tree with subgame differences
-  struct SubgameVisitor {
-    const std::unordered_set<GameNodeRep *> &m_roots;
-    std::unordered_map<GameNodeRep *, std::shared_ptr<GameSubgameRep>> &m_cache;
-    GameTreeRep *m_game;
-    // Subgame roots on the current DFS path, innermost at back
-    std::vector<GameNodeRep *> m_stack;
-    std::unordered_set<GameInfosetRep *> m_infosetVisited;
-
-    DFSCallbackResult OnEnter(const GameNode &p_node, int)
-    {
-      if (p_node->IsTerminal()) {
         return DFSCallbackResult::Continue;
       }
-      GameNodeRep *node = p_node.get();
-      if (contains(m_roots, node)) {
-        auto subgame = std::make_shared<GameSubgameRep>(m_game, node);
-        if (!m_stack.empty()) {
-          auto &parent_subgame = m_cache.at(m_stack.back());
-          subgame->m_parent = parent_subgame;
-          parent_subgame->m_children.push_back(subgame);
-        }
-        m_cache.emplace(node, std::move(subgame));
-        m_stack.push_back(node);
+
+      static DFSCallbackResult OnAction(GameNode, GameNode, int)
+      {
+        return DFSCallbackResult::Continue;
       }
-      if (m_infosetVisited.insert(node->m_infoset).second) {
-        m_cache.at(m_stack.back())
-            ->m_subgameDifference.emplace_back(node->m_infoset->shared_from_this());
-      }
-      return DFSCallbackResult::Continue;
-    }
+      static void OnVisit(GameNode, int) {}
+    };
 
-    DFSCallbackResult OnExit(const GameNode &p_node, int)
-    {
-      if (!m_stack.empty() && m_stack.back() == p_node.get()) {
-        m_stack.pop_back();
-      }
-      return DFSCallbackResult::Continue;
-    }
+    const std::unordered_set<GameNodeRep *> subgame_root_set(sd.m_subgamePostorder.begin(),
+                                                             sd.m_subgamePostorder.end());
 
-    static DFSCallbackResult OnAction(GameNode, GameNode, int)
-    {
-      return DFSCallbackResult::Continue;
-    }
-    static void OnVisit(GameNode, int) {}
-  };
-
-  const std::unordered_set<GameNodeRep *> subgame_root_set(
-      m_subgameData.m_subgamePostorder.begin(), m_subgameData.m_subgamePostorder.end());
-
-  SubgameVisitor subgame_visitor{subgame_root_set, m_subgameData.m_subgameByRoot,
-                                 const_cast<GameTreeRep *>(this)};
-  WalkDFS(game, m_root, TraversalOrder::Preorder, subgame_visitor);
-  m_subgameData.m_valid = true;
+    SubgameVisitor subgame_visitor{subgame_root_set, sd.m_subgameByRoot,
+                                   const_cast<GameTreeRep *>(this)};
+    WalkDFS(game, m_root, TraversalOrder::Preorder, subgame_visitor);
+    return sd;
+  });
 }
 
 std::vector<GameSubgame> GameTreeRep::GetSubgames() const
 {
-  BuildSubgameRoots();
+  const auto &subgameData = GetSubgameData();
   std::vector<GameSubgame> result;
-  result.reserve(m_subgameData.m_subgamePostorder.size());
-  for (auto *rep : m_subgameData.m_subgamePostorder) {
-    result.emplace_back(m_subgameData.m_subgameByRoot.at(rep));
+  result.reserve(subgameData.m_subgamePostorder.size());
+  for (auto *rep : subgameData.m_subgamePostorder) {
+    result.emplace_back(subgameData.m_subgameByRoot.at(rep));
   }
   return result;
 }
@@ -1500,7 +1486,7 @@ void GameTreeRep::WriteEfgFile(std::ostream &p_file, const GameNode &p_subtree /
 
 void GameTreeRep::WriteNfgFile(std::ostream &p_file) const
 {
-  BuildComputedValues();
+  EnsureStrategies();
   GameRep::WriteNfgFile(p_file);
 }
 
@@ -1604,7 +1590,6 @@ void GameTreeRep::DeleteOutcome(const GameOutcome &p_outcome)
   std::for_each(
       m_outcomes.begin(), m_outcomes.end(),
       [outc = 1](const std::shared_ptr<GameOutcomeRep> &c) mutable { c->m_number = outc++; });
-  ClearComputedValues();
 }
 
 //------------------------------------------------------------------------
@@ -1626,7 +1611,6 @@ Game GameTreeRep::SetChanceProbs(const GameInfoset &p_infoset, const Array<Numbe
   ValidateDistribution(p_probs);
   IncrementVersion();
   std::copy(p_probs.begin(), p_probs.end(), p_infoset->m_probs.begin());
-  ClearComputedValues();
   return shared_from_this();
 }
 
@@ -1664,7 +1648,7 @@ MixedStrategyProfile<double> GameTreeRep::NewMixedStrategyProfile(double) const
   if (!IsPerfectRecall()) {
     throw UndefinedException("Mixed strategies not supported for games with imperfect recall.");
   }
-  BuildComputedValues();
+  EnsureStrategies();
   return StrategySupportProfile(std::const_pointer_cast<GameRep>(shared_from_this()))
       .NewMixedStrategyProfile<double>();
 }
@@ -1674,7 +1658,7 @@ MixedStrategyProfile<Rational> GameTreeRep::NewMixedStrategyProfile(const Ration
   if (!IsPerfectRecall()) {
     throw UndefinedException("Mixed strategies not supported for games with imperfect recall.");
   }
-  BuildComputedValues();
+  EnsureStrategies();
   return StrategySupportProfile(std::const_pointer_cast<GameRep>(shared_from_this()))
       .NewMixedStrategyProfile<Rational>();
 }
@@ -1685,7 +1669,7 @@ GameTreeRep::NewMixedStrategyProfile(double, const StrategySupportProfile &spt) 
   if (!IsPerfectRecall()) {
     throw UndefinedException("Mixed strategies not supported for games with imperfect recall.");
   }
-  BuildComputedValues();
+  EnsureStrategies();
   return MixedStrategyProfile<double>(std::make_unique<TreeMixedStrategyProfileRep<double>>(spt));
 }
 
@@ -1695,7 +1679,7 @@ GameTreeRep::NewMixedStrategyProfile(const Rational &, const StrategySupportProf
   if (!IsPerfectRecall()) {
     throw UndefinedException("Mixed strategies not supported for games with imperfect recall.");
   }
-  BuildComputedValues();
+  EnsureStrategies();
   return MixedStrategyProfile<Rational>(
       std::make_unique<TreeMixedStrategyProfileRep<Rational>>(spt));
 }
@@ -1725,7 +1709,7 @@ public:
 
 PureStrategyProfile GameTreeRep::NewPureStrategyProfile() const
 {
-  BuildComputedValues();
+  EnsureStrategies();
   return PureStrategyProfile(std::make_shared<TreePureStrategyProfileRep>(
       std::const_pointer_cast<GameRep>(shared_from_this())));
 }

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -23,6 +23,7 @@
 #ifndef GAMETREE_H
 #define GAMETREE_H
 
+#include "core/lazy.h"
 #include "gameexpl.h"
 #include "seqpure.h"
 #include <unordered_map>
@@ -41,15 +42,15 @@ class GameTreeRep final : public GameExplicitRep {
   };
 
 protected:
-  mutable bool m_computedValues{false}, m_nodesOrdered{false}, m_infosetsOrdered{false},
-      m_hasSequences{false};
+  mutable LazyAction m_nodeOrdering, m_infosetOrdering, m_strategies, m_sequences;
   std::shared_ptr<GameNodeRep> m_root;
   std::shared_ptr<GamePlayerRep> m_chance;
   std::size_t m_numNodes = 1;
   std::size_t m_numNonterminalNodes = 0;
   std::map<GameNodeRep *, std::vector<GameNodeRep *>> m_nodePlays;
+  mutable LazyAction m_ownPriorActions;
   mutable std::shared_ptr<OwnPriorActionInfo> m_ownPriorActionInfo;
-  mutable std::unique_ptr<std::set<GameNodeRep *>> m_unreachableNodes;
+  mutable Lazy<std::set<GameNodeRep *>> m_unreachableNodes;
   mutable std::set<GameInfosetRep *> m_absentMindedInfosets;
   mutable std::vector<std::pair<GameInfosetRep *, GameNodeRep *>> m_absentMindedReentries;
   // The subgames of the game, held in two synchronized forms:
@@ -58,19 +59,8 @@ protected:
   struct SubgameData {
     std::vector<GameNodeRep *> m_subgamePostorder;
     std::unordered_map<GameNodeRep *, std::shared_ptr<GameSubgameRep>> m_subgameByRoot;
-    bool m_valid{false};
-
-    void Invalidate()
-    {
-      for (const auto &[node, subgame] : m_subgameByRoot) {
-        subgame->Invalidate();
-      }
-      m_subgamePostorder.clear();
-      m_subgameByRoot.clear();
-      m_valid = false;
-    }
   };
-  mutable SubgameData m_subgameData;
+  mutable Lazy<SubgameData> m_subgameData;
 
   /// @name Private auxiliary functions
   //@{
@@ -87,14 +77,14 @@ protected:
   /// Jointly invalidates the ordering of the nodes and the ordering of the information sets.
   void InvalidateTreeOrdering() const
   {
-    m_nodesOrdered = false;
-    m_infosetsOrdered = false;
+    m_nodeOrdering.Invalidate();
+    m_infosetOrdering.Invalidate();
   }
-  void InvalidateInfosetOrdering() const { m_infosetsOrdered = false; }
+  void InvalidateInfosetOrdering() const { m_infosetOrdering.Invalidate(); }
   void EnsureNodeOrdering() const override;
   void EnsureInfosetOrdering() const override;
 
-  void BuildComputedValues() const override;
+  void EnsureStrategies() const override;
   void BuildConsistentPlays();
   void ClearComputedValues() const;
 
@@ -211,10 +201,9 @@ public:
 
 private:
   std::vector<GameNodeRep *> BuildConsistentPlaysRecursiveImpl(GameNodeRep *node);
-  void BuildOwnPriorActions() const;
-  void BuildUnreachableNodes() const;
-  void EnsureSubgames() const;
-  void BuildSubgameRoots() const;
+  void EnsureOwnPriorActions() const;
+  const std::set<GameNodeRep *> &GetUnreachableNodes() const;
+  const SubgameData &GetSubgameData() const;
 };
 
 template <class T> class TreeMixedStrategyProfileRep : public MixedStrategyProfileRep<T> {

--- a/src/games/stratspt.cc
+++ b/src/games/stratspt.cc
@@ -34,7 +34,7 @@ namespace Gambit {
 
 StrategySupportProfile::StrategySupportProfile(const Game &p_game) : m_game(p_game)
 {
-  m_game->BuildComputedValues();
+  m_game->EnsureStrategies();
   for (const auto &player : m_game->GetPlayers()) {
     for (const auto &strategy : player->GetStrategies()) {
       m_support[player].push_back(strategy);


### PR DESCRIPTION
This standardises the handling of invalidating and computing cached quantities internal to the game models, and ensures that caches are built only once in the event of multi-threaded execution.

