### PR TITLE
Migrate some solvers to run in threads in GUI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -213,6 +213,7 @@ core_SOURCES = \
     src/core/core.h \
     src/core/util.h \
 	src/core/array.h \
+	src/core/cancel.h \
 	src/core/lazy.h \
 	src/core/vector.h \
 	src/core/segment.h \
@@ -449,6 +450,23 @@ gambit_simpdiv_SOURCES = \
 
 gambit_SOURCES = \
 	${core_SOURCES} ${game_SOURCES} \
+	${linalg_SOURCES} \
+	src/solvers/enummixed/clique.cc \
+	src/solvers/enummixed/clique.h \
+	src/solvers/enummixed/enummixed.cc \
+	src/solvers/enummixed/enummixed.h \
+	src/solvers/lcp/lcp.h \
+	src/solvers/lcp/efglcp.cc \
+	src/solvers/lcp/nfglcp.cc \
+	src/solvers/lp/lp.h \
+	src/solvers/lp/lp.cc \
+	src/solvers/logit/logbehav.h \
+	src/solvers/logit/logbehav.imp \
+	src/solvers/logit/path.cc \
+	src/solvers/logit/path.h \
+	src/solvers/logit/logit.h \
+	src/solvers/logit/efglogit.cc \
+	src/solvers/logit/nfglogit.cc \
 	src/labenski/src/sheetatr.cpp \
 	src/labenski/src/sheet.cpp \
 	src/labenski/src/sheetedg.cpp \
@@ -498,6 +516,7 @@ gambit_SOURCES = \
 	src/gui/dlnash.cc \
 	src/gui/dlnash.h \
 	src/gui/dlnashmon.cc \
+	src/gui/nashspec.cc \
 	src/gui/nashspec.h \
 	src/gui/dlnewtable.cc \
 	src/gui/dlnewtable.h \

--- a/src/core/cancel.h
+++ b/src/core/cancel.h
@@ -1,0 +1,66 @@
+//
+// This file is part of Gambit
+// Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
+//
+// FILE: src/core/cancel.h
+// Cooperative cancellation of long-running computations
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#ifndef GAMBIT_CORE_CANCEL_H
+#define GAMBIT_CORE_CANCEL_H
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+
+namespace Gambit {
+
+/// @brief Thrown by CancelToken::Check() to unwind out of a computation when
+/// cancellation has been requested.
+class ComputationCanceledException : public std::runtime_error {
+public:
+  ComputationCanceledException() : std::runtime_error("Computation canceled") {}
+};
+
+/// @brief A cooperative cancellation flag, shared between the thread running
+/// a long computation and the thread (e.g. a GUI) that may want to stop it
+/// early.
+///
+/// A computation takes a CancelToken by const reference and calls Check() at
+/// its own natural iteration points (once per candidate/pivot/step, not tied
+/// to how often it happens to produce a result); Check() throws
+/// ComputationCanceledException once RequestCancel() has been called from
+/// another thread. A default-constructed token is never canceled, so
+/// passing one costs nothing for callers that don't need cancellation.
+class CancelToken {
+public:
+  void RequestCancel() const { m_canceled->store(true); }
+  bool IsCanceled() const { return m_canceled->load(); }
+  void Check() const
+  {
+    if (IsCanceled()) {
+      throw ComputationCanceledException();
+    }
+  }
+
+private:
+  std::shared_ptr<std::atomic<bool>> m_canceled = std::make_shared<std::atomic<bool>>(false);
+};
+
+} // namespace Gambit
+
+#endif // GAMBIT_CORE_CANCEL_H

--- a/src/games/nash.h
+++ b/src/games/nash.h
@@ -24,6 +24,7 @@
 #define LIBGAMBIT_NASH_H
 
 #include <functional>
+#include "core/cancel.h"
 #include "gambit.h"
 
 namespace Gambit::Nash {

--- a/src/gui/dlnashmon.cc
+++ b/src/gui/dlnashmon.cc
@@ -24,6 +24,7 @@
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif // WX_PRECOMP
+#include <wx/thread.h>
 #include <wx/txtstrm.h>
 #include <wx/process.h>
 #include <wx/tokenzr.h>
@@ -33,6 +34,7 @@
 #include "wx/sheet/sheet.h"
 
 #include "gamedoc.h"
+#include "nashspec.h"
 
 #include "efgprofile.h"
 #include "nfgprofile.h"
@@ -49,9 +51,6 @@ wxDECLARE_EVENT(wxEVT_EXTERNAL_RUNNER_FINISHED, wxThreadEvent);
 wxDEFINE_EVENT(wxEVT_EXTERNAL_RUNNER_FINISHED, wxThreadEvent);
 
 #include "bitmaps/stop.xpm"
-
-using ComputedProfile = std::variant<MixedStrategyProfile<double>, MixedStrategyProfile<Rational>,
-                                     MixedBehaviorProfile<double>, MixedBehaviorProfile<Rational>>;
 
 template <class T>
 void AddProfile(AnalysisOutput &p_output, const MixedStrategyProfile<T> &p_profile)
@@ -252,9 +251,61 @@ public:
   }
 };
 
+//
+// Runs a solver directly, in-process, on a worker thread, rather than
+// shelling out to a gambit-<method> executable. Knows nothing about any
+// particular method -- it just calls whatever SolverFunction it was given
+// (see NashComputationSpec::MakeSolver()), which is where the knowledge of
+// which methods are instrumented, and how to call each one, actually lives.
+class SolverThreadRunner final : public wxThread {
+  wxEvtHandler *m_parent;
+  Game m_game;
+  SolverFunction m_solver;
+  CancelToken m_cancel;
+
+  void PostProfile(const ComputedProfile &p_profile) const
+  {
+    auto *event = new wxThreadEvent(wxEVT_EXTERNAL_RUNNER_PROFILE);
+    event->SetPayload(p_profile);
+    wxQueueEvent(m_parent, event);
+  }
+
+  ExitCode Entry() override
+  {
+    int exitCode = 0;
+    try {
+      m_solver(
+          m_game, [this](const ComputedProfile &p) { PostProfile(p); }, m_cancel);
+    }
+    catch (const ComputationCanceledException &) {
+      // Not an error -- NashMonitorDialog's m_stopRequested flag (already
+      // set before RequestCancel() was called) is what determines that the
+      // "finished" event below is reported as a stop rather than a failure.
+    }
+    catch (const std::exception &) {
+      exitCode = 1;
+    }
+
+    auto *evt = new wxThreadEvent(wxEVT_EXTERNAL_RUNNER_FINISHED);
+    evt->SetInt(exitCode);
+    wxQueueEvent(m_parent, evt);
+    return static_cast<wxThread::ExitCode>(0);
+  }
+
+public:
+  SolverThreadRunner(wxEvtHandler *p_parent, Game p_game, SolverFunction p_solver)
+    : wxThread(wxTHREAD_JOINABLE), m_parent(p_parent), m_game(std::move(p_game)),
+      m_solver(std::move(p_solver))
+  {
+  }
+
+  void RequestCancel() { m_cancel.RequestCancel(); }
+};
+
 class NashMonitorDialog final : public wxDialog {
   GameDocument *m_doc;
   std::unique_ptr<class ExternalProcessRunner> m_runner;
+  std::unique_ptr<class SolverThreadRunner> m_threadRunner;
   wxWindow *m_profileList;
   wxStaticText *m_statusText, *m_countText;
   wxButton *m_stopButton, *m_okButton;
@@ -365,6 +416,38 @@ void NashMonitorDialog::Start(const std::shared_ptr<AnalysisOutput> &p_command)
 
   m_doc->DoAddEquilibriumOutput(p_command);
 
+  const auto &spec = p_command->GetComputationSpec();
+  if (auto solver = spec ? spec->MakeSolver() : std::nullopt) {
+    // Force whichever of the game's lazily-built caches this computation
+    // will need to be built on this (the main) thread before handing the
+    // game to the worker thread -- GameRep's lazy caches are not
+    // synchronized against concurrent first touch from two threads. Only
+    // warm what's actually needed for the representation in play: forcing
+    // GetStrategies()'s reduced-strategy derivation for a behavior-form
+    // solve would needlessly do (potentially expensive) extra work on the
+    // main thread that the computation itself never uses.
+    if (spec->representation == NashRepresentation::Behavior) {
+      // EnsureInfosetOrdering() itself is protected; constructing a
+      // profile forces it via the same public code path the worker's own
+      // starting profile will use.
+      MixedBehaviorProfile<double> warmup(m_doc->GetGame());
+      m_doc->GetGame()->EnsureSequences();
+    }
+    else {
+      m_doc->GetGame()->GetStrategies();
+    }
+
+    m_threadRunner =
+        std::make_unique<SolverThreadRunner>(this, m_doc->GetGame(), std::move(*solver));
+    if (m_threadRunner->Run() != wxTHREAD_NO_ERROR) {
+      m_threadRunner.reset();
+      SetStatusFinishedAbnormally("Failed to launch solver thread.");
+      return;
+    }
+    SetStatusRunning();
+    return;
+  }
+
   std::ostringstream s;
   if (p_command->IsBehavior()) {
     m_doc->GetGame()->Write(s, "efg");
@@ -405,6 +488,14 @@ void NashMonitorDialog::OnRunnerFinished(wxThreadEvent &p_event)
 {
   m_stopButton->Enable(false);
 
+  if (m_threadRunner) {
+    // Joinable thread: must be waited on before it can be safely destroyed.
+    // Entry() has already posted this event and is returning, so this
+    // should not block for any appreciable time.
+    m_threadRunner->Wait();
+    m_threadRunner.reset();
+  }
+
   if (m_stopRequested) {
     SetStatusStopped();
   }
@@ -421,19 +512,29 @@ void NashMonitorDialog::OnStop(wxCommandEvent &)
 {
   m_stopRequested = true;
   SetStatusStopping();
-  m_runner->Stop();
+  if (m_threadRunner) {
+    m_threadRunner->RequestCancel();
+  }
+  else {
+    m_runner->Stop();
+  }
 }
 
 void NashMonitorDialog::OnClose(wxCloseEvent &p_event)
 {
-  if (!m_runner || !m_stopButton->IsEnabled()) {
+  if ((!m_runner && !m_threadRunner) || !m_stopButton->IsEnabled()) {
     p_event.Skip();
     return;
   }
 
   m_stopRequested = true;
   SetStatusStopping();
-  m_runner->Stop();
+  if (m_threadRunner) {
+    m_threadRunner->RequestCancel();
+  }
+  else {
+    m_runner->Stop();
+  }
 
   if (p_event.CanVeto()) {
     p_event.Veto();

--- a/src/gui/nashspec.cc
+++ b/src/gui/nashspec.cc
@@ -1,0 +1,123 @@
+//
+// This file is part of Gambit
+// Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
+//
+// Builds in-process, cancellable solver functions for Nash equilibrium
+// computations initiated by the GUI.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#include "nashspec.h"
+
+#include "solvers/enummixed/enummixed.h"
+#include "solvers/enumpure/enumpure.h"
+#include "solvers/lcp/lcp.h"
+#include "solvers/logit/logit.h"
+#include "solvers/lp/lp.h"
+
+namespace Gambit::GUI {
+
+std::optional<SolverFunction> EnumPureNashSpec::MakeSolver(NashRepresentation) const
+{
+  return [](const Game &p_game, const ProfileFoundCallback &p_callback,
+            const CancelToken &p_cancel) {
+    Nash::EnumPureStrategySolve(
+        p_game,
+        [&p_callback](const MixedStrategyProfile<Rational> &p) { p_callback(ComputedProfile(p)); },
+        p_cancel);
+  };
+}
+
+std::optional<SolverFunction> EnumMixedNashSpec::MakeSolver(NashRepresentation) const
+{
+  return [](const Game &p_game, const ProfileFoundCallback &p_callback,
+            const CancelToken &p_cancel) {
+    Nash::EnumMixedStrategySolve<Rational>(
+        p_game,
+        [&p_callback](const MixedStrategyProfile<Rational> &p) { p_callback(ComputedProfile(p)); },
+        p_cancel);
+  };
+}
+
+std::optional<SolverFunction> LPNashSpec::MakeSolver(NashRepresentation p_representation) const
+{
+  if (p_representation == NashRepresentation::Behavior) {
+    return [](const Game &p_game, const ProfileFoundCallback &p_callback,
+              const CancelToken &p_cancel) {
+      Nash::LpBehaviorSolve<Rational>(
+          p_game,
+          [&p_callback](const MixedBehaviorProfile<Rational> &p) {
+            p_callback(ComputedProfile(p));
+          },
+          p_cancel);
+    };
+  }
+  return [](const Game &p_game, const ProfileFoundCallback &p_callback,
+            const CancelToken &p_cancel) {
+    Nash::LpStrategySolve<Rational>(
+        p_game,
+        [&p_callback](const MixedStrategyProfile<Rational> &p) { p_callback(ComputedProfile(p)); },
+        p_cancel);
+  };
+}
+
+std::optional<SolverFunction> LCPNashSpec::MakeSolver(NashRepresentation p_representation) const
+{
+  if (p_representation == NashRepresentation::Behavior) {
+    return [](const Game &p_game, const ProfileFoundCallback &p_callback,
+              const CancelToken &p_cancel) {
+      Nash::LcpBehaviorSolve<Rational>(
+          p_game,
+          [&p_callback](const MixedBehaviorProfile<Rational> &p) {
+            p_callback(ComputedProfile(p));
+          },
+          p_cancel);
+    };
+  }
+  const LCPNashSpec spec = *this;
+  return [spec](const Game &p_game, const ProfileFoundCallback &p_callback,
+                const CancelToken &p_cancel) {
+    Nash::LcpStrategySolve<Rational>(
+        p_game, spec.stopAfter, spec.maxDepth,
+        [&p_callback](const MixedStrategyProfile<Rational> &p) { p_callback(ComputedProfile(p)); },
+        p_cancel);
+  };
+}
+
+std::optional<SolverFunction> LogitNashSpec::MakeSolver(NashRepresentation p_representation) const
+{
+  const LogitNashSpec spec = *this;
+  if (p_representation == NashRepresentation::Behavior) {
+    return [spec](const Game &p_game, const ProfileFoundCallback &p_callback,
+                  const CancelToken &p_cancel) {
+      const LogitQREMixedBehaviorProfile start(p_game);
+      LogitBehaviorSolve(
+          start, spec.maxRegret, spec.omega, spec.firstStep, spec.maxAcceleration,
+          [&p_callback](const MixedBehaviorProfile<double> &p) { p_callback(ComputedProfile(p)); },
+          NullLogitEventCallback<LogitQREMixedBehaviorProfile>, p_cancel);
+    };
+  }
+  return [spec](const Game &p_game, const ProfileFoundCallback &p_callback,
+                const CancelToken &p_cancel) {
+    const LogitQREMixedStrategyProfile start(p_game);
+    LogitStrategySolve(
+        start, spec.maxRegret, spec.omega, spec.firstStep, spec.maxAcceleration,
+        [&p_callback](const MixedStrategyProfile<double> &p) { p_callback(ComputedProfile(p)); },
+        NullLogitEventCallback<LogitQREMixedStrategyProfile>, p_cancel);
+  };
+}
+
+} // namespace Gambit::GUI

--- a/src/gui/nashspec.h
+++ b/src/gui/nashspec.h
@@ -22,8 +22,12 @@
 #ifndef GAMBIT_GUI_NASHSPEC_H
 #define GAMBIT_GUI_NASHSPEC_H
 
+#include <functional>
+#include <optional>
 #include <variant>
 
+#include "core/cancel.h"
+#include "games/nash.h"
 #include "core/rational.h"
 
 namespace Gambit::GUI {
@@ -31,12 +35,47 @@ namespace Gambit::GUI {
 enum class NashRepresentation { Strategic, Behavior };
 enum class NashEquilibriumTarget { One, Some, All };
 
-struct EnumPureNashSpec {};
-struct EnumMixedNashSpec {};
+/// A profile found by an in-process computation, in whichever of the four
+/// shapes (strategy/behavior, double/Rational) the method in question
+/// produces.
+using ComputedProfile = std::variant<MixedStrategyProfile<double>, MixedStrategyProfile<Rational>,
+                                     MixedBehaviorProfile<double>, MixedBehaviorProfile<Rational>>;
+
+/// Reports one profile found by an in-process computation.
+using ProfileFoundCallback = std::function<void(const ComputedProfile &)>;
+
+/// A runnable in-process Nash computation: given the game, a callback to
+/// report each equilibrium found, and a token to cooperatively cancel it.
+using SolverFunction =
+    std::function<void(const Game &, const ProfileFoundCallback &, const CancelToken &)>;
+
+//
+// Each method spec below provides its own MakeSolver(), returning a
+// SolverFunction that runs it in-process, or std::nullopt if its solver
+// hasn't been instrumented with a CancelToken yet (the default for
+// everything not yet touched). This is the only thing NashComputationSpec
+// needs from whichever alternative its `method` variant holds -- adding or
+// instrumenting a method never requires touching any other method's spec,
+// NashComputationSpec itself, or any of its callers.
+//
+// The non-trivial ones (those returning more than std::nullopt) are
+// implemented out of line, in nashspec.cc, which is the only place that
+// needs to depend on the solvers' own headers.
+//
+
+struct EnumPureNashSpec {
+  std::optional<SolverFunction> MakeSolver(NashRepresentation p_representation) const;
+};
+
+struct EnumMixedNashSpec {
+  std::optional<SolverFunction> MakeSolver(NashRepresentation p_representation) const;
+};
 
 struct EnumPolyNashSpec {
   int stopAfter{0};
   double maxRegret{1.0e-4};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation) const { return std::nullopt; }
 };
 
 struct GNMNashSpec {
@@ -45,23 +84,33 @@ struct GNMNashSpec {
   int steps{100};
   int localNewtonInterval{3};
   int localNewtonMaxIterations{10};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation) const { return std::nullopt; }
 };
 
 struct IPANashSpec {
   int perturbations{1};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation) const { return std::nullopt; }
 };
 
-struct LPNashSpec {};
+struct LPNashSpec {
+  std::optional<SolverFunction> MakeSolver(NashRepresentation p_representation) const;
+};
 
 struct LCPNashSpec {
   int stopAfter{0};
   int maxDepth{0};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation p_representation) const;
 };
 
 struct LiapNashSpec {
   int startingPoints{10};
   double maxRegret{1.0e-4};
   int maxIterations{1000};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation) const { return std::nullopt; }
 };
 
 struct LogitNashSpec {
@@ -69,6 +118,8 @@ struct LogitNashSpec {
   double omega{1.0};
   double firstStep{0.03};
   double maxAcceleration{1.1};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation p_representation) const;
 };
 
 struct SimpdivNashSpec {
@@ -77,6 +128,8 @@ struct SimpdivNashSpec {
   int gridResize{2};
   int leashLength{0};
   Rational maxRegret{1, 10000000};
+
+  std::optional<SolverFunction> MakeSolver(NashRepresentation) const { return std::nullopt; }
 };
 
 using NashMethodSpec =
@@ -88,6 +141,16 @@ struct NashComputationSpec {
   NashEquilibriumTarget target;
   NashMethodSpec method;
   bool selectedByRecommendation{false};
+
+  /// Build a function that runs this computation in-process on a worker
+  /// thread, or std::nullopt if this method/representation combination
+  /// has not been instrumented with cooperative cancellation -- callers
+  /// should fall back to running the external gambit-<method> process in
+  /// that case. Just forwards to whichever method's own MakeSolver().
+  std::optional<SolverFunction> MakeSolver() const
+  {
+    return std::visit([this](const auto &m) { return m.MakeSolver(representation); }, method);
+  }
 };
 
 } // namespace Gambit::GUI

--- a/src/solvers/enummixed/enummixed.cc
+++ b/src/solvers/enummixed/enummixed.cc
@@ -79,7 +79,8 @@ Array<Array<MixedStrategyProfile<T>>> EnumMixedStrategySolution<T>::GetCliques()
 
 template <class T>
 std::shared_ptr<EnumMixedStrategySolution<T>>
-EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onEquilibrium)
+EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onEquilibrium,
+                               const CancelToken &p_cancel)
 {
   if (p_game->NumPlayers() != 2) {
     throw UndefinedException("Method only valid for two-player games.");
@@ -127,8 +128,8 @@ EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onE
   b2 = (T)-1;
 
   // enumerate vertices of A1 x + b1 <= 0 and A2 x + b2 <= 0
-  const VertexEnumerator<T> poly1(A1, b1);
-  const VertexEnumerator<T> poly2(A2, b2);
+  const VertexEnumerator<T> poly1(A1, b1, p_cancel);
+  const VertexEnumerator<T> poly2(A2, b2, p_cancel);
 
   const auto &verts1(poly1.VertexList());
   const auto &verts2(poly2.VertexList());
@@ -145,6 +146,7 @@ EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onE
   for (int i2 = 2; i2 <= solution->m_v2; i2++) {
     const BFS<T> &bfs1 = verts2[i2];
     for (int i1 = 2; i1 <= solution->m_v1; i1++) {
+      p_cancel.Check();
       const BFS<T> &bfs2 = verts1[i1];
 
       // check if solution is nash
@@ -204,8 +206,10 @@ template class EnumMixedStrategySolution<double>;
 template class EnumMixedStrategySolution<Rational>;
 
 template std::shared_ptr<EnumMixedStrategySolution<double>>
-EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<double> p_onEquilibrium);
+EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<double> p_onEquilibrium,
+                               const CancelToken &p_cancel);
 template std::shared_ptr<EnumMixedStrategySolution<Rational>>
-EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<Rational> p_onEquilibrium);
+EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<Rational> p_onEquilibrium,
+                               const CancelToken &p_cancel);
 
 } // end namespace Gambit::Nash

--- a/src/solvers/enummixed/enummixed.h
+++ b/src/solvers/enummixed/enummixed.h
@@ -64,14 +64,16 @@ public:
 template <class T>
 std::shared_ptr<EnumMixedStrategySolution<T>>
 EnumMixedStrategySolveDetailed(const Game &p_game,
-                               StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>);
+                               StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>,
+                               const CancelToken &p_cancel = CancelToken());
 
 template <class T>
 std::list<MixedStrategyProfile<T>>
 EnumMixedStrategySolve(const Game &p_game,
-                       StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>)
+                       StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>,
+                       const CancelToken &p_cancel = CancelToken())
 {
-  return EnumMixedStrategySolveDetailed<T>(p_game, p_onEquilibrium)->m_extremeEquilibria;
+  return EnumMixedStrategySolveDetailed<T>(p_game, p_onEquilibrium, p_cancel)->m_extremeEquilibria;
 }
 
 } // end namespace Gambit::Nash

--- a/src/solvers/enumpure/enumpure.h
+++ b/src/solvers/enumpure/enumpure.h
@@ -46,7 +46,8 @@ inline bool IsNash(const PureStrategyProfile &p_profile)
 ///
 inline std::list<MixedStrategyProfile<Rational>> EnumPureStrategySolve(
     const Game &p_game,
-    StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>)
+    StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>,
+    const CancelToken &p_cancel = CancelToken())
 {
   if (!p_game->IsPerfectRecall()) {
     throw UndefinedException(
@@ -54,6 +55,7 @@ inline std::list<MixedStrategyProfile<Rational>> EnumPureStrategySolve(
   }
   std::list<MixedStrategyProfile<Rational>> solutions;
   for (const auto &profile : StrategyContingencies(p_game)) {
+    p_cancel.Check();
     if (IsNash(profile)) {
       solutions.push_back(profile->ToMixedStrategyProfile());
       p_onEquilibrium(solutions.back());

--- a/src/solvers/lcp/efglcp.cc
+++ b/src/solvers/lcp/efglcp.cc
@@ -179,7 +179,8 @@ MixedBehaviorProfile<T> GetProfile(const linalg::LemkeTableau<T> &tab, const Vec
 //
 template <class T>
 std::list<MixedBehaviorProfile<T>> LcpBehaviorSolve(const Game &p_game,
-                                                    BehaviorCallbackType<T> p_onEquilibrium)
+                                                    BehaviorCallbackType<T> p_onEquilibrium,
+                                                    const CancelToken &p_cancel)
 {
   if (p_game->NumPlayers() != 2) {
     throw UndefinedException("Method only valid for two-player games.");
@@ -193,7 +194,7 @@ std::list<MixedBehaviorProfile<T>> LcpBehaviorSolve(const Game &p_game,
   linalg::LemkeTableau<T> tab(ConstructMatrix<T>(columns), ConstructVector<T>(columns));
 
   tab.Pivot(columns.rootIndex1, 0);
-  tab.SF_LCPPath(columns.rootIndex1);
+  tab.SF_LCPPath(columns.rootIndex1, p_cancel);
   Vector<T> sol(tab.MinRow(), tab.MaxRow());
   tab.BasisVector(sol);
 
@@ -206,9 +207,9 @@ std::list<MixedBehaviorProfile<T>> LcpBehaviorSolve(const Game &p_game,
   return equilibria;
 }
 
-template std::list<MixedBehaviorProfile<double>> LcpBehaviorSolve(const Game &,
-                                                                  BehaviorCallbackType<double>);
+template std::list<MixedBehaviorProfile<double>>
+LcpBehaviorSolve(const Game &, BehaviorCallbackType<double>, const CancelToken &);
 template std::list<MixedBehaviorProfile<Rational>>
-LcpBehaviorSolve(const Game &, BehaviorCallbackType<Rational>);
+LcpBehaviorSolve(const Game &, BehaviorCallbackType<Rational>, const CancelToken &);
 
 } // end namespace Gambit::Nash

--- a/src/solvers/lcp/lcp.h
+++ b/src/solvers/lcp/lcp.h
@@ -30,12 +30,14 @@ namespace Gambit::Nash {
 template <class T>
 std::list<MixedStrategyProfile<T>>
 LcpStrategySolve(const Game &p_game, int p_stopAfter, int p_maxDepth,
-                 StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>);
+                 StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>,
+                 const CancelToken &p_cancel = CancelToken());
 
 template <class T>
 std::list<MixedBehaviorProfile<T>>
 LcpBehaviorSolve(const Game &p_game,
-                 BehaviorCallbackType<T> p_onEquilibrium = NullBehaviorCallback<T>);
+                 BehaviorCallbackType<T> p_onEquilibrium = NullBehaviorCallback<T>,
+                 const CancelToken &p_cancel = CancelToken());
 
 } // end namespace Gambit::Nash
 

--- a/src/solvers/lcp/nfglcp.cc
+++ b/src/solvers/lcp/nfglcp.cc
@@ -112,8 +112,10 @@ template <class T> Vector<T> Make_b2(const Game &p_game)
 template <class T> class NashLcpStrategySolver {
 public:
   NashLcpStrategySolver(int p_stopAfter, int p_maxDepth,
-                        StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>)
-    : m_onEquilibrium(p_onEquilibrium), m_stopAfter(p_stopAfter), m_maxDepth(p_maxDepth)
+                        StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>,
+                        const CancelToken &p_cancel = CancelToken())
+    : m_onEquilibrium(p_onEquilibrium), m_stopAfter(p_stopAfter), m_maxDepth(p_maxDepth),
+      m_cancel(p_cancel)
   {
   }
   ~NashLcpStrategySolver() = default;
@@ -125,6 +127,7 @@ private:
 
   StrategyCallbackType<T> m_onEquilibrium;
   int m_stopAfter, m_maxDepth;
+  CancelToken m_cancel;
 
   class Solution;
 
@@ -225,6 +228,8 @@ typename NashLcpStrategySolver<T>::SearchResult
 NashLcpStrategySolver<T>::AllLemke(const Game &p_game, int j, linalg::LHTableau<T> &B,
                                    Solution &p_solution, int depth) const
 {
+  m_cancel.Check();
+
   if (m_maxDepth != 0 && depth > m_maxDepth) {
     return SearchResult::Continue;
   }
@@ -244,7 +249,7 @@ NashLcpStrategySolver<T>::AllLemke(const Game &p_game, int j, linalg::LHTableau<
   for (int i = B.MinCol(); i <= B.MaxCol(); i++) {
     if (i != j) {
       linalg::LHTableau<T> Bcopy(B);
-      Bcopy.LemkePath(i);
+      Bcopy.LemkePath(i, m_cancel);
       if (AllLemke(p_game, i, Bcopy, p_solution, depth + 1) == SearchResult::LimitReached) {
         return SearchResult::LimitReached;
       }
@@ -275,23 +280,24 @@ std::list<MixedStrategyProfile<T>> NashLcpStrategySolver<T>::Solve(const Game &p
     AllLemke(p_game, 0, B, solution, 0);
   }
   else {
-    B.LemkePath(1);
+    B.LemkePath(1, m_cancel);
     OnBFS(p_game, B, solution);
   }
   return solution.m_equilibria;
 }
 
 template <class T>
-std::list<MixedStrategyProfile<T>> LcpStrategySolve(const Game &p_game, int p_stopAfter,
-                                                    int p_maxDepth,
-                                                    StrategyCallbackType<T> p_onEquilibrium)
+std::list<MixedStrategyProfile<T>>
+LcpStrategySolve(const Game &p_game, int p_stopAfter, int p_maxDepth,
+                 StrategyCallbackType<T> p_onEquilibrium, const CancelToken &p_cancel)
 {
-  return NashLcpStrategySolver<T>(p_stopAfter, p_maxDepth, p_onEquilibrium).Solve(p_game);
+  return NashLcpStrategySolver<T>(p_stopAfter, p_maxDepth, p_onEquilibrium, p_cancel)
+      .Solve(p_game);
 }
 
-template std::list<MixedStrategyProfile<double>> LcpStrategySolve(const Game &, int, int,
-                                                                  StrategyCallbackType<double>);
+template std::list<MixedStrategyProfile<double>>
+LcpStrategySolve(const Game &, int, int, StrategyCallbackType<double>, const CancelToken &);
 template std::list<MixedStrategyProfile<Rational>>
-LcpStrategySolve(const Game &, int, int, StrategyCallbackType<Rational>);
+LcpStrategySolve(const Game &, int, int, StrategyCallbackType<Rational>, const CancelToken &);
 
 } // end namespace Gambit::Nash

--- a/src/solvers/linalg/lemketab.h
+++ b/src/solvers/linalg/lemketab.h
@@ -23,6 +23,7 @@
 #ifndef GAMBIT_LINALG_LEMKETAB_H
 #define GAMBIT_LINALG_LEMKETAB_H
 
+#include "core/cancel.h"
 #include "tableau.h"
 
 namespace Gambit::linalg {
@@ -44,7 +45,9 @@ public:
 
   int SF_PivotIn(int i);
   int SF_ExitIndex(int i);
-  int SF_LCPPath(int dup); // follow a path of ACBFS's from one CBFS to another
+  int SF_LCPPath(int dup,
+                 const CancelToken &p_cancel = CancelToken()); // follow a path of ACBFS's
+                                                               // from one CBFS to another
   int ExitIndex(int i);
 };
 

--- a/src/solvers/linalg/lemketab.imp
+++ b/src/solvers/linalg/lemketab.imp
@@ -174,12 +174,13 @@ template <class T> int LemkeTableau<T>::ExitIndex(int inlabel)
 // Executes one step of the Lemke-Howson algorithm
 //
 
-template <class T> int LemkeTableau<T>::SF_LCPPath(int dup)
+template <class T> int LemkeTableau<T>::SF_LCPPath(int dup, const CancelToken &p_cancel)
 {
   int enter, exit;
   enter = dup;
   // Central loop - pivot until another CBFS is found
   do {
+    p_cancel.Check();
     // Talk about optimism! This is dumb, but better than nothing (I guess):
     exit = SF_PivotIn(enter);
     if (exit == enter) {

--- a/src/solvers/linalg/lhtab.h
+++ b/src/solvers/linalg/lhtab.h
@@ -23,6 +23,7 @@
 #ifndef GAMBIT_LINALG_LHTAB_H
 #define GAMBIT_LINALG_LHTAB_H
 
+#include "core/cancel.h"
 #include "lemketab.h"
 
 namespace Gambit::linalg {
@@ -73,7 +74,7 @@ public:
   int PivotIn(int i);
   int ExitIndex(int i);
   /// Follow a path of ACBFS's from one CBFS to another
-  int LemkePath(int dup);
+  int LemkePath(int dup, const CancelToken &p_cancel = CancelToken());
   //@}
 
 protected:

--- a/src/solvers/linalg/lhtab.imp
+++ b/src/solvers/linalg/lhtab.imp
@@ -117,7 +117,7 @@ template <class T> int LHTableau<T>::ExitIndex(int inlabel)
   return 0;
 }
 
-template <class T> int LHTableau<T>::LemkePath(int dup)
+template <class T> int LHTableau<T>::LemkePath(int dup, const CancelToken &p_cancel)
 {
   int enter, exit;
   enter = dup;
@@ -126,6 +126,7 @@ template <class T> int LHTableau<T>::LemkePath(int dup)
   }
   // Central loop - pivot until another CBFS is found
   do {
+    p_cancel.Check();
     exit = PivotIn(enter);
     enter = -exit;
   } while ((exit != dup) && (exit != -dup));

--- a/src/solvers/linalg/lpsolve.h
+++ b/src/solvers/linalg/lpsolve.h
@@ -23,6 +23,7 @@
 #ifndef LPSOLVE_H
 #define LPSOLVE_H
 
+#include "core/cancel.h"
 #include "gambit.h"
 #include "lptab.h"
 
@@ -50,6 +51,7 @@ private:
   Array<T> ub, lb;
   Vector<T> xx, cost;
   Vector<T> y, x, d;
+  CancelToken m_cancel;
 
   void Solve(int phase = 0);
   int Enter();
@@ -57,7 +59,8 @@ private:
 
 public:
   LPSolve(const Matrix<T> &A, const Vector<T> &B, const Vector<T> &C,
-          int nequals); // nequals = number of equalities (last nequals rows)
+          int nequals, // nequals = number of equalities (last nequals rows)
+          const CancelToken &p_cancel = CancelToken());
   ~LPSolve() = default;
 
   T OptimumCost() const { return total_cost; }

--- a/src/solvers/linalg/lpsolve.imp
+++ b/src/solvers/linalg/lpsolve.imp
@@ -36,11 +36,12 @@ template <class T> Array<int> MakeArtificials(const Vector<T> &b)
 }
 
 template <class T>
-LPSolve<T>::LPSolve(const Matrix<T> &A, const Vector<T> &b, const Vector<T> &c, int nequals)
+LPSolve<T>::LPSolve(const Matrix<T> &A, const Vector<T> &b, const Vector<T> &c, int nequals,
+                    const CancelToken &p_cancel)
   : nvars(c.size()), neqns(b.size()), nequals(nequals), total_cost(0), tmin(0),
     tab(A, MakeArtificials(b), b), UB(nvars + neqns), LB(nvars + neqns), ub(nvars + neqns),
     lb(nvars + neqns), xx(nvars + neqns), cost(nvars + neqns), y(b.size()), x(b.size()),
-    d(b.size())
+    d(b.size()), m_cancel(p_cancel)
 {
   // These are the values recommended by Murtagh (1981) for 15 digit
   // accuracy in LP problems
@@ -162,6 +163,7 @@ template <class T> void LPSolve<T>::Solve(int phase)
   const Vector<T> a(neqns);
 
   do {
+    m_cancel.Check();
     // step 1: Solve y B = c_B
     do {
       in = Enter(); // step 2: Choose entering variable

--- a/src/solvers/linalg/vertenum.h
+++ b/src/solvers/linalg/vertenum.h
@@ -23,6 +23,7 @@
 #ifndef GAMBIT_LINALG_VERTENUM_H
 #define GAMBIT_LINALG_VERTENUM_H
 
+#include "core/cancel.h"
 #include "gambit.h"
 #include "lptab.h"
 
@@ -51,13 +52,15 @@ private:
   Vector<T> btemp;
   Array<BFS<T>> m_list, m_duallist;
   Array<long> visits, branches;
+  CancelToken m_cancel;
 
   void Deeper();
   void Search(LPTableau<T> &tab);
   void DualSearch(LPTableau<T> &tab);
 
 public:
-  VertexEnumerator(const Matrix<T> &, const Vector<T> &);
+  VertexEnumerator(const Matrix<T> &, const Vector<T> &,
+                   const CancelToken &p_cancel = CancelToken());
   // explicit VertexEnumerator(LPTableau<T> &);
   ~VertexEnumerator() = default;
 

--- a/src/solvers/linalg/vertenum.imp
+++ b/src/solvers/linalg/vertenum.imp
@@ -25,9 +25,10 @@
 namespace Gambit::linalg {
 
 template <class T>
-VertexEnumerator<T>::VertexEnumerator(const Matrix<T> &A, const Vector<T> &b)
+VertexEnumerator<T>::VertexEnumerator(const Matrix<T> &A, const Vector<T> &b,
+                                      const CancelToken &p_cancel)
   : mult_opt(std::any_of(b.begin(), b.end(), [](const T &v) { return v == static_cast<T>(0); })),
-    A(A), b(b), btemp(b)
+    A(A), b(b), btemp(b), m_cancel(p_cancel)
 {
   btemp = static_cast<T>(-1); // NOLINT(cppcoreguidelines-prefer-member-initializer)
   LPTableau<T> tab(A, b);
@@ -50,6 +51,7 @@ template <class T> void VertexEnumerator<T>::Deeper()
 
 template <class T> void VertexEnumerator<T>::Search(LPTableau<T> &tab)
 {
+  m_cancel.Check();
   Deeper();
   if (tab.IsLexMin()) {
     m_list.push_back(tab.GetBFS1());
@@ -70,6 +72,7 @@ template <class T> void VertexEnumerator<T>::Search(LPTableau<T> &tab)
 
 template <class T> void VertexEnumerator<T>::DualSearch(LPTableau<T> &tab)
 {
+  m_cancel.Check();
   Deeper();
   branches[depth] += 1;
 

--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -309,11 +309,10 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
 
 namespace Gambit {
 
-std::list<LogitQREMixedBehaviorProfile>
-LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
-                   Nash::BehaviorCallbackType<double> p_onEquilibrium,
-                   LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent)
+std::list<LogitQREMixedBehaviorProfile> LogitBehaviorSolve(
+    const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
+    double p_firstStep, double p_maxAccel, Nash::BehaviorCallbackType<double> p_onEquilibrium,
+    LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent, const CancelToken &p_cancel)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -341,7 +340,8 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
       [game, p_regret](const Vector<double> &p_point) {
         return RegretTerminationFunction(game, p_point, p_regret);
       },
-      [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
+      [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); },
+      NullCriterionFunction, NullCriterionBracketFunction, p_cancel);
   const auto &profiles = callback.GetProfiles();
   p_onEquilibrium(profiles.back().GetProfile());
   return profiles;

--- a/src/solvers/logit/logit.h
+++ b/src/solvers/logit/logit.h
@@ -96,7 +96,8 @@ std::list<LogitQREMixedStrategyProfile> LogitStrategySolve(
     double p_firstStep, double p_maxAccel,
     Nash::StrategyCallbackType<double> p_onEquilibrium = Nash::NullStrategyCallback<double>,
     LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent =
-        NullLogitEventCallback<LogitQREMixedStrategyProfile>);
+        NullLogitEventCallback<LogitQREMixedStrategyProfile>,
+    const CancelToken &p_cancel = CancelToken());
 
 std::list<LogitQREMixedStrategyProfile>
 LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
@@ -118,7 +119,8 @@ std::list<LogitQREMixedBehaviorProfile> LogitBehaviorSolve(
     double p_firstStep, double p_maxAccel,
     Nash::BehaviorCallbackType<double> p_onEquilibrium = Nash::NullBehaviorCallback<double>,
     LogitEventCallbackType<LogitQREMixedBehaviorProfile> p_onEvent =
-        NullLogitEventCallback<LogitQREMixedBehaviorProfile>);
+        NullLogitEventCallback<LogitQREMixedBehaviorProfile>,
+    const CancelToken &p_cancel = CancelToken());
 
 std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -347,11 +347,10 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
 
 } // namespace
 
-std::list<LogitQREMixedStrategyProfile>
-LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
-                   Nash::StrategyCallbackType<double> p_onEquilibrium,
-                   LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent)
+std::list<LogitQREMixedStrategyProfile> LogitStrategySolve(
+    const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
+    double p_firstStep, double p_maxAccel, Nash::StrategyCallbackType<double> p_onEquilibrium,
+    LogitEventCallbackType<LogitQREMixedStrategyProfile> p_onEvent, const CancelToken &p_cancel)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -380,7 +379,8 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
       [p_start, p_regret](const Vector<double> &p_point) {
         return RegretTerminationFunction(p_start.GetGame(), p_point, p_regret);
       },
-      [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); });
+      [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); },
+      NullCriterionFunction, NullCriterionBracketFunction, p_cancel);
   const auto &profiles = callback.GetProfiles();
   p_onEquilibrium(profiles.back().GetProfile());
   return profiles;

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -130,7 +130,8 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
                       std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
                       Vector<double> &x, double &p_omega, TerminationFunctionType p_terminate,
                       CallbackFunctionType p_callback, CriterionFunctionType p_criterion,
-                      CriterionBracketFunctionType p_criterionBracket) const
+                      CriterionBracketFunctionType p_criterionBracket,
+                      const CancelToken &p_cancel) const
 {
   const double c_tol = 1.0e-4;   // tolerance for corrector iteration
   const double c_maxDist = 0.4;  // maximal distance to curve
@@ -159,6 +160,8 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   p_callback(x);
 
   while (!p_terminate(x)) {
+    p_cancel.Check();
+
     bool accept = true;
 
     if (fabs(h) <= c_hmin) {

--- a/src/solvers/logit/path.h
+++ b/src/solvers/logit/path.h
@@ -24,6 +24,7 @@
 #define PATH_H
 
 #include <functional>
+#include "core/cancel.h"
 
 namespace Gambit {
 
@@ -86,7 +87,8 @@ public:
             Vector<double> &p_x, double &p_omega, TerminationFunctionType p_terminate,
             CallbackFunctionType p_callback = NullCallbackFunction,
             CriterionFunctionType p_criterion = NullCriterionFunction,
-            CriterionBracketFunctionType p_criterionBracker = NullCriterionBracketFunction) const;
+            CriterionBracketFunctionType p_criterionBracker = NullCriterionBracketFunction,
+            const CancelToken &p_cancel = CancelToken()) const;
 
 private:
   double m_maxDecel{1.1}, m_hStart{0.03};

--- a/src/solvers/lp/lp.cc
+++ b/src/solvers/lp/lp.cc
@@ -197,9 +197,9 @@ MixedBehaviorProfile<T> GetBehavior(const Array<T> &p_primal, const Array<T> &p_
 //
 template <class T>
 void SolveLP(const Matrix<T> &A, const Vector<T> &b, const Vector<T> &c, int nequals,
-             Array<T> &p_primal, Array<T> &p_dual)
+             Array<T> &p_primal, Array<T> &p_dual, const CancelToken &p_cancel = CancelToken())
 {
-  const linalg::LPSolve<T> LP(A, b, c, nequals);
+  const linalg::LPSolve<T> LP(A, b, c, nequals, p_cancel);
   const auto &cbfs = LP.OptimumBFS();
 
   for (size_t i = 1; i <= A.NumColumns(); i++) {
@@ -212,7 +212,8 @@ void SolveLP(const Matrix<T> &A, const Vector<T> &b, const Vector<T> &c, int neq
 
 template <class T>
 std::list<MixedBehaviorProfile<T>> LpBehaviorSolve(const Game &p_game,
-                                                   BehaviorCallbackType<T> p_onEquilibrium)
+                                                   BehaviorCallbackType<T> p_onEquilibrium,
+                                                   const CancelToken &p_cancel)
 {
   if (p_game->NumPlayers() != 2) {
     throw UndefinedException("Method only valid for two-player games.");
@@ -231,7 +232,7 @@ std::list<MixedBehaviorProfile<T>> LpBehaviorSolve(const Game &p_game,
   const Vector<T> c = ConstructC<T>(indexMap);
 
   Array<T> primal(A.NumColumns()), dual(A.NumRows());
-  SolveLP(A, b, c, indexMap.equalityRows, primal, dual);
+  SolveLP(A, b, c, indexMap.equalityRows, primal, dual, p_cancel);
 
   MixedBehaviorProfile<T> profile = GetBehavior(primal, dual, indexMap);
   profile.UndefinedToCentroid();
@@ -242,14 +243,15 @@ std::list<MixedBehaviorProfile<T>> LpBehaviorSolve(const Game &p_game,
   return solution;
 }
 
-template std::list<MixedBehaviorProfile<double>> LpBehaviorSolve(const Game &,
-                                                                 BehaviorCallbackType<double>);
-template std::list<MixedBehaviorProfile<Rational>> LpBehaviorSolve(const Game &,
-                                                                   BehaviorCallbackType<Rational>);
+template std::list<MixedBehaviorProfile<double>>
+LpBehaviorSolve(const Game &, BehaviorCallbackType<double>, const CancelToken &);
+template std::list<MixedBehaviorProfile<Rational>>
+LpBehaviorSolve(const Game &, BehaviorCallbackType<Rational>, const CancelToken &);
 
 template <class T>
 std::list<MixedStrategyProfile<T>> LpStrategySolve(const Game &p_game,
-                                                   StrategyCallbackType<T> p_onEquilibrium)
+                                                   StrategyCallbackType<T> p_onEquilibrium,
+                                                   const CancelToken &p_cancel)
 {
   if (p_game->NumPlayers() != 2) {
     throw UndefinedException("Method only valid for two-player games.");
@@ -291,7 +293,7 @@ std::list<MixedStrategyProfile<T>> LpStrategySolve(const Game &p_game,
   c[m + 1] = static_cast<T>(1);
 
   Array<T> primal(A.NumColumns()), dual(A.NumRows());
-  SolveLP(A, b, c, 1, primal, dual);
+  SolveLP(A, b, c, 1, primal, dual, p_cancel);
 
   MixedStrategyProfile<T> eqm(p_game->NewMixedStrategyProfile(static_cast<T>(0)));
   for (int j = 1; j <= m; j++) {
@@ -306,9 +308,9 @@ std::list<MixedStrategyProfile<T>> LpStrategySolve(const Game &p_game,
   return solution;
 }
 
-template std::list<MixedStrategyProfile<double>> LpStrategySolve(const Game &,
-                                                                 StrategyCallbackType<double>);
-template std::list<MixedStrategyProfile<Rational>> LpStrategySolve(const Game &,
-                                                                   StrategyCallbackType<Rational>);
+template std::list<MixedStrategyProfile<double>>
+LpStrategySolve(const Game &, StrategyCallbackType<double>, const CancelToken &);
+template std::list<MixedStrategyProfile<Rational>>
+LpStrategySolve(const Game &, StrategyCallbackType<Rational>, const CancelToken &);
 
 } // end namespace Gambit::Nash

--- a/src/solvers/lp/lp.h
+++ b/src/solvers/lp/lp.h
@@ -30,12 +30,14 @@ namespace Gambit::Nash {
 template <class T>
 std::list<MixedStrategyProfile<T>>
 LpStrategySolve(const Game &p_game,
-                StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>);
+                StrategyCallbackType<T> p_onEquilibrium = NullStrategyCallback<T>,
+                const CancelToken &p_cancel = CancelToken());
 
 template <class T>
 std::list<MixedBehaviorProfile<T>>
 LpBehaviorSolve(const Game &p_game,
-                BehaviorCallbackType<T> p_onEquilibrium = NullBehaviorCallback<T>);
+                BehaviorCallbackType<T> p_onEquilibrium = NullBehaviorCallback<T>,
+                const CancelToken &p_cancel = CancelToken());
 
 }; // namespace Gambit::Nash
 


### PR DESCRIPTION
This is a step towards #990 - our goal of managing long-running equilibrium computation in the GUI process rather than depending on external tools and running in external processes.

For this change we are focusing on methods which do not take starting points, and therefore are not embarrassingly parallelisable.  Migrating those requires a bit more thought and work and so will be done in a separate tranche.

The methods which now run in threads by default are:
* `enumpure`
* `enummixed`
* `lcp`
* `lp`
* `logit`

To test: Run on several games, but ideally especially on some examples which run long enough to exercise the cancellation button.  Cancellation is cooperative, so the solvers have to be instrumented to poll for a cancellation request periodically and then act to shut themselves down.  This attempts to wire this so polling happens acceptably often on games of a size that are sensible to load in the graphical interface.
