### PR TITLE
Small fix to action on clicking branch label

### DIFF
--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -1255,6 +1255,16 @@ void EfgDisplay::OnLeftDoubleClick(wxMouseEvent &p_event)
     return;
   }
 
+  if (m_doc->GetStyle().GetBranchAboveLabel() == GBT_BRANCH_LABEL_LABEL) {
+    node = m_layout.BranchAboveHitTest(x, y);
+    if (node) {
+      m_doc->SetSelectNode(node);
+      const wxCommandEvent event(wxEVT_COMMAND_MENU_SELECTED, GBT_MENU_EDIT_MOVE);
+      wxPostEvent(this, event);
+      return;
+    }
+  }
+
   if (m_doc->GetStyle().GetBranchBelowLabel() == GBT_BRANCH_LABEL_LABEL) {
     node = m_layout.BranchBelowHitTest(x, y);
     if (node) {

--- a/src/gui/efglayout.cc
+++ b/src/gui/efglayout.cc
@@ -410,36 +410,6 @@ GameNode TreeLayout::BranchBelowHitTest(int p_x, int p_y) const
   return (hit != m_nodeList.end()) ? (*hit)->GetNode()->GetParent() : nullptr;
 }
 
-bool TreeLayout::InfosetHitTest(const std::shared_ptr<NodeEntry> &p_entry, const int p_x,
-                                const int p_y) const
-{
-  auto nextMember = ComputeNextInInfoset(p_entry);
-  if (nextMember && p_entry->GetNode()->GetInfoset()) {
-    if (p_x > p_entry->m_x + p_entry->GetSublevel() * m_infosetSpacing - 2 &&
-        p_x < p_entry->m_x + p_entry->GetSublevel() * m_infosetSpacing + 2) {
-      if (p_y > p_entry->m_y && p_y < nextMember->m_y) {
-        // next infoset is below this one
-        return true;
-      }
-      if (p_y > nextMember->m_y && p_y < p_entry->m_y) {
-        // next infoset is above this one
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-GameNode TreeLayout::InfosetHitTest(int p_x, int p_y) const
-{
-  const auto hit =
-      std::find_if(m_nodeList.begin(), m_nodeList.end(),
-                   [this, p_x, p_y](const std::shared_ptr<NodeEntry> &p_entry) -> bool {
-                     return InfosetHitTest(p_entry, p_x, p_y);
-                   });
-  return (hit != m_nodeList.end()) ? (*hit)->GetNode() : nullptr;
-}
-
 wxString TreeLayout::CreateNodeLabel(const std::shared_ptr<NodeEntry> &p_entry, int p_which) const
 {
   const GameNode n = p_entry->GetNode();

--- a/src/gui/efglayout.h
+++ b/src/gui/efglayout.h
@@ -165,8 +165,6 @@ public:
   GameNode OutcomeHitTest(int, int) const;
   GameNode BranchAboveHitTest(int, int) const;
   GameNode BranchBelowHitTest(int, int) const;
-  bool InfosetHitTest(const std::shared_ptr<NodeEntry> &p_entry, int p_x, int p_y) const;
-  GameNode InfosetHitTest(int, int) const;
 
   void Render(wxDC &, bool p_noHints) const;
 };


### PR DESCRIPTION
Clicking on a branch label which contained an action label is intended to display a dialog box to edit the move. This was implemented for the below-label but at some point the same behaviour for the above-label was lost.
