### PR TITLE
Add tutorial: finding non-principal branches of the QRE correspondence

### DIFF
--- a/doc/pygambit.rst
+++ b/doc/pygambit.rst
@@ -43,6 +43,7 @@ Advanced tutorials:
 
    tutorials/advanced_tutorials/starting_points
    tutorials/advanced_tutorials/quantal_response
+   tutorials/advanced_tutorials/quantal_response_branches
    tutorials/advanced_tutorials/agent_versus_non_agent_regret
    .. pygambit.external_programs
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,3 +1,12 @@
+@article{Bla24,
+  author    = {Bland, J. R.},
+  title     = {Approximate computation and estimation of quantal response equilibrium through simulation},
+  journal   = {SSRN Working Paper},
+  number    = {4774850},
+  year      = {2024},
+  category  = {articles_equilibria}
+}
+
 @article{BlaTur23,
   author    = {Bland, J. R. and Turocy, T. L.},
   title     = {Quantal response equilibrium as a structural model for estimation: the missing manual},

--- a/doc/tutorials/advanced_tutorials/quantal_response_branches.ipynb
+++ b/doc/tutorials/advanced_tutorials/quantal_response_branches.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "49aaba9e",
+   "id": "c638ed3b",
    "metadata": {},
    "source": [
     "# Finding non-principal branches of the QRE correspondence\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6282bc79",
+   "id": "a34e895c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:05.854013Z",
-     "iopub.status.busy": "2026-07-22T11:38:05.853695Z",
-     "iopub.status.idle": "2026-07-22T11:38:07.284888Z",
-     "shell.execute_reply": "2026-07-22T11:38:07.283933Z"
+     "iopub.execute_input": "2026-08-01T21:08:39.576812Z",
+     "iopub.status.busy": "2026-08-01T21:08:39.576456Z",
+     "iopub.status.idle": "2026-08-01T21:08:40.969842Z",
+     "shell.execute_reply": "2026-08-01T21:08:40.969180Z"
     }
    },
    "outputs": [],
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2a3a15c",
+   "id": "3a564a0e",
    "metadata": {},
    "source": [
     "## A game whose correspondence has a second branch\n",
@@ -55,13 +55,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "999fb419",
+   "id": "fb28cafd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:07.287766Z",
-     "iopub.status.busy": "2026-07-22T11:38:07.287224Z",
-     "iopub.status.idle": "2026-07-22T11:38:07.296176Z",
-     "shell.execute_reply": "2026-07-22T11:38:07.294948Z"
+     "iopub.execute_input": "2026-08-01T21:08:40.973079Z",
+     "iopub.status.busy": "2026-08-01T21:08:40.972780Z",
+     "iopub.status.idle": "2026-08-01T21:08:40.979925Z",
+     "shell.execute_reply": "2026-08-01T21:08:40.979465Z"
     }
    },
    "outputs": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2111ab8",
+   "id": "d2cbc136",
    "metadata": {},
    "source": [
     "The principal branch starts from uniform play at $\\lambda = 0$.\n",
@@ -104,13 +104,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b7cd5985",
+   "id": "daebbd26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:07.297983Z",
-     "iopub.status.busy": "2026-07-22T11:38:07.297724Z",
-     "iopub.status.idle": "2026-07-22T11:38:07.482405Z",
-     "shell.execute_reply": "2026-07-22T11:38:07.481058Z"
+     "iopub.execute_input": "2026-08-01T21:08:40.982139Z",
+     "iopub.status.busy": "2026-08-01T21:08:40.981964Z",
+     "iopub.status.idle": "2026-08-01T21:08:41.134695Z",
+     "shell.execute_reply": "2026-08-01T21:08:41.133575Z"
     }
    },
    "outputs": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5fe6141",
+   "id": "33bbdb4c",
    "metadata": {},
    "source": [
     "## A density which concentrates on the correspondence\n",
@@ -169,13 +169,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "eda34d1f",
+   "id": "9c46d068",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:07.484403Z",
-     "iopub.status.busy": "2026-07-22T11:38:07.484142Z",
-     "iopub.status.idle": "2026-07-22T11:38:07.491479Z",
-     "shell.execute_reply": "2026-07-22T11:38:07.490602Z"
+     "iopub.execute_input": "2026-08-01T21:08:41.137394Z",
+     "iopub.status.busy": "2026-08-01T21:08:41.137198Z",
+     "iopub.status.idle": "2026-08-01T21:08:41.141928Z",
+     "shell.execute_reply": "2026-08-01T21:08:41.141507Z"
     }
    },
    "outputs": [],
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a7ea38f",
+   "id": "282194e6",
    "metadata": {},
    "source": [
     "## Sampling near the correspondence\n",
@@ -237,13 +237,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2ab7419e",
+   "id": "b80770c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:07.493923Z",
-     "iopub.status.busy": "2026-07-22T11:38:07.493691Z",
-     "iopub.status.idle": "2026-07-22T11:38:08.830996Z",
-     "shell.execute_reply": "2026-07-22T11:38:08.829969Z"
+     "iopub.execute_input": "2026-08-01T21:08:41.143627Z",
+     "iopub.status.busy": "2026-08-01T21:08:41.143447Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.154004Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.153519Z"
     }
    },
    "outputs": [
@@ -260,31 +260,39 @@
    ],
    "source": [
     "PENALTY_WEIGHT = 10_000.0  # w; the value used in the online appendix of [Bla24]\n",
-    "N_CHAINS = 12\n",
-    "N_ITER = 1_500\n",
     "STEP_SIZE = 0.15  # std. dev. of proposal increments in log-odds space\n",
     "\n",
+    "\n",
+    "def sample_locus(game, rng, n_chains, n_iter):\n",
+    "    \"\"\"Random-walk Metropolis on the penalised density.\n",
+    "\n",
+    "    Returns one row per draw: the fitted lambda*, then each player's probability\n",
+    "    of their first strategy, then the value of the penalty objective.\n",
+    "    \"\"\"\n",
+    "    draws = []\n",
+    "    for _ in range(n_chains):\n",
+    "        z = [np.log(rng.dirichlet(np.ones(len(p.strategies)))) for p in game.players]\n",
+    "        probs = [softmax(zi) for zi in z]\n",
+    "        obj, lam = obj_fun(game, probs)\n",
+    "        for _ in range(n_iter):\n",
+    "            z_prop = [zi + STEP_SIZE * rng.standard_normal(zi.shape) for zi in z]\n",
+    "            probs_prop = [softmax(zi) for zi in z_prop]\n",
+    "            obj_prop, lam_prop = obj_fun(game, probs_prop)\n",
+    "            if np.log(rng.uniform()) < PENALTY_WEIGHT * (obj_prop - obj):\n",
+    "                z, probs, obj, lam = z_prop, probs_prop, obj_prop, lam_prop\n",
+    "            draws.append([lam, *(pr[0] for pr in probs), obj])\n",
+    "    return np.array(draws)\n",
+    "\n",
+    "\n",
     "rng = np.random.default_rng(20260722)\n",
-    "draws = []\n",
-    "for _ in range(N_CHAINS):\n",
-    "    z = [np.log(rng.dirichlet(np.ones(len(p.strategies)))) for p in g.players]\n",
-    "    probs = [softmax(zi) for zi in z]\n",
-    "    obj, lam = obj_fun(g, probs)\n",
-    "    for _ in range(N_ITER):\n",
-    "        z_prop = [zi + STEP_SIZE * rng.standard_normal(zi.shape) for zi in z]\n",
-    "        probs_prop = [softmax(zi) for zi in z_prop]\n",
-    "        obj_prop, lam_prop = obj_fun(g, probs_prop)\n",
-    "        if np.log(rng.uniform()) < PENALTY_WEIGHT * (obj_prop - obj):\n",
-    "            z, probs, obj, lam = z_prop, probs_prop, obj_prop, lam_prop\n",
-    "        draws.append([lam, probs[0][0], probs[1][0], obj])\n",
-    "draws = np.array(draws)\n",
-    "on_locus = draws[draws[:, 3] > -1e-4]\n",
+    "draws = sample_locus(g, rng, n_chains=12, n_iter=1_500)\n",
+    "on_locus = draws[draws[:, -1] > -1e-4]\n",
     "len(on_locus), len(draws)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "acbdbfa2",
+   "id": "aff40926",
    "metadata": {},
    "source": [
     "Plotting the draws next to the principal branch reveals a second branch."
@@ -293,13 +301,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "466c2627",
+   "id": "4b637abb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:08.833026Z",
-     "iopub.status.busy": "2026-07-22T11:38:08.832821Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.012358Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.011307Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.156075Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.155891Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.305847Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.305302Z"
     }
    },
    "outputs": [
@@ -328,7 +336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a389bab",
+   "id": "9940a820",
    "metadata": {},
    "source": [
     "The second branch exists only above a minimum value of $\\lambda$, where its two sides meet at a *fold*.\n",
@@ -343,13 +351,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6e9a86fa",
+   "id": "c3f13dab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:09.014467Z",
-     "iopub.status.busy": "2026-07-22T11:38:09.014166Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.018940Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.018101Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.309086Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.308766Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.313580Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.313074Z"
     }
    },
    "outputs": [],
@@ -384,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "957626ef",
+   "id": "a881d7ff",
    "metadata": {},
    "source": [
     "Take the best draw on the upper side of the second branch and polish it."
@@ -393,13 +401,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "70e0fd70",
+   "id": "77a4278e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:09.020775Z",
-     "iopub.status.busy": "2026-07-22T11:38:09.020562Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.027868Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.027054Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.315563Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.315323Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.322926Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.322326Z"
     }
    },
    "outputs": [
@@ -428,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "637a02d4",
+   "id": "32e74704",
    "metadata": {},
    "source": [
     "## Tracing the branch\n",
@@ -441,13 +449,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "43c4b99c",
+   "id": "c6528ec5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:09.030119Z",
-     "iopub.status.busy": "2026-07-22T11:38:09.029786Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.127188Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.126075Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.324923Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.324679Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.399179Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.398011Z"
     }
    },
    "outputs": [
@@ -487,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2b9d921",
+   "id": "22cb65c5",
    "metadata": {},
    "source": [
     "The same procedure applied to a draw on the lower side traces the other half of the branch, which approaches the fold from below."
@@ -496,13 +504,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ef77347d",
+   "id": "c237a685",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:09.129099Z",
-     "iopub.status.busy": "2026-07-22T11:38:09.128853Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.221745Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.220732Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.403640Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.403445Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.481295Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.480563Z"
     }
    },
    "outputs": [
@@ -529,13 +537,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "fa4a36e8",
+   "id": "7d556b2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T11:38:09.223968Z",
-     "iopub.status.busy": "2026-07-22T11:38:09.223768Z",
-     "iopub.status.idle": "2026-07-22T11:38:09.345862Z",
-     "shell.execute_reply": "2026-07-22T11:38:09.345166Z"
+     "iopub.execute_input": "2026-08-01T21:08:42.484039Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.483812Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.587218Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.586717Z"
     }
    },
    "outputs": [
@@ -568,18 +576,490 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ed30af0",
+   "id": "8845932a",
+   "metadata": {},
+   "source": [
+    "The upper side of the second branch converges to the payoff-dominant equilibrium (Stag, Stag), and the lower side to the mixed equilibrium — neither of which can be found by following the correspondence from the centroid.\n",
+    "The two sides stop just short of each other at the fold, which fixed-$\\lambda$ continuation cannot go around.\n",
+    "\n",
+    "## A larger example: three players\n",
+    "\n",
+    "Nothing above is specific to $2\\times 2$ games.\n",
+    "The penalty needs only expected payoffs, which Gambit computes for any finite game, so the same functions apply unchanged to a larger game.\n",
+    "\n",
+    "We use the three-player game of McKelvey and McLennan (1997) distributed with Gambit and also used in the [starting points](starting_points.ipynb) tutorial.\n",
+    "It has nine Nash equilibria, two of them totally mixed — the largest number of regular totally mixed equilibria possible in a game of this size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "93207263",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:42.589632Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.589351Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.596768Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.596232Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9 Nash equilibria; totally mixed: [7, 8]\n",
+      "  #7: [[0.5, 0.5], [0.4, 0.6], [0.25, 0.75]]\n",
+      "  #8: [[0.4, 0.6], [0.5, 0.5], [0.3333, 0.6667]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "g3 = gbt.read_nfg(\"../../2x2x2.nfg\")\n",
+    "nash3 = [\n",
+    "    [np.array([float(eq[s]) for s in player.strategies]) for player in g3.players]\n",
+    "    for eq in gbt.nash.enumpoly_solve(g3).equilibria\n",
+    "]\n",
+    "totally_mixed = [i for i, eq in enumerate(nash3) if min(pr.min() for pr in eq) > 1e-9]\n",
+    "print(f\"{len(nash3)} Nash equilibria; totally mixed: {totally_mixed}\")\n",
+    "for i in totally_mixed:\n",
+    "    print(f\"  #{i}: {[np.round(pr, 4).tolist() for pr in nash3[i]]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b8907a",
+   "metadata": {},
+   "source": [
+    "Here the principal branch is of little help, for a different reason than in the stag hunt: `logit_solve_branch` stops early."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1d98c259",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:42.598800Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.598548Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.611866Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.610958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17 points; final lambda = 0.5968\n",
+      "profile there:  [[0.5, 0.5], [0.5, 0.5], [0.574, 0.426]]\n",
+      "max regret:     0.2130\n"
+     ]
+    }
+   ],
+   "source": [
+    "branch3 = gbt.qre.logit_solve_branch(g3)\n",
+    "final3 = [[float(branch3[-1].profile[s]) for s in player.strategies]\n",
+    "          for player in g3.players]\n",
+    "print(f\"{len(branch3)} points; final lambda = {branch3[-1].lam:.4f}\")\n",
+    "print(f\"profile there:  {[np.round(pr, 4).tolist() for pr in final3]}\")\n",
+    "print(f\"max regret:     {float(g3.mixed_strategy_profile(final3).max_regret()):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a49528ca",
+   "metadata": {},
+   "source": [
+    "The final point has a max regret of about $0.21$, so it is nowhere near a Nash equilibrium: the trace has stopped, not converged.\n",
+    "It stops because the branch passes through a *bifurcation* at this $\\lambda$, where another branch crosses it and the Jacobian of the defining system is singular.\n",
+    "Arclength continuation handles folds, but a bifurcation is a genuinely harder obstacle, because the tangent to the path is not unique there.\n",
+    "\n",
+    "The branch itself does not end.\n",
+    "Players 1 and 2 are each indifferent between their strategies whenever the *other* plays $(\\tfrac12, \\tfrac12)$, so $\\sigma_1 = \\sigma_2 = (\\tfrac12, \\tfrac12)$ satisfies their logit conditions at every $\\lambda$, and player 3's expected payoffs are then constant.\n",
+    "This gives the whole principal branch in closed form, and we can check that it solves the system well past where the trace stopped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e81fd7f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:42.613668Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.613459Z",
+     "iopub.status.idle": "2026-08-01T21:08:42.619023Z",
+     "shell.execute_reply": "2026-08-01T21:08:42.618152Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "player 3's expected payoffs at sigma_1 = sigma_2 = (1/2, 1/2): [3.5, 3.0]\n",
+      "  lambda =   0.60:  residual = 0.0e+00, sigma_3 = [0.574046, 0.425954]\n",
+      "  lambda =   5.00:  residual = 0.0e+00, sigma_3 = [0.924142, 0.075858]\n",
+      "  lambda =  25.00:  residual = 0.0e+00, sigma_3 = [0.999996, 4e-06]\n"
+     ]
+    }
+   ],
+   "source": [
+    "centre = g3.mixed_strategy_profile([[0.5, 0.5]] * 3)\n",
+    "u3 = np.array([centre.strategy_value(s) for s in list(g3.players)[2].strategies])\n",
+    "\n",
+    "\n",
+    "def principal_at(lam):\n",
+    "    \"\"\"Closed form for this game's principal branch: sigma_1 = sigma_2 = (1/2, 1/2).\"\"\"\n",
+    "    return [np.array([0.5, 0.5]), np.array([0.5, 0.5]), softmax(lam * u3)]\n",
+    "\n",
+    "\n",
+    "print(f\"player 3's expected payoffs at sigma_1 = sigma_2 = (1/2, 1/2): {u3.tolist()}\")\n",
+    "for lam in (branch3[-1].lam, 5.0, 25.0):\n",
+    "    residual = np.linalg.norm(qre_residual(pack(principal_at(lam)), g3, lam))\n",
+    "    print(f\"  lambda = {lam:6.2f}:  residual = {residual:.1e}, \"\n",
+    "          f\"sigma_3 = {np.round(principal_at(lam)[2], 6).tolist()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64bc4e73",
+   "metadata": {},
+   "source": [
+    "So the principal branch runs to $\\lambda \\to \\infty$ and converges to the equilibrium in which players 1 and 2 randomise uniformly and player 3 plays their first strategy.\n",
+    "Every other equilibrium lies on some other branch.\n",
+    "\n",
+    "We can also see the crossing branch directly.\n",
+    "Perturbing off the principal branch and re-solving at the same $\\lambda$ finds a second, asymmetric LQRE nearby; its distance from the principal branch shrinks to zero as $\\lambda$ approaches the value where the trace stopped, and grows again on the other side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "bc8c997d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:42.621678Z",
+     "iopub.status.busy": "2026-08-01T21:08:42.621440Z",
+     "iopub.status.idle": "2026-08-01T21:08:43.882307Z",
+     "shell.execute_reply": "2026-08-01T21:08:43.881645Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lambda = 0.4500 (below): nearest distinct branch 0.1121 away\n",
+      "  lambda = 0.5500 (below): nearest distinct branch 0.0294 away\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lambda = 0.5968 (   at): no distinct branch nearby\n",
+      "  lambda = 0.6500 (above): nearest distinct branch 0.0290 away\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lambda = 0.8500 (above): nearest distinct branch 0.1115 away\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng_cross = np.random.default_rng(7)\n",
+    "\n",
+    "\n",
+    "def crossing_branch(lam, tries=150):\n",
+    "    \"\"\"Distance to the nearest LQRE which is distinct from the principal branch.\"\"\"\n",
+    "    base = principal_at(lam)\n",
+    "    best = None\n",
+    "    for _ in range(tries):\n",
+    "        start = [np.clip(pr + rng_cross.normal(0, 0.12, 2), 1e-6, 1 - 1e-6) for pr in base]\n",
+    "        sol = polish(g3, [pr / pr.sum() for pr in start], lam)\n",
+    "        if sol is None or np.linalg.norm(qre_residual(pack(sol), g3, lam)) > 1e-11:\n",
+    "            continue\n",
+    "        dev = max(np.max(np.abs(a - b)) for a, b in zip(sol, base, strict=True))\n",
+    "        if 1e-6 < dev < 0.25 and (best is None or dev < best):\n",
+    "            best = dev\n",
+    "    return best\n",
+    "\n",
+    "\n",
+    "for lam in (0.45, 0.55, branch3[-1].lam, 0.65, 0.85):\n",
+    "    dist = crossing_branch(lam)\n",
+    "    where = (\"at\" if lam == branch3[-1].lam\n",
+    "             else \"below\" if lam < branch3[-1].lam else \"above\")\n",
+    "    print(f\"  lambda = {lam:.4f} ({where:>5}): \"\n",
+    "          + (f\"nearest distinct branch {dist:.4f} away\" if dist\n",
+    "             else \"no distinct branch nearby\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32175894",
+   "metadata": {},
+   "source": [
+    "Sampling proceeds exactly as before, calling the same `sample_locus` with the new game."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9c0ebc3c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:43.884287Z",
+     "iopub.status.busy": "2026-08-01T21:08:43.884076Z",
+     "iopub.status.idle": "2026-08-01T21:08:56.266273Z",
+     "shell.execute_reply": "2026-08-01T21:08:56.265720Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(92993, 144000)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rng3 = np.random.default_rng(20260801)\n",
+    "draws3 = sample_locus(g3, rng3, n_chains=48, n_iter=3_000)\n",
+    "on_locus3 = draws3[draws3[:, -1] > -1e-4]\n",
+    "len(on_locus3), len(draws3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fbf009d",
+   "metadata": {},
+   "source": [
+    "With three players there is no longer a single picture in which to pick out branches by eye, so we seed systematically instead.\n",
+    "At each of several values of $\\lambda$ we take the draws whose $\\lambda^*$ is nearby, polish each at that exact $\\lambda$, and keep the distinct solutions.\n",
+    "Draws are subsampled at random, because successive states of one chain are nearly identical.\n",
+    "\n",
+    "Draws which have saturated at a vertex of the simplex are skipped: they are not usable as starting points, since the log-odds parameterisation is undefined where a probability is zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1cbdbb25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:56.269046Z",
+     "iopub.status.busy": "2026-08-01T21:08:56.268718Z",
+     "iopub.status.idle": "2026-08-01T21:08:56.875125Z",
+     "shell.execute_reply": "2026-08-01T21:08:56.874408Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "22 distinct LQRE found across lambda = (1.0, 1.5, 2.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "LAMBDA_SEEDS = (1.0, 1.5, 2.0)\n",
+    "SEED_WINDOW = 0.5  # how close a draw's lambda* must be to the seeding lambda\n",
+    "MAX_SEEDS = 150  # draws polished per seeding lambda\n",
+    "INTERIOR_TOL = 1e-6  # a probability below this counts as saturated\n",
+    "DEDUPE_TOL = 1e-4  # solutions closer than this are the same point\n",
+    "\n",
+    "\n",
+    "def interior(probs):\n",
+    "    return min(pr.min() for pr in probs) > INTERIOR_TOL\n",
+    "\n",
+    "\n",
+    "seeds3 = []  # (profile, lambda it was polished at)\n",
+    "for lam_seed in LAMBDA_SEEDS:\n",
+    "    near = on_locus3[\n",
+    "        (np.abs(on_locus3[:, 0] - lam_seed) < SEED_WINDOW)\n",
+    "        & np.all(on_locus3[:, 1:-1] > INTERIOR_TOL, axis=1)\n",
+    "        & np.all(on_locus3[:, 1:-1] < 1 - INTERIOR_TOL, axis=1)\n",
+    "    ]\n",
+    "    if len(near) > MAX_SEEDS:\n",
+    "        near = near[rng3.choice(len(near), MAX_SEEDS, replace=False)]\n",
+    "    for row in near:\n",
+    "        sol = polish(g3, [np.array([p, 1 - p]) for p in row[1:-1]], lam_seed)\n",
+    "        if sol is None or not interior(sol):\n",
+    "            continue\n",
+    "        if not any(np.max(np.abs(np.concatenate(sol) - np.concatenate(s))) < DEDUPE_TOL\n",
+    "                   for s, _ in seeds3):\n",
+    "            seeds3.append((sol, lam_seed))\n",
+    "print(f\"{len(seeds3)} distinct LQRE found across lambda = {LAMBDA_SEEDS}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "145ad1d6",
+   "metadata": {},
+   "source": [
+    "Each of these is a point on some branch.\n",
+    "Following each one upward in $\\lambda$ shows which equilibrium its branch leads to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9a5bf69f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:08:56.877924Z",
+     "iopub.status.busy": "2026-08-01T21:08:56.877729Z",
+     "iopub.status.idle": "2026-08-01T21:09:01.109286Z",
+     "shell.execute_reply": "2026-08-01T21:09:01.108123Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  equilibrium #0: reached by 1 branch\n",
+      "  equilibrium #1: reached by 3 branches\n",
+      "  equilibrium #2: reached by 3 branches\n",
+      "  equilibrium #3: reached by 2 branches\n",
+      "  equilibrium #4: reached by 3 branches\n",
+      "  equilibrium #5: reached by 1 branch\n",
+      "  equilibrium #6: reached by 3 branches\n",
+      "  equilibrium #7: reached by 3 branches (totally mixed)\n",
+      "  equilibrium #8: reached by 3 branches (totally mixed)\n",
+      "\n",
+      "equilibria reached: [0, 1, 2, 3, 4, 5, 6, 7, 8] of 9; totally mixed are [7, 8]\n"
+     ]
+    }
+   ],
+   "source": [
+    "LAMBDA_MAX_3 = 25.0\n",
+    "\n",
+    "\n",
+    "def follow_up(game, probs, lam, lam_max, step=LAMBDA_STEP):\n",
+    "    \"\"\"Continue a branch upward in lambda; returns the lambdas and profiles reached.\"\"\"\n",
+    "    lams, profiles = [lam], [probs]\n",
+    "    while lams[-1] < lam_max - 1e-9:\n",
+    "        nxt = polish(game, profiles[-1], min(lams[-1] + step, lam_max))\n",
+    "        if nxt is None or not interior(nxt):\n",
+    "            break  # no nearby solution, or the profile has saturated at a vertex\n",
+    "        lams.append(min(lams[-1] + step, lam_max))\n",
+    "        profiles.append(nxt)\n",
+    "    return np.array(lams), profiles\n",
+    "\n",
+    "\n",
+    "def nearest_equilibrium(probs):\n",
+    "    \"\"\"Index of, and largest deviation from, the closest Nash equilibrium of `g3`.\"\"\"\n",
+    "    dists = [max(np.max(np.abs(a - b)) for a, b in zip(probs, eq, strict=True))\n",
+    "             for eq in nash3]\n",
+    "    i = int(np.argmin(dists))\n",
+    "    return i, dists[i]\n",
+    "\n",
+    "\n",
+    "REACHED_TOL = 0.05\n",
+    "\n",
+    "paths3 = [follow_up(g3, sol, lam, LAMBDA_MAX_3) for sol, lam in seeds3]\n",
+    "reached = {}\n",
+    "for lams, profiles in paths3:\n",
+    "    i, dist = nearest_equilibrium(profiles[-1])\n",
+    "    if dist < REACHED_TOL:\n",
+    "        reached.setdefault(i, []).append(lams[-1])\n",
+    "for i in sorted(reached):\n",
+    "    tag = \" (totally mixed)\" if i in totally_mixed else \"\"\n",
+    "    n = len(reached[i])\n",
+    "    print(f\"  equilibrium #{i}: reached by {n} branch{'es' if n > 1 else ''}{tag}\")\n",
+    "print(f\"\\nequilibria reached: {sorted(reached)} of {len(nash3)}; \"\n",
+    "      f\"totally mixed are {totally_mixed}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f164db5e",
+   "metadata": {},
+   "source": [
+    "Plotting each player's probability of their first strategy against $\\lambda$ shows the picture behind those numbers: a cloud of draws covering several branches, the principal branch ending abruptly at the bifurcation, and the continued branches running out to the equilibria."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "9d6ffca8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T21:09:01.112043Z",
+     "iopub.status.busy": "2026-08-01T21:09:01.111718Z",
+     "iopub.status.idle": "2026-08-01T21:09:01.499783Z",
+     "shell.execute_reply": "2026-08-01T21:09:01.499118Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABQoAAAGPCAYAAAAUb+0gAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAA3CRJREFUeJzs3QeYE+XWB/B/stls742l9yYgRUEUAQvYxa5Ywd57Q7y2i+Wzglexi733fhFQBL2CgCggvZftve+mfM95J7Nkd5NtJJv2/z3POMlkkswmuGfnzHnPa7Db7XYQERERERERERFRSDP6+gCIiIiIiIiIiIjI95goJCIiIiIiIiIiIiYKiYiIiIiIiIiIiIlCIiIiIiIiIiIiYqKQiIiIiIiIiIiImCgkIiIiIiIiIiIihZOZEBEREREREREREROFRERERERERERExEQhkd/6+++/sWnTJl8fBhERBTmLxYLff/8d2dnZvj4UIiIKcoWFhSrmVFZW+vpQiMgNg91ut7t7kIg8759//kFpaWn9/cjISPTs2ROJiYkN9hsyZAj69u2LL774ImC/BpvNphKe1dXVOOSQQ2AymXx9SEREIUVOxnQGgwGxsbEqtkRERNRvz8/PR1paGp555hncfPPNCETy5+zu3btRXl6OXr16ISoqyteHREQUUuT8Rs5zdEajEcnJyejdu7e6rfvkk09w9tln488//8Tw4cMRqDFn165dKuZ0794dcXFxvj4kIo/iWTtRB7vyyiuxfPlyjBw5Ut0vKCjAtm3bcNxxx+GVV15Bly5dAv47WbNmDV5++WV8/vnnKoCWlJQgLy8Pqampvj40IqKQqhQcO3YsUlJSVHJQP7GR38mXXXYZnnrqKZjNZgSyffv24YknnsDbb7+tfha56LZ161acc845ePzxx5GZmenrQyQiCglyfjNp0iR1sSY9PV3FoM2bN6uiiIceeghXXXUVgqEa8rHHHsObb76J+Ph4lQDVz+Mkpg4YMMDXh0jkEZzMhMgH5OqaVHnIIgF04cKFajnttNOC5g+F/v37Y8WKFTjvvPN8fThERCHt2GOPVfFm2bJlKrF233334bnnnsM999yDQLdo0SK8//776uLU3r17VTXL6tWr1XY5Ya2rq/P1IRIRhZQ777xTxRw5D8jKysLhhx+Oq6++Gt988w0CnVxsk0SonL/JsnHjRqxbt06NoGLMoWDCRCGRH5g4caJKEkpA3bJli9v91q9fX59g/OOPP7Bjxw5VIeJMyvhlP3fBTZ5rtVobbK+pqcHatWtVkJPbjclrSoWGqKqqUvvJa7kjlSo33HADOnXq1OLPTkREHUeGH991113q9/MHH3zQ7L6SWNRjzqpVq5Cbm9vgcYkX8pgk6FyRuCIV5o0VFxerZJ704W0cw/TXlCp0vXpj5cqV6jmuSKWkxMMzzjhD/Wxi0KBBuP3229XJ29KlS1v4RIiIyFuio6PxyCOPqNvNxZyysrL6eCOxR841ZFSSM4kL8rjs66rdkTy2c+fOJo9JjJIY5ipW6a+pn/9ICwspeJDXc0WGSl9zzTWqmlAnxRHTpk1Tz3UV84gCEROFRH5CSvRFUVGR231eeOEF1T9KFhnCPGzYMNX3Q6oRdVL2LkPNKioqmjxfTqQuv/xyhIWFqfu1tbW44447VIXjiSeeqJKVchzyGs5OOeUU3H///XjrrbcwcOBAnHrqqXj22Wc9+NMTEVFHkYSatIJoLt6I2267rT7mXHTRRejWrRuOPPLI+hOx8PBwVTUuJ0iNSVsN6U370ksv1W+TypIpU6YgIyNDPW/cuHEqhs2fP79+HznRkhgmrSvkfUeMGKGGdLlL+B122GHquBqLiYmpTzQSEZF/n+Ns3769Pt7cdNNNOP3005GUlIRLLrlEna8IuWAk1YmuzkG+++47FTvkwpHuf//7n2r1JIm8iy++WA0Llrgj76X78ssv1fPk4pXEmqOPPhrjx49v80QrEt8kJnbt2rVNzyPyV0wUEvkBqaj49ddfVYDp16+f2/0kMOpX26TKLycnB5MnT1a9mPTqi+uuu071n3rvvfcaPFeujklVhlT76S699FK8+OKL+Oqrr1SFoPTYkD5PMmTgtddea/B8ubInAVcqC6WScerUqR7/HIiIyPtkdmOpXh88eHCz+0lyTo85Up0nCUKpupCkoZDeTNJzSi5WSXWgM4khsq8ec+Ti1VFHHaXijFS9b9iwQcUwiV9y8Ule35nEJkkSynvKIpWDbYmpb7zxhrooduihh7bhkyEiIk9bsmSJWjcXc6T4QY83ssj5xm+//Yavv/4as2bNUvvIOZIM75VWE41HR82dO1ddAJN4IqSy75hjjlHPkZgnFe7SekMm8pJzJ5lo0dm9996rKh9lOLGcL7U0AeOePXvUcf7444+4++671XmXtPTQk6JEgY6JQiIfkJ5JeiCUK2DnnnuuSvzNmDGjyezHrkjFhQSxv/76S/WekooJSTQKuSomJ1dSfehM7kujd/0ETwLou+++q3pUSSDVSYCVmcikUW/j93zyySfrA+eoUaM88lkQEZF3SXWfxBu52PPhhx/ihBNOUCdZDz/8cIvP1ZvRy8UmuUgk8UJO+vShwFKlLhe5JLHnnKiTSkKJRbKIefPmqV5OcoInVYR6ZaMcg8y4PHv27AbvKyd8UkmiVwdKNXtrSaySn1V6YslslERE1HGkYk9ijlxskgSejILq3LmzqhZsiVTySVJPhh9LnJKLPVLQoLv22mtVccO3337b4P3++9//qnMcfYKuBx98EFFRUeqilT4jsQwXfv7559WFsk8//bTB+8qFLP3c5qCDDlITsDTnhx9+UD+PDEOWmHPmmWfi5JNPbuMnReS/OOsxkQ9Ibw09WMqVLWmKKwlDOXlrjlxVk+fJlTE50ZKTJ71Ru3PPQAmiV1xxhQrSMixLSv3l5FCSgPrMw4sXL1Zr6VMlvRHlxE7vFSX7SBAtLS2t78Ehpfv6UC4iIgocciFKYock5uT3+IQJE1T1+JAhQ5p9niTxpBWFVA7K8F6JV5J01GOOXNiSJJ9cXJIKPtlfTszkBEoqB6W6Qvfzzz+r50uVn3PMkUVeWy5+OZMhzu3x0UcfqeqOI444Qp28ERFRx/r444/VeYbEDhk+LH3L5cKNxIvmzo3k/EV+h0t7ClkkXkgS0HlSKknGyQUgSUDq1YNyoUp6CjqPmpKYI0OOpXpdOMcciUUScy644IJ2xxy5SCaLkItp0lZj9OjRKsnZmqIPIn/HRCGRD2c9bgsJlHK1SoKaBEQJcnpwkkDo3HT3/PPPV70HpYpQEoVSySGTkDgHUEkCiv/85z/1V9+cjRkzpsHEJhKwiYgo8EjleUsTlzQmFecyFEsqAOVkSJ8o5JVXXlHVIc4xR1peyP7yHtOnT1exR6oxJBY1jjk33nijy/fr06dPg/vtiTlSdXLhhReqChS5+NZSRQgREXmetDCSxGBb3HrrrapfoIyQkv62Ojnvca4elOShvPbMmTPV8GTpCfj666+r8xapBHSOOfL49ddf73JCksZJywM5z5HhzTISS5KFEgfb+rMT+SMmCokCxE8//aSuqElzeT1JKPQrZY1nGJPm8pJQlGoQWUsglZ4cOn041jPPPKOqS1oiVwWJiCg0yDAuuagl1enOXMUcveWFVHjI0GQ5qZPJSqSSxDnmSCXHL7/84vLi1IHGHDle6XcoJ4By23lGSiIi8m/ye1vOU5yThO5ijly8euCBB9T5zcEHH4z8/Pz6mZWdY45Uq8v5U2sc6HmOnmjkBFoULHjmTxQg9BMufdiXkJMuOTFzRcr39abzUnUoVR7OQfCkk05SpfFSUehuCAAREYVuzJFm71KNrpO+hFI56C7myJBimdyk8RAwIZV+MnOlVCh6OubIEDOZIXPo0KFqBuWEhIR2vxYREfkm5jif4wjphyuTKTamt7yQEVMy0aO01JCLU41jjlQnSuuNxiRGtXVWY115ebnL7Z9//vkBtc0g8jesKCQKEDLLl/QylHL2f//736oiQxr0Sj8M6QflqgxehpvJYzJkTBKFjQOynPBJBcbxxx+vmsZLv0KZXXLBggXqpE2GALSHXE3TZ8DMzc1Va+kFIidvEszlZI6IiPyXPoRYYoQM3crLy8OcOXPUxSdXvf/0lhcScyRWSWN4ZxMnTlQVIDK87J9//lGVIxIP5EKW9KQ68cQT1XC1tlq1ahVOOeUU1axeYmPj6hM5FrbOICLyb9LSQmLNXXfdpeKD9PqTXroSg5yHHjtfnJLzGEkuyigqfcISnUwQKROiSJW7jMaSSkW5WLVu3TrVU1eSjFIN31byunJuI+dOPXv2VH3gpYf8W2+9pVprMFFIwYKJQqIOJv0zWlPtIKX0MlxYFxsbq66M/d///Z86eZNqwEsvvVQFJCnXz8zMbPIaklT88ccfcfTRR6uTpcbkxEwC5quvvqoCnFSPyCQp0ij4rLPOqt9PJjLp27dvq39GmY1ZAqlO+obcf//96rb0U5T3IiIi75KLRPL7Vy4cNUdmLZb9nOOIDOH97bffVNW59F6SGCKxQhKGUuXReHIraXkhSUTZX2KT3tPQmcQBObmSGCD7yfvKsc2aNQvjxo1T+0hfQTmW9PT0Vv2MkmjU+1JJIrKx22+/vUE8IyIi75DzG/n93dLFmZSUFLWfcxyRXrcymaJcOPrjjz/UDMTff/+9SujpRQfODj/8cFV4sGbNmiYV7ELaNEmCUWY3lv61Um0uRRIyiZf0sJXzHSGxRo6ltT1tpYJRLoh98cUXKpEpPRMHDBighjiPHz++Va9BFAgMdn2aUyIKOjLjpMw09t5772Hq1Km+PhwiIgpikpCT4VdSme58oYuIiMiTrFYrOnfurAonNm7cyA+XyMPYo5AoiMnMW9LHQ3o3EREReYvMMCnVH9L/lklCIiLyJqngk0pD6YtLRJ7HocdEQUZmRpZ+gIsXL1ZDlaWnVGvL6YmIiNpC+kOtX79etcSQ/k+uhv8SERF5wvbt27F161bVE1cuSjFRSOQdTBQSBRmZhOTmm29WPQ2feeYZNfSYiIjIG2RGyX/961+qt5T0gZKetkRERN7w8ccfq8kWpdfgzJkzm/TLJSLPYI9CIiIiIiIiIiIiYo9CIiIiIiIiIiIiYqKQiIiIiIiIiIiIQrVHoc1mw759+xAXFweDweDrwyEiog5it9tVH8/OnTvDaDR6/f0Yb4iIQlNHxxvBmENEFJrsHo45fpEo3LZtGzZt2oTRo0cjOTm5Vc+RGfZycnIwaNAgZGRktOn9JEnYrVu3dh4tEREFIgl4UxOT0M0cjktn3INe114Do9ns1fdkvCEiCj0SWe5IS0cPsxkTp05F74ceRFhUlNfflzGHiCj0mL0Qc3w6mclvv/2Ghx56CGvWrFGB7aeffsLEiRObfU5FRQXOOOMMLF++HH379sXatWtx//334+677271+5aUlCAxMRG7d+9GfHy8y31KS0vVe0jy0t0+REQUGEr+8x+Uv/uelFvs32g0Inn6NGTccYf33rcV8UYw5hARBYeCO+5A9eJfmmyPPeZodHv+ea++N89xiIhCS4GXYo5PE4Xvv/++OoE66KCD0KNHj1YlCm+77TZ89tln+OOPP5Camor//ve/OP7447FkyRKMGzeuVe8rJ2QJCQkqmDIJSEQU3HKeeAKFr73u9vHkyy71WrKQ8YaIKHTsvu46lC9c5PZxbycLGXOIiELHbi/GnI5pmOHG1KlTccIJJ7RpDPVbb72Fyy67TCUJxXHHHYcRI0bgzTff9OixVVdXY+PGjWpNRESByVZbi8J5bzS7jzwu+/kSYw4RUWCzVlU1e8Im5HHZz5cYb4iIAp/VyzHHL3oUttaePXuQn5+vEoPO5P5ff/3l9nk1NTVqcb7a1pLc3Fw8/fTTuPDCCxv0QAwv2YGw2hLpFqnuV6cPxwGzWoGwMHQUSczKsG0iomBX9N77DYcbu2Kzqf1Spl1ywO/XnnjTbMwp3QGjpQYGWx1s4TGoTejV/AtZamGqLkBYTRFM5Xthqi4CrNUwWmthtFkAuxUVmYejOqNhHG2v9PR0NTKAiIKY/M2rFv13qeO+rPXH27wNB/hcezPb0Mr9Gh9H/Z12bc+d475y3Vnu408g8/774AmePMcx1pYjomhj/f262C6wxHRq9rX69+/f7mMn8jWbzQ6r3Q6rzQ6T0QBTmFa8VFhRC4vNpv581Nc2ux2d4iMQaTLCUluDHXklsFtrYbdaYLNaYLfWwW6zoX+SASaDFWXVFmwvrIXdZlXbbXYb7HYrTLDh4BT5tWFFdoUNO0rssMtjNjvskH3siA+3YViSVf1u2VgE7Ks0qPeX11G/bex2dI22YFBCnbq9PC8cRXK9W/ap/91mx+C4GnSP1i6EL8yJQZ28pHoP9SJq++ikcqSYrai2GrAwL67h7znHex2bXooIgw15NSb8XhSj/QrVHlT/NRvtOD69WN3eVmHGmtKYJp91qrkORySXqdurS2KwvTLC6T20//SKrsbwhAq1aXFBAvJrtVSV8xGNiC9Hn2itkOvL7BTU2g0Nfh4xMbkI6RF1qLYa8VVuaoOfRXdqeh4iw+zIqQnH4sKmf8dGGG2Ykp6nbm+piMKqMr190P7XSDfXqvcSK0visbWyaU/APtGVGBWv/V5eVJCM/LqmvdFHxpeib3Sleu0vctJRa29aRDcxuVC9n/qZ8tLVtuKVe1DZ/dD6fY7a8yfM8re+h2JOQCUKi4u1f4CNJzxJSUlBUZH2Jbny6KOP4sEHH2z1+8jEKhaLBZdeeqmaGdlZ+sonEZO9TN22Gc3Yct6vLb5eRME6xO7+GdHZy2Eu2wmjpdrxx5b2D01O/rae/TM6isyIRkQUCmp37/bofi1pa7xpKeb0/PY8GOzqLztUZI7F3qOeVbcNlmrEb/8Ocdu/hbl8D4y1ZSqZaGjF+0XlrcaeSa/AEwoLC5kopMBlswLWWsdS1/JtS23D7fIHub7I33X1962ORX/M6nq73K5/zN3zrPuTdG4XLz/e+MSRXKpdJucnkS1+OrW7dnnsE2xLzJHzKEkSuos35pKt6Lbw6vr7ecOvR9HgA7+ARqFH72xmMBhgsVixKzsP1cVZqCotRE1FKaoqylBdXYFJiVkw15Zgd5ldJT/qLDbUWW2os9lRawUiUIMZsd+p34c/VffD+1VjUGcPQx3CUGsPg8VuxOCw3ZgV8bb6PfZkzen43DoWNhhhsYfBBgOsMOLcsJ8xI/wDdUxTa+/BcttAWNGwSOffptdxkWmBun1U9csoQWyTn+sD80M4zLgBhfYEHFvzgsuffVXEVUg2lGGNdTDOr7u3yeOpKMGKyGvU7R8sk/GAZZrTIE/tmA4zrsMH5ofV7TfrLsV71mObvM7FYfPxULg2YubJmn9huX1Qk32cf6bbq19CERr+Py8+ND+EFOMGlNnjcV3Ni25/pghDGTZbB+MGNz/T8ZH/UreXWCbjfvUzNTTWuA5HmJ9Wtz+uuxTvuvmZhjt+pufVz9TH5c/Ux/EzPdDMz5Tu+JnudPMzHbvjSUQayrDVOhh3uvmZpmx/SN3+tZmfaaJZe/3PmvmZRjl+phfVzzTA5c/U1/EzPdiWnyluIDBy/z6HZa+DudbisZgTUIlCs2N2yqpG5ZOVlZX1j7kyY8YM3HrrrQ2utrmb9VhmYBYmkwlJSUlNHs8dfTcMlhrAYITd4GbItM2G+G1fI3HTB4go2V5/kuf4lQm7MRz28BjYTNGwhsegKs0DVYlt4InpsomIAoG5lTPct3a/lrQl3jhzF3N2H/sS7EYT7EYzbOZYhFUVIHndPMRv+wZhlgrYYYQ1Ih618T1giUyFNTIZ1shE2MJjtVhlt8JuioDNGAG7MQwwmlGVMQqe0vjCHdEBkZPL2grHUq4tNbKuAOpkqQYsVW7WjqWuyrF2sY+1pmHir75C7gAZTU5LGGAIa7TN2PC+/P3Y+DlqcdpminDaV17T6FgMTrfdLS3sI5cUWnwdg+v7+uUIua+/jrbBxbbW7teWbY51k9c+kG31B+vyZsPt7vY3wFz9Giq/+LHFfy7m7t3hKW2JOZIkbC7e1CQNwPaTP62/b41I8NhxUgCy1GHz5g3Yt2c7SgtzUFZWgvKKSpTVWDHRtA6jDBvU79YrSy5Fti0B5fZIlNqjUIFIVMOM982zVFKt2B6Poxska+ScXUrqUrAi4hGkGkqxxzoIT9RpiSZnSSjDDIuWkNtjGYSFliEIhwXhsDrWFmQaCrQLKwYjogy1SDZUwAgbTEYbwuSvJIMNGeHVQGSS2meEYR/irPKYDUaDHWGyAOgVLXn+Pur/5fNK/kIVwusfC1O/KuzoHN8ZiIhHjD0CNxYtV6+nfjUaDOq3gayj0o8EjHZ0r4vFXcV/Qh6p38cARBltQMbZ6rljKhPwYNkax3P1fQzICK8BUiUxZcCZZYkYXvVPg/cwGoBeUelAwrUqyXh9kR2FdVvqf0dqv6aMGJZwGBAzQm14NKcAtfZCx++t/b9T+6ScC0TaEGc14rncvfXb5efV94vJuAMIs6N/jQlzC7K07UbteNQ3arQDnbTE5sSKcLxYqv2ucZYckQKkPKpuX1ASjgmVso/2CvrrdI05GEh4XN2+s8CM4tr8/b+yHf/tH38iEHOcuvdsbg0s9tomv4/7J18FRNgRbwXm5crP7MSRv4nN+LfKzw6qMWBeYXGT1wiXnyljjvrsjqkwontpSZOfKdHcBUj5j7p9cUkYjq2UysGGl+y7RI8BEg5Rm+8uCENJrVZV6ax//BlAzGnq9n9yDKizlzfZZ0DyTfU/0xu52uOF8/9AxSr53jXRdfuryz0Rc3w6mYnzkGIJai1NZiIJQrn69dprr+GSS/Zf4TrttNNQV1eHb7/9tlXv11yjX6ns0PdZsWIFDjnkkDZNeJK4/h2krnkZRkuVOoGTYWIVnY9AWfdjUJM0UPtjsQ0kmPfu3RttlZWVhbKyMvV5RUVFqSHbQno7cpgYEYUK6T24cfiI5ocfG40YsPpPGJu54OStxvJycUqqO1oTc6L3/YrM37ShA8X9z0Zp9+NQl9Cz0Ymr57U3DlGIkWq76mKgugSoKna6XaSt9fuS9NOTf/IHc/19x7YWq9cMQHgUYIpsZh0JmKIarWWJAMLMjiX8wG8bw9v8dx0FL+kDtWmEU3mHG/3/XIWwqKZD1LwZc3bu3Fk/RLm95zg6tjAKPHK6X1ZjQXneXnQuXAZk/YVFO2vwS0E8imrCUGiNQKEtBkX2GEw2rsAD4W+p511YOwNLbUObvN5M0zu4wvSdun18zWMoQzRiUY04YxViDLWINtbhxtifMCi6BNXGODxbPhGRJgOizGGINIcjKsKMyIhIHNvDiMiYRJSHJWJHbRzMMckwxSQhPCoaZlMYwsOMSI4x1/8MkiQjoo6JOX5fUbhu3TpVKn/EEUeohNf48ePxxRdf1CcKJRAuWLBAld57kiQed+/ejYMPPrhV+8swsIxl/0b8zvmwmaJQMOQyFAy+FDA1PfGMiIho0E9EknmZmZkNknty/0DI851fg8lBIgpFkvxLnj6t+VmPp0/zSpKwNSRJ2JqYE7N3KTr/crsafpx92P2wRXZMX0D2nwpRVgtQVQhU5AOV+UBFHlBR4HRbtsv9Qi0BKIlBqdpzRariIhMA+Tcr64hYwBwLSGWGOWb/fbXI/Tht3fh+eLSWCJQEHU8WyQ/JiZjMMNnSDJTeShI2x/m8o63nOIKxwL9JEq2wrBopecuArYvw9/a9eCu7J/bUxSLHGo8ceyIqEYnBhh34LuIe9Zw/687GG9aj1e1YVCHJUIY0QxlSzRYgsaeqwLvImoMTw+xIiI9HbGIa4lK7Ir5TH6SnTQYiw9Vzf3B7VDPVf2Uw/p0tHL8M8h3Swj5MEhJ1bMzxaUXh3r17sWbNGlXtdtFFF+H//u//MGzYMDXRhj7ZxuWXX47ff/8da9euVffltlQdXnHFFRg7dixeeOEF9fyVK1ciOlpqhj1TUegqudejR48m22V/Y00xuv50k+rtUTjwQhQOvdLtFWZWZhARdbycJ57QZj92riw0GlWSMOOOO7z2vi1VFLqLOTq5cFSVvRk9vjsfVenDse/Ix7XES6M/niWUS5yyWq1qODAvDpFLMuy2PAcoywZK92nrsn0N70siUKoAG1f2SfVcTBoQkwJEpwIxqUB0yv4EYFRio9uO5KAk+ZjYoxCy+7rrXJ64yQlbt+ef9+p7u4s5jWMNE3+Bq3LPWsz/aRE2ZRVhS3kEdlkSscuWphKBGyIuQaShDj9bh2Fa3d2IQwUyDUXICCtVw2/7xNTgmn6lQKeDUJg8AjXJg5AUH43I8I6bVJOIAiPm+DRR+OOPP+Kpp55qsl1m4ZJFzJ49Gxs2bMCLL+7vbfDnn3+qBGFOTg6GDh2qenO0pU9Sa4NoS4F08+bNQF0lui24CqaKbNVkviZ5oMt9OTMkEZHvhyFnzZuHuffdh2sfegiZ06d7vZKwPYlC57gjj3f67T41GdaOkz+Czay9hicqzykIydDd4l1A0U5tXSxrx+3SLC0J6JwAlOq8uE5AXKZj6eRIBqY5EoGOhKAsEfFM+BG1YUjYnocfxvw33sTkaZeg68yZHVJJyERhcJDT85yCYqxd+jXWbtmOtaURuNHwCYYZNqPEHo2Da15V+4XBii6GfHQPK0T3iArc2XsXEnsNR3WvSahJ6IOEaK3qj4iCm9ULMccvehR2tNYE0by8PHz22WcqCdmlSxeXr6OfwMXu/gm7J72KmuSGs9gwOUhE5F9aStx15Ps594xyF3O2r1yEnt+cidxRt6Gk/zlqGyvTQ5xU+xVsBfI3AwVbgMKt+xODMjTYuQIwsRuQ2F1b4rvsTwjGy7ozEJ3M5B9RkMSb1p7jxMTE4Nlnn8WNN97o9hyHOpbdaoVhw9fAn2/j7s0DsaBmMPKxv8WICRY8HfEKTo3fAqQOwH+jT0Kvg49Cz959YDaxTyoRweMxx+97FPqK9EOUIc6xsU2nRtcb0EuCMH7H98ga+2CDJCEThERE1JaeURJzpPVG45gTt/O/sIdForT3qfXbOLFICJAh8iW7gJx/gPyNWkIwf4u2dk4GSvIvuTeQMRgYcOL+pGBSDyC2EyfaIKImJM6MGzfO7TkOeV9xWRV+X/AJ/li/FX+Up2KYYQtmhc9Tj1XVDUCmsRiTorZiSKcYDB09Af0Hj0Bk+JT652tzvhIReQ8ThW5I8DzllFPcfnDWmkqkrZqNcpnRuOcJ9duZJCQiovbEHH2SLp1M5BW380eUdzkSdpmxlX2lgrdCUBKCuf8AOWv335ZZgIU5DkjtC6T0A/ocvf+2JAhlIhAiojaQipPmznHIS7YvxdJv38ZT+w7CX7ZesEHaZiUjEWUYGbkHGHwaMPpKzO5xOCfuICKfY6LQDZvNhh07dqgeUNIg3pnMThy/7SuYKrOxd+Ls+mE7bAxMRETtIbNQNo45eft2onNUKsp6Hs8YEyyqS4B9q4F9fzqWVdqQYX2ocNoAIH0wMPAkIOMg7bbMDszJQIjIg9Xsci7j6hyn1bOih/EUsiWVVTX46eu3sfCfLDyKZxGBWhitg7HFdiwmm9diXBdgzFGno0/fATAaz6t/nnZWSUTkW/wt74bMoPzwww9j5syZ6N69e4PHykpL0HPD+yjvdjRqE3qpbUY3sxwTERG1pLq6WvWMco45dlMU9h79HD+8QCUn09l/A7uXAXtXaolBGToswmOAzsOBQacCmcO1pGBqPyCMjeeJyLtkMshHH33U5TlOc6TKvXjPRvT44lQYxl4HHHOfV48zEFVV1eLnr17DN+sKsKh2EKogk45l4oKofhjVIwljxt+DVT3GIjyM541E5N+YKHSjU6dO+Ne//qWGEjcWlbsK5rJdyB7zr/ptffv29d63REREQW3o0KFuYw4FiJpyYM8fwK7fgV3/A/asAOoqgLAIIHOYNmz4yNuBziO0pKAxzNdHTEQhwHkik5bOcZqTm5uLnj9cCliqURA/GCkePs6AtuYTYOFDODXnOmy2S/K1Ow4J24KTutbghNMuQqfM39Ru8lufv/mJKBAwUegmiJrNZnTt2tXlhxa3cz5qYzqjOu1g7UM08WMkIqL2ay7mCLa28EN11cDu34FtPwPbFgNZf8nUlUBUEtDtMGDiXUD3sUDmwYCpHcP7iIh8EG/cTeKY8tcLMJfvQUnvU1CQMCzkE4V79u7Fxx+8jrqiPbjT9IH6nC6OWIy6jOE44YzpyMw4if9+iShgMcPlRlFREX7++Wc183FSUlL99k0b1qPP7kUo6XNafc8gzkBJREQHcnHKXcwhP5uJWIYSq8Tgz1rVoKUaiEkDek0ARl6sJQZT+3O2YSLyW+2JN9bqMiRu+hiWiCTkjL4Xocput+P3n77GvJ//wYLag2DDSPQ2ZOK2PlkIO+15XJTUzdeHSETkEUwUulFVVYWVK1dizJgxDYJoRPEmhNWUoLzzOHWfVR5EROStmEM+VlMGbF0EbPwB2DwfqMwHwqOBHkcAR/8L6HOUNuEIJxshogAg5y379u1rU7yRC1sp/7wFg7UGu45/U10IiYuLQ6gpmP8ELvg5DhtskgwciqPD1+KiQztj/MmXIcx4ua8Pj4jIo5godKNz586YNWtWk+3R2StgC4tEdcpBnv0miIgoZLmLOeQDMguxJAY3fQ/sWApYa4G0QcDIi4C+k4CuhwImM78aIgqJeBNWlY+k9e+geOB5qIvTKuZkxuRQUF1di+KvZ6LT+teQbLUi1n4/psWtwCXnnodefTm0mIiCFxOFbbB582Z0zlmOqvThambCULyaRkREFHQKtgLrPgfWfQHkrAGM4UDPccDkWUD/44Cknr4+QiKiDifVhGn/vAm70YTCwdNC5huoqbPgvddn44XtnTDImIg3zTYY+k/Gx2deCUNkrK8Pj4jI65godEPK8l988UVcffXV6sqb3pci/+BrYbBZQupqGhERdXzMIS8r2uFIDn6uTUQSHgMMOAEYf7s2Q3FkPL8CIgrpeBNWXYiELZ+jcPAlsJnjgr7tks1mx9fvz8WTa6Ox2z4I6SjCkV3CYL8qHwaTCVp3eiKi4MdEoQsSAKXR77BhwxAVFdXgsZrkQR313RARUYjHHPKw8lxgzcfAmk+AfasAU5RWMXjkbdqwYnM0P3IiCmoSZ1oTb1Rvwk0fAQYjivufo7alp6cjWFX99RXO+XA31th6Ig4VuKvzaky/8g5ERrLVBBGFHiYK3ZDmvmeddVbHfhtERBSSGHO8yFIDbPoBWP2+NiGJMQzoNxk4/Hqg//GAOcab705EFJDxRiYvSdj8GUp6nwpbRILalpiYiGBjL9kHw7zjEFW8C31xDQ5LLMB1V9+ExEQtOUpEFIqYKHSjtrYW+fn5SE1NhdnMK0lEROQ9jDlesG81sPpdrYKwqgjoPBI44f+AIWcC0cneeEcioqCJN7G7FsJUU4Ti/lpSMSIiAsGkzmrDmy89ie93m/CBeS/C4zrh6UsugyGtn68PjYjI54y+PgB/lZ2djQcffFCtiYiIGHMCQG0lsOpt4OWjgJcnAP98BYy8GLh2GXDlT8DoK5gkJKKQ1ppzHBl2nLD1C1RmHIK6eG0ypx49eiBYbFz9P5z+rxcxa9dByEUS9h01B7h9I5OEREQOrCh0Q3pw3HnnnW57cQRzI18iIvKvmEMtyNsIrJgH/PUeUF0K9D0WOO99bYhxGP/UISJqS7wJL9uN6Nw/kXX4v4Pqg7NYbXjx2UcwJ2corOiGa5JX4qYb72YfQiKiRvjXsxuRkZHo06ePu4eJiIg8hjGnHWw2rffg73OBHUuA6FRg1HRg1DQguRf/dRIRtSPebNmyBYk7foDVFIPyrhPVtrg4bcbjgJa7AS8/9zierD0T/Qx78eSUPjj4sPt8fVRERH6JiUI3SkpKsHTpUowbNw4JCVoDXyIiIm9gzGmD2grgr/eB/80FCrcCXUcDZ74GDDoFMAVXDy0ioo6ONzarFfE7fkB5t4mwmyLVtszMzID+Imw/PgTjr0/hEkME7KldcNn1/2IVIRFRM5godKOsrAw///wzDj74YCYKiYjIqxhzWvMhZQPLXwZWvA5UlwCDTgVOfxHoNpr/OomIPBRvzMVbYC7bhdxRt6r7JlPgni5WVlbjviefRHJNFu4xGxFzxlxcN6zlGZ+JiEJd4P7m97KuXbviiSeeaNDUl4iIqCNiDjnJ3wwsfQb4+yOtYlAmJxlzFZCkNdgnIiLPxJtt27YhYfciWMNjUZmhXYTp3bt3QH68W9f/haveWoYt9hGYGB4Jy+3bYYpJ9PVhEREFBCYKiYiIyP9krwGWPAWs+wKI6wQc8y9g5CVAFE/0iIi8wWKxIGbPYlR0GQeEhQfsh/zzN+/ihqXhqEAm7ur8N666/m4YjQZfHxYRUcAw+voA/IXBYGiwzsrKwqxZs9SaiIjImxhznOxZAbx3HvDiOGDvSuDkp4Gb/gKOuIlJQiIiL8YbU0U2Ios3o7zLkQH7OX/wwr9x6dJ4GGHHmxMqcM2NM5gkJCJqI1YUOtjt9gbriIgIVWovayIiIm9izAGw8zdg8ePAtp+AlH7AaS8CQ88K6KoWIqJAijcx+36F3RCGysyx6n7//v0RMOQc7sUjMSSrDAcZk/DstIno1X+Ir4+KiCggMVHoRnJyMs4///yO/TaIiCgkhXTMyfoLWPgQsGUBkDEEOGseMHgKYAzz9ZEREYVMvJF+7JnZy1CVOhQ2cxwCSUVFJfbMmYwBtWswJC4NX914GQwRUb4+LCKigMVEoRt1dXUoKSlRs4GFh7OagYiIvCckY07BVuCnh4G1nwIpfYGz3wAGSYKQXVGIiDo83tisiM5egaKBUwPqw8/P3YdLZ3+G3bbr8d8ubyD9hh/AboRERAeGf427IX07Zs6cyR6FRETkdSEVc0qzgG9uAZ4fDez8H3DKs8C1y4CDTmeSkIjIR/EmsnADwurKUNlJm+04Ls7/qwp3b9uIs575Hn/beuGijO1Iu/57Xx8SEVFQYEWhG2lpabj55pvVurGA6tdBREQBHXOCRlURsHQ2sOwlIDwSOOZ+YPQVQDiHhxER+Tre1MZ2QfaYe1GdcpC6n5mZ6ddfytZ//sTUt9YhD+n4d59NuOiKGb4+JCKioMFEoRtRUVEYNGhQx34bREQUklzFHLkoJT2jhKwD9iJVbSWw7EXg19mAtQ44/Hrg8BuAyARfHxkRUchxFW+2bNkCW2QiSvtMQSDI3rgC5721AYWIx7PDduKU82/x9SEREQUVDj12o7S0FD/++KNaExEReVNQxhxJCv7xKvDsCOCnR4Bh5wI3rgaOvpdJQiIiP4o3NputwT5Gf+4Vu2cl0t+bhElhK/Gfkbk45fzrfX1ERERBx4+jgG9Jk99vvvlGrYmIiBhzWklOONd8Ajx3KPDt7UDvicANK4ATnwDiMvgPiYjIz89x+vbtC3+0b/Mq2F45FkaDDY+c3BcnnnO5rw+JiCgoceixG926dcOcOXM69tsgIqKgpw8nbk3MCajhx3Y7sGUBsOBBIGcN0P8E4Lx3gQyt3xUREfleoJ7j7Nq8Dme+th6Tw6bh4ZN6A2Ov8/UhEREFLSYKiYiI6MDsWgYsfBDY+SvQ/XDg0vlA9zH8VImI6IDlZu3BRa8vQz7ScPiQfsDh1/JTJSLyIg49diM7OxuPP/64WhMREXlTwMacnHXAe+cBr08GqkuBCz4Bpn/HJCERUYDEm82bN8OflRQX45L/fI2d9gzM6rcVJ01lkpCIyNtYUejugzGZkJ6ertZERES+ijl+Ody4aAfw06PA3x8CST2BM18DDjpDOuD7+siIiKgN8cYubSP8NOZUV9fiiifewHpbP9zeeR0uuOxOXx8SEVFIYBbMjdTUVEybNq1jvw0iIgpJARNzSrOAX54AVr0FRCcDJz0FjLwYCAv39ZEREVEwxRsAO587GVus0zE98U9cd8NMXx8OEVHIYKLQDavVisrKSkRHRyMsLKzBY37fUJ6IiIIm5viFigJg6dPAH68C4VHA0fcCo68EzNG+PjIiIgqmeKN7cwoGlC/DD6llSL31NxgMBl8fERFRyOAYITf27t2L22+/Xa2JiIhCMuZUlwA/PQLMGQasfAM44mbgpr+AcTczSUhEFID8Nt44+ebtZ7B26w7AHIv0W5bCaGSSkIioI7GisJmy/GuvvVatiYiIQirmVOQDv78ALH8FsNYAo68AjrgFiEnx9ZEREVEwxZtGli/6HLes643uhusw/47T/bvqkYgoSDFR6IaU4x988MH192WosQw5JiIi8hS9jUXjmOMzJXuA357TqgcNRuCQ6cDY64H4TF8fGREReUBz8cbXrZV2bd+Mq+bXwAwTnjtnKMLi0nx6PEREoYqJQjfKysrw559/YsSIEYiLi+vYb4WIiEKKT2OOzHi5e5nWf3DdF4A5BjjiJmDMVdqEJUREFJTxJisrC/6iqqoGV76yEMXoglfG5GPQiLG+PiQiopDFRKEbRUVFeP/999GzZ08mComIyP9ijqUW2LoI6H8c0J4m75WFwLrPgRWvAzlrgeTewKQHtVmMI3iBjIgo2OONv7Db7bj3iSexwTYct2asxrGnc4ZjIiJfYqLQje7du+OFF17o2G+DiIhCUrtizsZvgY+nAb0maAm+ziNafk5pFrB1oVY5uO0nwG4D+p8ATHoI6H0UYOQcZ0REoRJv/KWtkv3rW5BSU4OjzeG4/qZ7fH04REQhz+eJwrlz52LOnDnIycnB0KFD8dRTT2H06NFu9y8uLsa9996L7777Tl0Rk2B39dVX45prrunQ4yYiIvKpg04HTFHAD3cDL08EMoZoScP0QUB0CmCzAHVVQPEuIH8TsG8VULAFgAHocThw/GPAoFOBuAx+kURE5BubFsC4ah7uiTDBcvsOznBMRBTqicK33noLt956K9555x2MHTsWjz/+OCZNmoR//vkHXbp0cfmcq666Cn/99Rc+/fRTVTL/ww8/4OKLL0ZSUhLOO+88jx2bJC4/+OAD9ZoZGTyJIiIi72l3zBlwPND3WGDLj8DaT4ENXwO/P99wn8hEIG2AlkQ8+l6g55FAjH/OdklERN4jFYQJCQn18cbXE5kUFhbh+Te/wO0mM6Iu/gqmaLa9ICJCqCcK/+///g+XXXYZzjrrLHX/mWeewccff6yqDB9++GGXz1m+fDkuueQS1YBXTJ06FY899hiWLVvm0USh0WhEZGSkWhMREXnTAcWcMBMw4ARt0XsXVhUBYeGAKRIIj2pfD0MiIgo6/nKOI30J75z9ChZYT8DI/t1xUk9OXkJE5C98FiFk2LBUDh511FH7D8ZoVPd//fVXt88788wz8eWXX2Lnzp2w2WyYP38+tm3bhtNOO82jx5eWlqaqF2VNRETkTR6NOSazNpxYZiw2RzNJSERE3ok3B+CdV5/GgtqDMCVyNU68+A6fHgsREflJRWFWVpZap6enN9gu91euXNlsFeKFF16ohh1LYtFkMuHll1/GhAkT3D6npqZGLbrS0tIWj0+SkHV1dQgPD3d5xU1K931Rok9ERP6rPfGmNTGHiIjIEzHHOd74yqbVv2PW1t7oasjDv2+7CQZWvRMR+RWfn400PiGS+1KK7s7ll1+Ov//+Ww1BzsvLw5tvvqkmMpEqQ3ceffRR1Y9DX7p169bice3Zswc33nijWhMREbVGe+INYw4REbXHgZzj/Pbbbz750Kura3HjR3/CgjDMOakT4uNifXIcRETkh4lCvVm7JPuc5ebmum3kXlBQgDfeeAMPPPAADj30UCQnJ6u+hKeffrqaLdmdGTNmoKSkpH7ZvXt3i8eXkpKi+ifKWscKQiIiak574o27mENEROTpmKPHm7g430wcUvzGOTDabbgp8x+MGne8T46BiIj8dOixBKl+/fph8eLFKtEnpJJQ7ssEJa7oZeky3NiZ3G+uZD0iIkItbRETE4PRo0c3PYa6ShgtlbBGccZIIiI68HjTXMwhIiI6kJgjhQ7SMqlxvHHe1mH++hCdsn/C53GrYbphe8e/PxER+f/Q41tuuQWvvfYaFi5ciIqKClUpmJ+frxrs6mRY8ahRo9RtqSAcN24cZs2ahS1btsBiseCHH35QMyVPmTLFo8cmx/P777+rtbMui29B2sqnPfpeREQU2tzFHCIiIm/Em6qqqg79YMtKy7Hw05fU7YgrfkSY0X2RBxERhXCiUJKAUjIvFYTx8fH49NNP8c0336B37971+0izXecmvR9++CEGDhyIww47DFFRUbj66qsxc+ZM3HzzzR49NhnmPG/ePLV2VpvQCxEl2zz6XkREFJr0ig53MYeIiMiT9HjT2sm2POWROc/gstrbsKTf3UBavw59byIiahuDvbmZQzqQzMDlaqZHqRqUx8xmc5PH5NDbM0uWBEZp+Cu9PCRBKZzL76VEX97TarUiLCyswXHlfDML6aueweZzlqD/wMFtfm8iIvIdV7//O/r9Gg/3ai7mEBFRYOroeNPcezrHnb59+6p4s23btvrzKG/3Yf/lm3dx8dJEHGHaiHf+fQtnOSYi8vOY4zdnI+5OjKT/oKskoWhPkrAtxxMeHt7kuGoTesNgsyC8bI9vensQEVHQcRdziIiIvBFvvHke5ay0rBx3/2pBDKrwf1ecziQhEVEA4BmJGzIb8wsvvNBkVmZJFAoOPyYiIm/HHCIiIm/Em+Li4g75YB+ZMxv77KmY2X8Puvbo1SHvSUREB4aJQjdkWLMMe248MtsamQxLZDIiijYe4EdPRETUfMwhIiIK1HiTtfxzfFE+GONM6zF1+k1efz8iIvIMk4deJ+ikp6fjhhtuaLJdeniUpwxBZMFanxwXERGFTswhIiLyRrzxegslqxWZP1yB/5qTYLrkSw45JiIKIKwobIeq1CGIzF8H2Kye/0aIiIiIiIgCWO075wC2OvQYOg5d+nACSCKiQMJEoRu7du3CVVddpdaNVacORZilAubSHd7+foiIKMRjDhERkafjTU5Ojtc+1C3rVmDc+tPxX4wFzp7ntfchIiLvYKLQjeTkZFx00UVq3Vh18iDYDUY1/JgzHxMRUVtIC4u2xBwiIiJP0eNNXFycVz5U6X04870lyEUSUifd5pX3ICIi72Ki0I3Y2FiMGzdOrRvrd9AI1Cb0QVT+Gi9/PUREFOoxh4iIyNPxJjo62isf6ifvzMUya39cELcKo46Y5JX3ICIi72Ki0I2KigqsWrVKrV2pSjkIkQXrvPndEBFRiGgp5hAREXky3lRXV3v8Ay0uLsEj61KQimLceT0n6CIiClRMFLpRUFCAl156Sa1dqU47GObirQirLuLwYyIi8mrMISIi8mS8KSkp8fgH+vTzc1CEOMw8qBAJCYkef30iIuoYpg56n4DTpUsXPP3004iMjHT5eEXmYTDAjuis/6Gs14kdfnxERBQ6MYeIiMhT8ebGG29EWFiYZz/QXcsxuGolJpnCcNqF93j2tYmIqEOxotANCZ4xMTFug6g1KhXVSQMRs+83b34/REQUAlqKOURERJ6KN+Hh4TAaPXwa+O5ZOM/0M1654mgYDAbPvjYREXUoJgrdyM/Px2uvvabW7matrOh8OGKyfgdsVm9+R0REFOIxh4iIyFPx5vvvv/fo0ONl8z/E7iozkDEU6DHWY69LRES+wUShG1arFcXFxWrtjiQKw2pLEFn4D/sUEhGRV2MOERHRgZI4Y7FYPBZvKqtrcdNPdTiz7gHUXvy9R16TiIh8i4lCNzIyMnDbbbeptTs1qUNhNScgZs8v3vp+iIgoBLQm5hAREXkq3iQnJ3vkw5z7+mvItifhusG1MMfEeeQ1iYjIt5goPAD9BgxEebeJiNs5H7DbPfetEBERERERecGmTZs88jp7s7Lxyq5OGBC2DxecP80jr0lERL7HRKEbu3fvxg033KDWzSnteQLMFfsQmf+3N74fIiIKAa2NOURERAdi6dKlmDNnDnJzcw/4g3zyjQ9QAzNmHtsDpjCeVhIRBQv+RncjISEBp59+ulo3pyp9BOqi0hG/4wdvfD9ERBQCWhtziIiIDkRsbCyOPPJItT4QW9avxucl/TA+chvGHzWZXwoRURAx+foA/FV8fDyOPvroFvfrP2AgMOJcJK5+D7DUAiZzhxwfERGFXswhIiI6ENHR0Rg5cuQBf4h9Fl6FeeGR6Dr1JX4hRERBhhWFblRVVWHdunVq3aLhFwKVBcD6rzz89RARUShoU8whIiJqp5qaGuzYsUOtRf/+/dv8Gnt/eh3I34BDu8epnu1ERBRcDihRWFdXp5ZglJeXh2effVatW5Q+EJUZh6Bq8WyPNQcmIqLQ0aaYQ0RE1E7FxcX49NNP1bo96qw2PL5oJ/6090f22If4PRARhXqi0Gq14rPPPsM555yDTp06wWw2IyIiApmZmTj33HPxxRdfqH2CQefOnfHYY4+pdWsU9T8XUflrEFG4nslCIiLyaswhIiJqj9TUVFx55ZVqLdpa5PD+h+/iy7rRmJ94LmzmA+tzSEREAZ4o/PLLLzFgwABcf/31qvnt/fffr65GffLJJ7jvvvtUv4trrrlG7fPVV4E/BNdkMiEpKUmtW6OiyzjUxWQiaf27Xj82IiIKLm2NOURERK3lPLw4LCwMcXFxat1WFVW1eHaNCemGYtx4zQ3tGrZMRET+r9VnJA888ACeeuopnHzyyS4DiyQJpZrwm2++UUnEU089FYGssLAQ3333HU488UQkJye3uH//gYORu+EspK3+D0r6TJGI3CHHSUREga+tMYeIiKg9SktLsWzZMowZM0ZNpNUWr7/9OvLt3TBraC6iIyP4BRARhXpF4apVqzBlypRmrz7JY7KP7BvoamtrsWvXLrVurdLepwAwIGP5I149NiIiCi7tiTlERERtJf3lc3Jy2txnvqikDC9vS0EPYx7OPe8SfvBEREGs1YlCg8FQf/uRRx7B3r17W7VvoJIejPfcc49at1bfYWNgGHQqzOV7gA3fefX4iIgoeLQn5hAREbVVSkoKLrroIrVuiyUfPY1yROK2w+IQHnZA82ESEZGfa9dv+ddffx09evRQQ6SkRyErIJxMeQ4whgFf3+ixL4mIiIiIiMgT7HZ7255gqcGphW/ix7TncPLJZ/BLICIKcu1KFG7evBkLFy5EWloaLrnkEnTp0gW33HIL1qxZg2CxZ88e3HbbbWrdJpHxwKFXAhV5wJKnvHV4REQURNodc4iIiNogLy8Pc+fOVevWsv8xD6guQt+L/wOjMfBHjhERkRcShTK0eMKECXjzzTeRnZ2thiL//vvvGDZsGA499FC8+OKLqKioQKDatGmTmg3s2GOPVes2O+4RWMNjYV/0CLasWeGNQyQioiByQDGHiIiolaKjozFq1Ci1bo1te3NwzNdmLOl5I5DGyRqJiELBATeYiI2NRa9evdQSHh6O8vJyNUOyDE3+9ttvEagSEhJwwgknqHWbGY3IGvsQYLegy883eePwiIgoiBxQzCEiImqlmJgYNeOxrFtj9icLsM2WgahRU/kZExGFiHYnCnfs2KESgpIglJmOzWYzFi1ahPXr12P37t2YMWMGrrrqKgSK/v0bXiGrrq7Gli1b1Lo9KrseicpOYxBZsBZY+aaHjpKIiILRgcYcIiKi1pDe8tLmojU95hcu/R1fZ8Xj8LhcxJs5gQkRUaho1298GR7Vu3dvfP3117jrrruQlZWFN954A+PGjVOPS2Wh9CxsbmZkf5ebm4snnnhCrdubeIy57CsYwqOBb28Dytv3OkREFPwONOYQERG1RlFRET788EO1bsmHv/4DO4w4/7C+/HCJiEKIsb1JsJUrV6rlmmuuQXx8fNMXluG3WVkIVJmZmXjwwQfVut3CI4Fz3gZsdcBrkwCbzZOHSEREQcIjMYeIiKgFKSkpmD59ulo3Z9OOPfixKA1HxOWif7cMfq5ERCGkXYlCmSlrxIgRLe7XqVMnBCqpipTjl/UB6XcscMhlQNEO4JNLPXV4REQURDwWc4iIiJphMpmQnJys1s3Z8OsXiEYNzh/b12WbJiIiCl7NRwg3ZFZjdyIiItSw5COOOKLFAOTPpBz/xx9/xKRJk5CUlHRgL3by08Du5cA/nwOLhwATbvfUYRIRURDwaMwhIiJyo6ysTI0Kk5mP4+Limjy+efNmGKqLcdL2RzB82Nmo7nodP0siohDTrkze008/rYKIDC9OT0+HwWBATk4ObDYbunXrhn379qlkoUxu0rVrVwSiqqoq/PPPP6rvokdO2i6bDzzRB/jp30BkAjDmCk8cJhERBQGPxxwiIiIXZBITmZRy6NChLj8fu92O6H/eh8FuRd2QqawkJCIKQe0aenzxxRfjpJNOwq5du1QfQkkM7ty5E8cff7ya6ViShlKefuuttyJQde7cWc3qLGuPMEcDl/4XgAH4/nZg3ZeeeV0iIgp4Ho85RERELkhvwmnTprntUbgjOx8n/nkYPkq7EdbIZH6GREQhqF2Jwnnz5uGll15Cly5d6rdJ5eArr7yiHpPAM3v2bCxZssSTxxr4MocBF36q3f74YmDTfF8fERERERERkfLBbxtQghgkDJzIakIiohDVrkShVBDKMOPGZNvevXvV7bS0NFgsFgQq+Tnuueee+p/HY/oeA5z5mnb7vbOBtZ959vWJiMjvOTeF37Rpk/diDhERkZP8/HxV3CHrxtZt3YVFxRmYmJCDPp3T+LkREYWodiUKjzzySFx22WXYvn17/bZt27bh0ksvxfjx49X9BQsW4JhjjkGgiomJwejRo9Xa44aeBZzzlnb7k+nA7y95/j2IiChgeDXmEBEROURGRmLQoEFq7UwuWj350QJ1+9yxA1hNSEQUwtqVKHz11VfVjFkyYYkMM05OTkafPn1QUVGhrlCJgoICPPPMMwhUiYmJOO2009TaKwZPAS76XOtZ+MOdwBfXeud9iIjI73k95hAREQGIjY1VE2fJ2jlJuD0rDz+VZOAoVhMSEYW8ds163L17d/zvf//DsmXLsH79ejXr8cCBAzFmzJj6fa688sqAnxEsOzsbnTp1gtls9s6b9DkauHYZ8OIRwOp3gb2rgKt/BcLCvPN+REQUujGHiIhCuuWFJATr6upQWFioCj3Cw8PrHy8tLkDnsDKcM3aAT4+TiIgCtKJQJ4lBmTXrkksuaZAkbIsNGzbgtttuw4UXXoj/+7//Q3l5eYvPsVqteO+993D55ZfjxhtvxJ9//glPkxO2hx9+WK29Kn0AcNdOICYdyFsPPNYVyNvs3fckIiK/0mExh4iIQpIkCYUkCd955x21dnbwoIF47aJD2JuQiIjanyj8559/MGPGDJx77rn12z766CNUVVW1+jVWrVqFUaNGqUAlfQ8/+eQTta6pqXH7HHnsuOOOw/3334+DDz5YLddffz1Wr17t0a9Tqjpmzpyp1l4XEQPcsRnoeyxQVwk8fwiw4N/ef18iIvILHRpziIgoZEkloRRoyFpXWmNV6zCjwYdHRkREAZ0oXLhwIQ455BCsW7dOJQd1f//9N5577rlWv44kGidOnIh58+bhqquuwg8//ICNGzeq++5I1aFUEC5duhQ33HCDmlRl8eLF6NWrFzxJhn7JEOsOHQJ24afA6S8DBiOw9Eng6YOA8ryOe38iIvIJn8QcIiIKOTLcOCMjo37YcVZpHc7/YDs+XlNUP0RZFiIiCl3tShTec889ePnll/HVV1812H7BBRfgpZdaN4OvVAYuWrQIZ511Vv02mRhFZkr+7rvv3D7vtddeU1fBJMDpTCYTEhIS4EnFxcX44osv1LpDHXwucOcOIKE7ULoHeLIv8MOMjj0GIiLqUD6LOUREFBL05J+0eZKCC73d00drClFrtaNvSoSPj5CIiAI6Ubh27VqcccYZ6rZMZKKTaohdu3a16jVkP4vFop7jTO5v27bN5XOKiorU86Sacfbs2bjoootw1113Yc2aNS0mJUtLSxssruhX0GSRGZyXL1+u1h0uKgG4ZQ0w+RGtuvD3ucAjXYBNP3b8sRARUau1Nt405tOYQ0REIRNzqqur1WSUss6vsGD+5jIMTIvE8MyoDjlmIiIK0kRhXFwcsrKymiQK5SSnc+fOrXoNvQ9hdHR0g+2xsbEqcLmin0BJRaP0SJw0aZK6GjZy5Eh8//33bt/r0UcfVRWH+tKtW7cWj69Lly545JFH1NpnDr8OmJkDdBkF1JYD752lDUfO3ei7YyIiIo/GG7+JOUREFPQxJzU1FVdccYVaf7K2CHU2O6YenASj0cghx0RE1P5E4TnnnIObb765frYsm82m+gRK0DnvvPNa9Rr6UGGpEnRWUFCAxMREl8/Rt0tiUIY+X3zxxXj++edVdeOsWbOa7YVYUlJSv+zevbvZGcH0xS+YzMAVi4BrfgViM7ThyHNHA8+PAQpbV71JREQdoy3xxrmKnYiIyJsxp7GSaiu+3ViC3klmHNYtBna7nV8AERG1P1EoV68kOZiWlqbWUmEok5IMHDgQDzzwQKteo2vXrkhKSlIToDiT+8OGDXP5HKk27N27d5OTqn79+tVXOLoSERGB+Pj4BosrzslBSVjKz7Jv3z74hYwhwO2bgKkfAhHxQN4G4NmhwJzhQFbDz5CIiHyjtfGmMYk1fhVziIgoqGKOfq4k5zhvvPEGdmYXoHdSBM47OFmNEHMeJUZERKGtXYnCmJgYfPvtt1ixYoWq7Hv66afVsONvvvkGkZGRrXoNCUYy+YlMTqI3b5eqxD/++ENNVqJ78cUXceutt9bfnzZtmnpvfRhyVVWVet/DDz8cniQzTw4ePBhRUX7Wr2PA8cCM3cBZ84DIRKBoO/DSkcDjvYHV7/n66IiIqJWcK9gl1vhlzCEioqBQVlZWf47Ts2dP9EqJwuyTu2JCr1i1nRWFRESkM6EdpLJPegOOGDFCLa4ea42HH34Yq1atwqBBg9SybNky1X/w6KOPrt9HkpG///57/f0777xTbZMqwuHDh6sKRKlOlGSlJ0mVpAyx9ltDztCW7b8An10FlO0DvrgG+OoGoP8JwGlzgcjWVbIQEZFvSYW9X8ccIiIKeFabHa/+VYnDeh2CuDgtQUhEROSRRKG7WRnr6urU0lpSHr906VJVRZiTk4MhQ4agV69eDfa55pprcO655zYosf/yyy/VTMc7d+5UsyQPHTrU4+XyMiNzdnY2UlJSEB4eDr/Vazxw23qgNAv45FJg9+/Ahq+Bx74GYtKAsTcAh98AGNtVPEpERB1AYqcMB/P7mENERAFryY5yfL+pVC0JkUbccWQnHNo1msOOiYio/YnCd955x+VtIb0KpSJQKv3aQhJ8o0ePdvv4qFGjXG6X5KAs3iInbHPmzMHMmTNVMtLvxWcClzpmfl4yG/jff4CKPGDBfcCC+4GknsC4m4FR03x9pERE1IhUzktcDZiYQ0REAUWGFn/49/5JJEuqbXhzVYFKFApOrEVERDqDvQ0NKTp16qTWUv2XkZHR4DGpgJB+FzKcePz48fBnpaWlatZlmR2scdNffUKT2tpa1W9RhjW3tu+i36kuAb65Fdj4HVBX6dhoAOIygeEXABPu1GZVJiIKEc39/u/o93OeQCsoYg4REfks3rT0nu8t+hP3zG84Yda9R3XC+F5x6jYThUREgavUwzGnTRWFMhRXyBDhtWvXIphJo9++ffsioEUmAGe9pt0u2QP8MAPYulDrZ7jkCW0xxwHdxwAT7wa6HurrIyYiCklBEXOIiMhvOVcTiq7x4TiiB/sUEhGRh3oUBnuSUO/D+P3336vZlCUzG/ASugLnvq3drikHFj4ErPsMqMgHtizQFqk2lL6GvSdow5Qzhvj6qImIQkLQxRwiIvIbq3YV4a/sqgbbpgyIQZjRsz3eiYgohBOFOhm1LMOQZeIPZzJ0KtBVVlZiwYIFqg9i0J20RcQCJz6uLWLjD8CvzwLZq4GKXGDNx9oiicOoRKDTMGDkxcDg04GwMF8fPRFR0AnqmENERD715Dd/Nbgfaa/GoWn2Ju0wOPyYiIjanSgsLCzEDTfcgE8//RQ1NTVNHm9D20O/lZaWhqeeegohYcDx2iKsVmDNB8DKt4GctUBVEbB9sbZ8ehlgDAfiMoDOhwAHnwP0O57JQyKiAxRSMYeIiDrMltwy/LarosG2i0d3RedOSfwWiIjIc4nC22+/XVUS/vzzzxg7diz+/PNPLF++HP/6179wxx13tOclyV9IxaBMdCKLbvcfwO9zgd3LgPJcrd+hLOu/0B43moCoJCClL9BrPHDw+UByT5/9CEREgUAqN5wnNCEiIvK0lxZva3A/1mzEiQNZuU5ERB6a9VjXuXNnLFmyBH369IHBYIDVaoXRaFTDpiSJuHr1aviz1sxCWVBQoPpFXXvttfWzPRP2Vx1ung/8/RGwbyVQlg1Ym1aWqupDGbqc1AvoPALofzzQawIrEInIZ/xp1uPGMeenn37CpZdeyphDRBQE/GHW46ySKhz5f4tgse3f57T+kYjfsRgnnHACUlJSGjyfQ4+JiAKTT2c91mVlZaF3797qthyMnODIsClpwr5+/XoEg/DwcGRkZKiZKMlF1eHAE7TFWeEO4K/3ge2/AIVbtWHLFXnasmc5sPwlx44GIMyszcoc31mbNKXHEUDfY4G4dH7cRBRyJOZIPGXMISIiT3ltyfYGSUJzmAGn9I/DhqoMFXd0TBASEZFHJjORSkIxePBgfPjhh7j++uvx1VdfqeRaMJAs7KRJk5CcnOzrQwkcMtz4qBna4qw0B1j/JbBjCZC3QRu+XFuuTZwiS9ZqYPU7+/c3GLVEYkQcEJ0CJPYAMg4Cuh0G9B4PhEd1+I9GRORNjDlERORJJZV1ePf3HQ22Te4Xj27pieg2aZLL6nYmDImIqN2JwlGjRtXflr6Ep59+Ou69916UlZXh+eefD4pPVoZTyyyUMqOzyXRAk0NTfAYw5kptaay6DNj0X2DnEiB3A1C6V6tEtFTvr0aU5OLm/zZ6olQlhgOmSEdCMRmI6wwk99aSil0PBdIGSEabnz8R+T3GHCIi8qR3lu1ElWV/hymjAThrSGJ9vImOjkaYjBIiIiJqpF0ZsBUrVtTflv4WchVq1apVGDBgAAYNGoRgkJ+fj3feeQczZ85E9+7dfX04wSsyDhh2lra464eY/TewYzGw72+gaLuWPKwpBeqqtMpEuS0Jxuw1bt7EABjDtCpFUxQQEasNe45JBeIygaSeQOoAoNMQILEneygSUYdjzCEiIk+prrNi3q/bG2w7smcsOseb1YSUco5z4YUXBs1IMCIi8pNZj5988sn6+5JIC7ZkWmJiIs4880zVDJJ8SK50dhmhLc2RhGLuOmDPSm0tCcXSLK06sa5Cq1C01GjJxaqC1r23DIE2SILRBIRFAKYIwBwDmOO0SVpkWHRsJyDekWxM7qPN/Bwe4ZEfnYhChx5zpN8vERHRgfh6TS7yy2sbbDtnaJIaWtytWzdUVVWpuNOYFH9w+DEREbUrUfjcc8/hkUceCeqm6xEREejZs6evD4PaklDMHKYtrSGJxaJtQPZaoGATULQTKN0HVOQ7qhUrgLoawFoLWGqBumoAbZ4gXKtmlISjVDSqRZKOZi3xGB6pJR7DpcIxHohMBGJSgOhUbZGJXfREZHQaKx2Jgpgec6Ki2IOViIgOgMGIN5ftabBpZOdo9EuNVLclzvTt21e1VyIiIvJYonD06NH4+eefMXnyZAQr6d2xYcMGDBw40NeHQt5KLKb205a2kiRj2T4gf4tWuViyByjL0pKM1cVAbRlQW6lVL0qiURabBbDWaVWN9vJ2Jh1dJSEdiUi9+rE+GRnuWByVkDLk2hyt9XQMj9YSlDIEW6ojpcejDMWWRGVUAhCVpC0yNFseNxo9cKxE1JqYI+vhw4fzwyIionaJ7ncYdhXJBe79zh6aWF8pWFpaih07dqgJG6VPIRERkUcShcceeyzOO+88XHvttWrW48aVhWed5abfnJ/TZ/wS5eXlWLJkCbp27coyfGqaZEzspi046sA/napioGQ3ULJXS0CWZmsJx+oioEZ6MJZpFY6SfJREoyySdLTJYgFsVsBu1e5bJRFp91AisjmOSWLUZDF6slJfS7LSsdZvS/KyftGTmOGO6kp9bXYkNSMdi6PqUma5NjmSmyrJGe1IcEqyM25/slPWpnBOYEMBH3OIiIjaK37MmQ3u902JUBWFOmmr9Pnnn+Pcc89lopCIiFwy2O0qq9AmrnpaOCsuLoY/kytpCQkJKlDGx8e7PGlrjP06KKDZbEB1CVBZAFQVatWPkqCsKQGqSx3rcsBSCdRW7O/naNUTk1IZWedUHWlxJCdlbdNuy68SdduRqKz/1eLtpGVbOc2EXT8rtqM6091aEqBNEqKORao4G1R0OhZ1X0+OOt92VHyqxyVJ6kieqgl3HAnU+u1OiVSTWduu1vp9R/9MPcmq+mnqtyXZ6jTMXb8fwhWittpaZM2bh7n33YdrH3oImdOnw+jlFhru4o1gzCEiCk6+iDd6zBn2yJIG22ZM7ISrjh/lcn9XcYjnPEREgae5c44OSxQG44fY3AmbMwZPIg+RXz0WGY5d4UhWylIG1Eh/yHLHutJpqdbWqqpSJqepdvSQbJTIlLWexJRqS73iUm2zOpKZzouLBKfc1w6yacLTbxOgHZxkrb9rcFNp2ugxPfHqfLv++XpiFi0kbPXXcEraNhiCL/f1ZK5TQhdG5PxajcLVtQ2/NqMRydOnIeOOO+BPF6YEYw0RUWDKeeIJFM57Q7tI24HxxlWisFOsCUtnTIIpzPVFQiYKiYiCQ6mHE4XtGnocGxurhkm19TF/YoyKx8q1GxETE+O2KvLnxYsxccIEdO+UAqPjJFYPqDyJIzpA8v9UuFlbpCdiMJMKTFWlKYnOKi0JqpKcjtm4myQ9ZZskOvX78phjuLk+7FxVdTqSoWqbZX+Fp/Njcl8lTJ2GqetJ0vr7khDV93U8BsdtlSx1TqpKps0pwSrU2jmR6pRgbZBY1ROxztk6ue90u/6mu0Rs2xO0OavjULghtmny0mZD4Wuvq5vePHlzjjd9+vTB1q1bW4w5nHmSiChAk4SOuNJAB8Wbxs4cktQkSZiTk4N33nkHF154ocvnbNu2Db179+6gIyQiIn/UropCg8EAV0+rq6tTicKamhr4M1dl+c35aGovJEa1LqfKBCIRkX8N/9o4fETDyo7GjEYMWP2nV4aFtTXetCbmuIozzlUhjENERKEXbxrHnPgII5bNnIwoc1iDffLz8/Hll19iypQpKCwsdPk6jCNERIHFpxWFcvXJ1W1hs9mwbNky9OvXjllk/dyt3+5BmNFRhWK34a2jtETo8hzg+bUNr9KFm7ahR3QN/t1/p7r/yZ54fJWbUv9cVdUD4MjUCtw3KEfdfmh9BpbkN61svKh7ES7uUaRuX76yG3ZWhjfZ596BOZiQVqFuT1ri+urfKyN3o2dMHXZUhOOKVTIBR1M/HrlNrRfnxWDWhowmj/eIrsOro3ar22/tTMLbu5pWgPFn4vfEf3v8/8nffkf8/eMO3Djx1gaPvbToyYY722woeu99pEy7BP4Wc149NQPm0h2N4o0jKWi3o2+CDa9OqEFcVraKN5/tTYApfGODmMPfzfzd3Bj/LuDfOs74OyI4482pgxKbJAlFamoqLrvsMnW7SaJQCkHq24cQEVGoalOi8Pbbb3d5W4SHh6Nnz56YO3cugpnBVoceP1ykbu+wDkO4xUXZfkkOMgueUjcTLJMA66Sm+1T9DWQ7kq11FwK2YU332fQjsO1H7XbtbYC9aQIPf70PhP2t3a553PVB/z4XMOYAtgyg7jbX+/w0S1tbhwGufqbKHOAn7WcCfyZ+T/y3x/+fAuR3RO36PkDGSLSkdrd2IcTfSJJQYo7beCOf+2dPIdMRb0zyuVc12ofxhjG0Mf5dwL91+DsiqOON5AenDHY9+aTVakV1dTUiIyMbbI/MX4vMJXdh13FvQIrUWVVIRBS62jX0eMiQIVi7di0C1YEMPTZYqtWJmzs9OqcDxbuQlZVdvy0zs5N2Q/qPle3fTkRE3lWwYC1yP17e4n7pd9/tlQqPAx163FzMMVhr0D2umRDOmEMU/OTP+PqJuixOPWrlvtVx37r/vj6xlyxwbLfKbf1xqUSW3yv6c/RetXo/W+dJwFz1r9X3l+PS+9c6HpPXVb+y9P3UD9Co561zn1v9tr6fPK/+B2+4v/O2+u2u9nW+3+TDdPN8Vzs3/d1bsCEGuasT4Kt44xxzTugbjRcuP8rlPrt27cLDDz+MmTNnonv37vWtK4zVxejz2WTkjLkXpX1OZaKQiCiA+OWsx3JQ3333nWp8O3r0aPg7Od6kTt2wYMECt5OZSJ/FvXv3oUuXzkhLiK6fzKQxXm0jIvJfvu4Z1Zp401zMYYwhclAJrVqgpgyoLQdqK4A6mRyqXJsoSi1V2oRRau2YKMp5rU8OVb9IYq3WaaIox8RPDSZ7ckqYOU8G5ZwsazBRk83NpE7uklUuElrURm6Gyjb5293Q6KbBxXbn5xia7ld/3+C0v7bdZjFg43sxjq/R4LMehal9D8Y3n32EyeMOdblPRUUFNm7ciAEDBjSIS5Iw7PbfS2GJTkfWkY8x/hARBRC/mPX4k08+UcsHH3ygehMeddRRKuBIGfsbb7zhdhYtf2KrKsWoIQPUh+jcBL5elAkZia77LfLEjYgoMMjJWPL0aa5noXSQx7110tY43oi2xhwi7/3jtGlJt4o8oKIAqC4Cqku05JusVTJOknKOJJyauV2Sbo7Z2dWM7LX7Z2PXZ193nmW9vpLNebZ0p4qxxomzgNBMwsng4rbB6JRQ0teObWoxOm3Tt4ftv2807r9vlHWYY5tp/zaj8219nzCnx/RtJiDM5NjHcVtfG52WJtvNjnUYEBa+fzHKIvtFOPaV7XLf7Nim72sGTJGOfZv2zQsG8i0mR7qZ9biD4o2oy9uBw4YNcPu4JAdHjmw4RFqPSxWdxyJpw3v1PdWJiCg0tStROGvWLLz77rvq9tKlS5GXl4ecnBwsWrRIlbEHQqLQVeJv27ZtsFi0wFhZWYktW7agb9++iI6O9vEREhFRe2XccYdaF857o2FlodGoTtr0x/0t5vCiVAiSpFvpXqB0H1CeA5TnApUF2lJdCtSUaok9VTEnCbvqhtVxKlnXuPJNT8x1dDLORdKscdJLT4jp2+oTXI6EVH3SSk9IOSWo6pcIRxLKkZiSZJQpAgiXdZS2yO1wWUcD4TFARDRgigYiYgFzrLZdJcY4iQMFV7xxpby8HKtXr8bw4cMRGxvb4LGKzocjdc3LiMqXvoyDfXaMREQUgIlCuerUp08fdVuSg6effrq6OjVp0iScd955CFQydFr/+crKyvDjjz8iIyODJ21ERAFOTs7SbroJWfPmYe599+Hahx5C5vTpXq/sOJCYQ36urhoo2qEtJXuAsiwtuVdZCFQV7R8iK0k9VX2nV9w5JfE8mrhzrlbTE3DhDavK6hNtkliTpJojsaYn0cwx+9dmSarFApHxQIRjiUwAohKAyERtCY/w4PETBQd/jDfOZKbjt99+W/UnbJworEkeBEtEEmL2/YpNm0byghURUYhqV49CqXh46aWXMGHCBHU16pFHHsGpp56KzZs346STTnI9rCqAxm+7O35WdxARBTZP9+/wxPu5ijmMNx3AUgcUbAJy1wNF24Hi3VqiT4bhVsmwW0fvO9XDztG3rn4ChrZyqqhzHv6phmc6hmSqajepcpOKtzgtEReVBEQnAzFpQGwGENsJiO8MRCWy+o3Iz3V0vDmQ93SOQxm/P4So3NXYccqn6D/A/RBmIiLyH37Ro/Cmm25SCcHk5GR1EMcdd5zaLj0Lp06dikAnJ2j+nuwkIqLgwJjjIaXZwN6VQM5aoHCbVuUnSb/qYq3XnlT16dV8rWZoWI2nhrRGaRV3ejIvOkVL5MU5kniJPYDk3kB0kqd+MiKiDlPa8wQkbPsakflrACYKiYhCUrsShTfccIOa3Xjnzp2YPHkyIiK0oSddunTB2WefjWBQVFSEn376SU3UkpTEP/aJiMh7EhMT8frrr9fHHLlYxapCx4ywhduBHUuBrNVAwVath19VoSP5V6f142uJ6o1nclTtRe1P8sWkalV6CV215F7aACB1AIfUElHQys3NxYcffohzzz0X6enpapvEmx1//IDUv15A1mH3oS46HfE7vgOOOMvXh0tERIGSKBRjxoxRi7NLL70UwUJ6R/3yyy8wsLE1ERF5mcSasLCw0Is5MgHHjiXAtp+BrL+A4h3a7Lsy5LelWTcl8SdDdqW6T4bixqYD8d2AlN5ApyFA55FalR8REdWTOGMymZrEG5spGjF7FiN+1wKUSVXhls+xef1a2MPMvHBFRBRi2p0oDHZpaWmYMmWKrw+DiIhCQFDHnNoqYOO3wKb5QPYaoDwLqCnXZuh1yaDNYCuTZ8iwXhnOm9IPyBwO9DoSSO7ZwT8AEVFwxZtrrrmmyfbeI8aj/I/DkbDlC2SPfQDJ/7yJ2N2LUNbzeJ8cJxER+Q4ThW7YbDZYLJbQrPAgIqIOjzm9evXCtm3b6mNOwA0/lkrAP98Bti4E8jcDVQWApdbFzL4GbeZdSQLKsN+UvkCXUUD/44D0gT46eCKi0Ik3VqtVneMYjcYGj5X0OQ1dltwBg60WFZ3GIGn9uyjrofWiJyKi0MFEoRt79uzBnDlzcOGFFyIjI6NjvxUiIgq5mPPwww8HTszZuQz4801g93KgdJ82VLhxQlCGBkcmAPFdgcyhQL/jgAEnsv8fEZEfxJuZM2eie/fuDR6r6DIOlqhUNew45ti7gHfOQH9zLgDOfkxEFEralSiMjY1FeXl5mx8LJCkpKZg+fTqioqJ8fShERBTk/DrmFO8Blr0AbFkAFO0ELFVNJwqJjAeSegE9xwHDLwAyBvvqaImIqBXxRtaN9R84GMi+EolLnwFOfQxIPwj4dbbW9oGIiEJGuxKFFRUVLrfX1dWpJRjExMTgsMMOU0O/dAE3DIyIiAI25vjKjt+/RsqaVxCVtxqm2tKGlYKGMCAmTesXeNAZwNCzAVO4Lw+XiIjaEW/cGn0FbEufQdEPj6Cm3wXo/Os92szzciGIiIhCQpsShe+8847L23q/i2XLlqFfv34IBpIMXbduHSIiIvyzwoOIiIKGHnMOOugg7N27t367njj06kWqshzg58eATd+r2z1hU5tVetAcC6T2BwadAhx6uVY5SEREQRFvJGnYRHQyivudicRNH2H7qV+hOnkw8NUd2HXcG+g/gEOQiYhCQZsShbfffrvL2yI8PBw9e/bE3LlzEQwKCgrw2muvqf4d1dXVvj4cIiIKYs4xR5KC3qosVK9rtyFu+/fI3PEZkLcBsMqEIw7hUaiM74eigVNR0eNYVtETEQVxvHGZKARQNPACJG76GMnr30LeiBvRbeHViNvxPcBEIRFRSDDY7fbG0xG2aMiQIVi7di0CVWlpKRISElBSUoL4eNfVEVIhKcOoJQG6ZcuW+u0cekxEhKD+/e+L93OOOTILpZ4oNJXvhSWmM2AwHFj8yd8CLJoF65aFMNaWyrzD+4cSJ/XU+gqOvQ4Ij2z/exARkc/iTWvfs3G8cafgk9uQ9M9b2HHyx0j963nEZC9D2A0rgdg0L/4ERETkDzGnXT0KGycJ5aC+++479O7dG6NHj0YwkMApw46JiIh8EXOMNSXo8f1FKO11AvJG3da2F7TZkPP1g0jc8hnM5XthsFu115SHzHGoyBiN+FMeBdI5jIyIKJS09hyncNBFSNj6BdL+fBa5h96J+K9PB149BrhxtbxIhxwrERH5Rrt+y3/yySc477zz6q9KHXXUUbj88stx+OGHN+ldGKjy8vLw0ksvqTUREVFHxhypHrRFJCB/xPVI2vQROi++DdtX/KgqDV0NS5Ztu5Z+iJK3LkLtk4NhfygFGX/OhrlsF+wyK3GnYcCUuTDcV4Swe/Yg/rLPmCQkIgpBrT3H6XfQcOSNuAlxuxciKu8vFPU6GSjeCXxxdYcdKxER+Ua7KgpnzZqFd999V91eunSpCjQ5OTlYtGiR6ndx4YUXItBJAlR6E8paH+7lfILGIchEROSNmOOspO8ZsESmIn3F/6Hnt+eiMn0kqlOHIndDIkxVuYjKXYXw8iz0qy2BwW5TE5DYwyJQnTwQ5Z0PR0n/s2GLTGbMIiKiZuONK5mTbkD5zvlI/+Mx7DjpQ0Rn/wHz3x8iO2YIMo+7kZ8oEVGQalePwujoaBQWFiIyMhIPPPAAioqKMGfOHBV0UlJS1GxarWWxWLBkyRKVaBw6dKiagau1du/ejYULF2Lw4MFtGvLcnvHbjSs4mCgkIgosdqsV+b/8gmlTpuCNL79E6vjxMISFBUS/kM3r1yB+29eI2fcbIgs3qD6DdrsBRnsdrOZ41MV2RmWn0SjpMwWW2C7qOYxTREShE2+81Rdx6+pf0fO7qahKHYrssfej9xenwGCtxa5Jr6DHEWd55D2IiCgIehR27twZv/76KyZMmKCGIT/yyCP1ibsuXbQTlNaQZOOkSZPUWiZIWbx4MS699FLMnj27xedKE94zzzwTf//9N66++uqO640oeVW7VSUOeRJGRBQYSufPR84jj8KSnY0nO3dB/jXXorhTJ2TcMwPxkyfD30mVYEm/s9RCRET+K9DjTWPW6DRkj30QXRbfjIxlD2PX5Hno8cOFaiZk9BkIdBri60MkIiJ/6FF400034aSTTkL37t1VReBxxx2ntn/wwQeYOnVqq1/nnnvuQVVVFdasWYOvv/4aP/74I5599ln897//bfG5M2bMUNWHAwcOhDfs2rUL11xzjVo76/Tbv5C+8imvvCcREXnnpG3vTTerkzZnlpwctV0e9zV3MUfn7sJU4+1yX1+IiKhjBUO8aUziSUWXI1CZNhyxe35G/PZvsWfCMzDYrLC/NAE7//eFy965REQUYonCG264QVX/SeXf77//Xj9zllQT3n777a16DRnxLIlFqSCMjY1V28aMGaOW9957r9nn/vDDD/jyyy9VUtFbkpKSVNJT1kI/6ZLeUImbP0FU7p8MikREATD8Syo7VDV4kwe1bfK47OdLjWOOK85JQOdkIJODRES+F0zxpjGJM3uOeQGW6E5I2vAOIkq3Y8/Rz0nHQ3Sffymi9v3Pq8dMREQBkCiUZKAk9M455xwkJibWb5ekX1xcXKteQ4Ypy/jpxj0JZQjy2rVr3T4vKytLvc/bb7/d6veqqalRY7adl5bIa48fP77Be0iQLO5/NqpShyFj2SwYLFWten8iIvKNyhUrm1R2NGC3q8dlP09oT7xxF3OIiChwdHS88eQ5Tmv0HzgY4Tf+AZs5HmmrnkFkwTrsPvZl2A1GdP35RmDRwwfwkxARkT9pV4/C5557TvUlNJvN7X5jSRIK50SjSE5Orn+sMZmdS2ZUvuqqq3DYYYe1+r0effRRPPjgg206vsrKSmzevBn9+vVTk7fo+g8YiO2l/0KP/16MzKUzsMn4JGA0cZhXoJIZ36x1gLUWsFQ7btcAlhrHNqe1Tda12n2b1bFYAFsdYLc5bjttt1u1xaqv9W1O+8pt2abfVmutD2b9vvXPse2/rx+73Jd5TtV2WexO2/TXgWOb/rhj0R5wuo1G29WG/dv0+/X76ff1feDieU7Pafy8Fh9v9FiT9268vfH+jR9z83iTC/+u5ndyPsbW7N+CNs8h1Y73cPcannipxq/pxyw7o6R+ouX98vI88n7tiTfNxRwiIgoMrY0jnoo3nj7HaZXIeGw/+TP0/PZspP71PAoPmo7tp36OHt9fDNMvjwOr3wWuXgpEJ7ftdYmIKPAThTJxyM8//4zJB9CQNypKTt7QZIbksrKy+scae//997Fy5Uqcf/75eOONN9Q2mQjln3/+UfcvueQSGAwGl/0Mb7311vr7crWtW7duzR5ffn4+5s6di5kzZ6pejM56HToZSH4PMe+ejcxf70H2YQ8gJNSUAxV5QGWBtlQVa0ttGVBTBtRWAHWyVAG1VVrCzaon1iyARRJqkoiTJJnFKYnmuK0SX3qizJHUck5uNU5qNZc0Ij9laMfuLT3H0MJmd893td3gZnfD/sdafF0XjzW424rntbh/G1+/ye/F1uzjvJ+r43L1Ws77uTtGF/u7PAZD65/naj/Ha5kqHEnyFpjS0uAJ7Yk3LcUcIiLyf62NI56KN944x2mNvsMOxRbjZ+jx7TlIXjcPEQX/YNspn6P/wkuAoh3A472BYx8Axt3crp+JiIh8z2CXZoFt9NBDD6n+hNdeey0GDx7cpLLwrLNanpWxtrZW9SaUQHX55ZfXbz/xxBPV633xxRdNnrNw4UI15NjZV199hU6dOqnk5euvvw6j0eiRqaOtVqu64iZX2sLCwlzus3fRK8j87T7URWcgd/TdqEof2eDxDm8mL4m2qkKgeDdQvEsL1mVZQJUk9oqBmlItoVdXCciwaVUtV9ewus1VMq5DNDy515IyenLG+bbRsTg/pm+T794AqH8DRm1d/1iYtjbKOsyxlvum/ffVbad95Hs3mIAwfR+T06Lfl38bjufoS/3ry3P1+47n6bf17WHhju1O7yPrMLNj33DHff31HNvDHI8Z9X3CnX6OdnUUIApK0gtqyzHHqkbyLis5DQaYMjLQd+ECGNz8rj8QrYk3rY05RETkv3wdbzx5jtMamzb8g64Lr0F03mrURaVh97EvIW7nAqT9/YJ2HhGVDFz4GdBlxAH8RERE5MlzDq8mChsPF26suLi4Va8jMydLwlBmOxY5OTno0aOHGtqsJw9/++035OXlYcqUKS5fY/jw4Zg4caJKXHb0hygzfIWX7EDm/+5DZOF6VKaPQk1SP5T0PAm1Kc3Pxuw2iVhbCRRsAfI2aom+4t0oz9mCsJoSGGvLEIE6rWJPVevV7a/Aa1dizznR5pQsU8krR/JJElOmCMcSBYTrSwwQEast5jhtiYzXlohEICrBcT9B29cU3o7jIyLy3CyUinPIc1yY6DJnNuIPoEK+I4M2EZHHSVuV2nJtZIj8HSp/Y8pF5VrHhWX5u1P2kQvM+oVmdbFZWrZY9v9Nqi4+ywiROscio0LkcX0UiWV/mxXnFi3ye1nd19ux6O1UnBfnNiv6qJPG7VYaXfBu3DqlccuTZlugNNreSqW7I7H316Sm1e8dEG86OuboMx2n/vksktZrhRylPU9EwjnPA68fB+Q7ZkJO7AGc9y7QaahXj4eIKJSV+kOi0FNk0pIjjjgCxx13nOo5OG/ePMTExGDJkiUID9cSS5IwlJmV3U1w4q1EoZTlf/PNNzj55JORmprabICUP0xidy9C4ob3EZ3/t7YJRthMkarhrz3MDLsk3mx1CKsphsFmQZj6g8UKu1MlX+sHZTqSe3piT0/iRcQ4knRJQGwaENsJiO8KJHQGErsBcZ21xB0rzogoBJOFMtukc6N5U6dOyLhnhl+ctLUm5hBRB5P2KJIYq3aMyFDJNMei7ksSrdIxUqPakVCrdtyX5Jkk1BwtWPQeyCqx5tSKRe9TrLa5SZDV9yJurrfwgSe5AkvTJJzbESr19/X2Ik4jVRpcNHe6L6NFnLc7j2hRI1icbusjWRyPl26zIufnCljKbR0abzx5jtNWO3/9GN0WXAWj/HuWc5IzX9POOT66SBvtJOK7AKc8C/Q71iPvSURE3ksUtqtHoafIDMd//fWXGjK8ceNGNUmJJAb1JKGQRKIMLXbn1FNPxcCBzVfvtYfFYkFubq5at1QVKAnD8u7HqsVctAnx279DZP5amKryEFZbCkOtPlmFFQaVFHQMjzUYYTeaYDeaYTNFIDw6SQuq0SlAnCT5ugDJvbGjIhKWuEzYTDHoP3CQx39WIqJgJydnccccg/xffsG0KVPwxpdfInX8eK8N//JGzCEKSpJIK88BKvK1FinV0v9YEnOljoRcudb/WFW3SVJOknPVDRNxNqeJxvSWKs4ThTXpf+xmQi2/4KoVC1wntZoktBols5xbrajbenuVxm1UHIveDkWNKJHb5v3tUOSidJhjhIncrx9xEgWY9Mflefrjkdr9cP15kY7bsm+UYx//+P3raXJ6Fme1hlS86XHE2cBhZwBvnwrsWAp8eD4QmwGc865Wefr5lUDpXuDdM7V/D0POAE56BjC77ktPRES+1eqKQrnyJOTqk37bHdknlLKt9ZWF7Rhq7PzcDu9pSEQUYjp6KDCHHlPAkcSc9Dku3acl8MpzgcpCoKbEMTTVMURVT9hJEkDveaySdI7hp/oQUjUpmVOCrkPoSTQ94eacQGvUU1jvV+zcJ9igt1+RBJoktMIdSTG5rbdjiXQkv2QdBZhjgfBoLfERLm1Z5HacNtojMlFrx6ISZP6RLCIE5e9/v4g5eZuAt09TiUH5P94akYTs0TPQdciRwOdXA9l/7/9dIKOghp4NHPsQk4ZERIE49DgyMlKtq6ur1czCERERbveVffyZt4Mok39ERP6JiUIKGjLstWi7ltSTpWwfUJYLVBcC1TIs1jF5WX31nVTc6T3k9Eo7R083j2k8EZnTRGINeiDr1WiSaHPqf6zuS4JNWqnE7U+2qZ7HiYA5HohOBKKTtYkSJHFH5KdCNlGo27sKde+eB1NljrprkP/vB58GnPg08NtsYNWbQEXe/v3l//suhwDj7wR6jfPdcRMRBSCfDT1unPzz92Tggdq9ezeefPJJ3H777ejWrVubnsvKQCIi6qiYQwGoqgTIXgcUbtImLivZB1RIkq/YMdTWMcRW721nd07stVejCczCnIaVyqKSddH7JyuTxJy0RIlKcSTmkrTWKHoPZEnUsTqOKOB0WLzpMhLbT/sGptKdyPztPkQVrgfWfKQtqpLwLODo+4ClTwOr39Oql7cv1hb5fSXtmGQClBEXAkPO5u8bIqIO1OpEoVQR+nDekw4n2VgZQi1rIiIixhxqQobk7lkB5KwDCrZoVX2VBdrkFzJEVw3Nrd0/o2ubqvecqvJUFV74/oSeVN5IpV2UJPNSgZhUIC4TSOyqTWKW2J2JPCLy+TmOVjzRHzhkkjY50OLHgBWvA5X5wPJX1GI1RaMqdSgKD5uF7p0zgF+eBPb9qV042bFEWz6/Svs9KBcr0gcB/SYDwy8AonieRkTkDa0eehwdHa0a38bGxgZ80tCvyvKJiKjDcOgxNUsmxti9Ati7HMjbAJTs0YbGyQmrmkyj2inp1wr11XuOHndSsSdDaiOTtORefGcgsQeQ0gdIGwQkdGXVDFGQCPmhxy39rl00C/jrfdgrcp3msDZoF0A6DdMSgcl9gWUvALt+A8rztImLGjBov1ulAjqhG9BlBNB3EtDnGP4uJaKQUuqrocdHHnkkjj32WBx88MHq/tVXX+123xdffBGBrqqqCjt27EDPnj0RFcUZuYiIiDEnYEkly95VwK5fgdwNWm+/smzHBB2VWu++lpJ/etJPDc+N1ipZotO0ZF9SLyB9IJB5MJDUmyeoROS3/OIcR/qLTn5ILZs3bUJU1jKkrJuH6OKNQFWR0xBkOCoJk4HuhwF9jgYyRwCbvgN2/U/rzyrV2+XZ2rL3D2D5y/vfR/qjygzc0udUZmFO7qUNZ5ZeiF1GaW0WiIio/YnCd999F3PmzMHmzZvV/fz8fASzvLw8zJ49GzNnzkT37t19fThERBTEGHM8MLGHnFTuWArkrNX6/lUV7k8CumXQJtmQvnxyIilVfgndgTRJ+g1XPbaQ0PlAj46IyG/4W7xRw5NlmXDR/o17VgLLXnRUEuY6ZmDPAXb8sn8facUgFdqpA7XhyJnDtJnWs//SKsIr8rVJnaQSvKwCKMsCslYD6z5vehCqxYPEgkhtBnOp+pZ+rNFObR3kglDqAFZ+E1FIaPXQY2dyBUquRAVzWWZdXZ16XPYLDw/v8GMkIiLPslutyP/lF0ybMgVvfPklUsePh8HLkzG0dhgAY04rJwDZ8A2w9Scgd5120ldTpg0FdsmgnUjKSZ+c8EklSfpBWjVKz8O1ChUiohAbehyw8SZ3I/DXe1rPQrkYJLO7NxmK7HwRKBwwR2mTosgETHIRKDxCu4AkE0ZVl2i9EmUt26SfrF1aS7Sxl6xULapEo6PNhFFvNSETREk/WX2CqCRHX9kUIC5DOyapcpSJoWLTtWMlImoHW20tsubNw9z77sO1Dz2EzOnTYTSb0SGJQovFApOpdQWIbdnXF9ijkIgotJTOn4+cRx6FJTu7fpupUydk3DMD8ZMne+992RO37Qp3qr5VqkKwYDNQVeymKtCRCJSTwPhMIKWfNpSs3yQgtZ8Hvj0iouBLFAaduhpg60Jg6yIge602qZT0lVUzx0vssLcu2SfxRCX4YrT2EnJbEn/6PtKeQmKRXJyy1GivL9WKctt5wqoDmp3ezaRWDWatd7TBMOqLybFIwtLkSFY61uq2/FyO2e1lbYoCwuTnjHT8nFJFKQlNuS19dGO1++GxQFQcYI7XHpPEp3qudy+wElHb5DzxBArnvaFVVOuMRiRPn4aMO+5Ae7U6mzd48GDcf//9OPvss2F2k52srq7Gxx9/jIceeqh+iHKgKiwsxA8//IDjjz8eycmsOiAiCuQk4d6bbm5SJWDJydG2z5nt1WRha4RkzJG+gX9/CKz7FMhdrw0Ts9Y03U9ObmLStOFe0uC+72Sg/2TthIeIiEI73kiV4MATtaW5ivSdv2mzKRfvBEqztImqVJ/aci3Zpyf/pEdimzkl8iRJV5/Ik9uStDPKmbu2n2N37W8Sx98l+m27I9GoFqfbcLqvkpKOBKjza/gt/Wc2uL/vnAyt/yzlttEpQdooYeq8n3ze6qX0/cMaPc+RXFXfj/M+jbc7vjf98TD5/py3O5Kyan+nKlJ96Lra5kjU1idxndbqveS+o+JVJamd/8043db/LenPk2OBY60foySB9eOuPw6j9ndTfZWr4zYTvMGbJHzt9aYP2Gz129ubLGx1ovDll1/GzTffjJtuugmTJ0/GqFGjkJGRoWY/zs7Oxh9//IEff/wRPXr0wKuvvopAV1NTg23btqk1EREF7nBjqSR0OZRIthkM6vG4Y47x+jDkkI45khRc/xXw9wfAvtXacK/GQ4blD2JJCMosl72PBA6+EEju4asjJiIKSkEfb1yRyacGnqAtrVVXDRRuB4q2AcW7gdJ9Wp/EygKtYrGmHKir0PbTKw2tksSzavflwpdPEnlOibj6v330JFujx/XH9k87rR2ueszNcavHndb6Rpe7N9ro/LeY82dTXwjl6kX8PRFKrWNoxcOG9r9Og83uXsfV9kb//l3tZ3D1XEPLjzV53Hl74/dobh/nfff/fyy/cgrfdqp6dkEqDdNuuqldw5Db3KNw/vz5+OCDD/Drr79iz549alvXrl0xbtw4TJ06Vc2M7O9CsiyfiCgEVSxbjl2XXNLift3ffBMxY0Z7/P1DNt7ICdT/nteaxhdua1opKMOeZLbg7ocDo6YD3Q/11ZESEXkFhx6T2wtnMtmWVDRKaw2palTrcq26US2SgKxw9FOU4c36MOdarS+jpW5/clKtbY4EpaP60GZtWJWoD4l2rlysX6PRbcd9IvJrBRtikLs6ocX90u++GynTWj4XaqzNjQSlmlAWopCmAq8sjkBcH5AdgVoeq99mdR2o9R4mDQK3m6Bef99pWILzEAW3z4WbPxDcvU8Ljzd3/O6OQ/+8GvxhgmYea/xHS2sec/peXD2vre9Tf3geeK3mjq/dx9ze10Ib7te/UTue6+p+O9638ePteF/LVmOrQp0lL6/Ffai5D7AWWPqMVjEolRfOPQVl6Et8F6D7WGDkxUDvCfwoiYgoNMnoBZlgS5ZgTobK+Y8M55YLhdIrsj7RKdWWtY5tjsSn3JbFpi+OpKfa15EQVYlQqyM5Kot+jmVzszidizkP3a5f1LATp+Hdjc5hGidW5bXQ2nMyN3+/u93e6JypSSVqo3On+tdqtM3d38MNtrXwOu5G4DTc0Oi4Gh+Hu+Nz8/rOr+fiKU2P2e1OLt6jhaS325/NleaOz8V+beLqc2/+GbWVEa165drdu9txPO1IFL755pv46quv1JDjKVOm4JJWVGoEIqmWnDNnjhpqLRWT1AIptZdAoPf4ULdrG61le+3+QKFvq/+lr18Zc9zXA4O7x+v3cQ4aTvebJPAcS4MEntx3TvC18jkebVQcSBr3BjG6ud+o14h6qov+I80+pr8fmnnMF6/VaMhGa17L5WP6Z+butVrz8zS3P9wfs9fv65sbH2tHvLfzUADAlJQNLP4OLTGl+fYP9oCMOXtWAj/NAnYt0yofdNJ3J7k3MOAk4IibgvtkiIgowARkvKHAolq5hDl6Ccf5+miIgpL5jTeBxx5reb9u3byfKPzPf/6jgsrYsWPV/enTp6OsrAzXX389gk1cXBwmTpyo1kFLkmxS6i59NtS6xHG7SFtXlzpK3ysbrutv69srmvaaajXHrJX6jF2qQaubpcFj4Q1n+pIGrjJ7l/Nj9TODORrONmlY63zf+XHH7GcGV/s4Nb91+5quXtfQfGLN5WMtJeXasq+r92nhmFwm/4gCS/QRVpjeXaUmLnF5FdNggCkjA9GHjIIvBUzM2bIIWHA/kLNOu3CiGIDYTsDgU4Gj7tV6QRERkV8KmHhDRERuJZ0/FbmPP95wtuPGjEa1X3u0qUehzHx811131VcRvv7663jqqaewbt06BJKg7xklvSxK9gDFO7RZvaTxbnlu03VtmevnS7ItMhGIjAfMMUB4DGCOBsKjAXOs0+0Yp3WU1nNKrhyptWNpsM3FY2oGJyKiDpj1WDiHPEfyu4sXZz0OingjlYPf3ALkrN2fHJQLMp1HAhPuBPr5f29iIqKOxh6FRETkk1mPHZIvu7Tdsx63KVEYFRWFwsJCtRaVlZVISUlBVVUVgi1wV1dXY+/evejSpQsiIyPhdyRzXLILyF2vLXkbgaIdQPFOoCyr4b7RKUBsBhCbvn8dI0sqEJmgJQWjJDEoS4KW+GP1GBEFWbJQZje2ZGfXbzN16oSMe2Z4LUnYlkSh38UcaQ8hycG1n2pN1PXkYNdDgRP+D8gc5usjJCLya/6aKPS7eENERAeWLJz3RsPKQqMRydOntTtJ2OZEocFgUL0JW9rm71oTRHft2oWHH34YM2fORPfu3eFT8vlKAnDPCmDvSm0tw770nlAR8UDaAK0nVGIPILE7kCTrHtqskjIsl4goxNmtVuT/8gumTZmCN778Eqnjx8Og+uj4/kTRb2JO/mbgo4uB3H/2b0sdAJw0G+h1uO+Oi4gowPhrotBv4g0REXmErbYWWfPmYe599+Hahx5C5vTpMJqlRyg6LlF42223NdgmQ48bb3vyySfhz1oTRGtra5Gfn4/U1FSYD/BDbhfpE7htMbB1odYTqnSPtj2pJ9DlECDzYCB9MJA+UJtNkhWARER+d+LW2vfzeczZvAD46jqgzFFxKW0lRl8JHH2foyk5EREFQ6LQ5/GGiIj8Pua0KVE4ZMiQVu23du1a+DO/7RklE4qs/xpY8zGwY4k2s65UcvQ5Gug1XhvyxdkjiYiCLlHoM7v+AD6cClTkafelLcUps4GBJ/n6yIiIApq/JgqJiCj4lHr493+bZpLw9wSgJxUVFWHhwoU45phjkJSU5P1G8cteAP75UpuJuNeRwElPA32PBRLbN501EREFjg6NOaJkHzDveK2thZCWFVM/BDIGe/+9iYgodOINEREFHE4564ZM0PL333/j8MMP904QlULOTT8AS54G9izXhhQfcx8w5CwgPtPz70dERKEbc5x9djXw9/va7Zg04Nz3ge6Hevc9iYgo9OINEREFpDYNPQ4WPi/L370cmP8vYPfvQPfDgcNvAPofBxjZB4qIyJtCeuixDDN+62TAUg0YTcBJTwGjpvn2mIiIghSHHhMRUUgMPaYDVFMGLHgQ+OMVoNNQ4MJPgT7HcCISIiLyrs+vBf56V7vd+yjggk85SQkRERERETVhbLqJxL59+3DvvfeqtUfsWQHMHQusfg844XHgysVaD0LOVkxEFPI8HnN0llrg6cFaklCqCCVBePEXTBISEYUor8UbIiIKGqwodCMqKgqjRo1S6wO26i3g29uAzOHAtG+BpB4H/ppERBQ0PBpzdHmbgBePAKy1QFIv4LrlgMnsudcnIqKA45V4Q0REQYWJQjekue/pp59+YJ+utH9ccD/w6xxg1HTghP8DTBEH9ppERBR0PBJznOVtBOYeBthtwEFnAGfP89xrExFRwPJ4vCEioqDDocdu1NbWYs+ePWrd7iTh93dpScLjHgVOmc0kIREReSfmONu3GnhxnJYklPjDJCEREXkj3hARUVBiotCN7Oxs/Pvf/1brdvn5MWD5S8DJs4Gx1x7AV0RERMHugGOOLmcD8OoxgM0KXPAZ4w8REXkn3hARUdBiotCNjIwMzJgxQ63bbPX7wOLHgGPuAw6ZfoBfERERBbsDijm68jzg1aO0SsJLvgL6HePJQyQiolayW62oWbkSJ8bFqbXcD6p4Q0REfsNWW4uy99/HPenpai33D5TBbpcxsqGltLQUCQkJKCkpQXx8vGdfPHc98PJRwJAzgSnPcVZjIqJQ+f3vy/erqwZmDwEq8oAzXwWGnu299yIiIrdK589HziOPwuJUsWfq1AkZ98xA/OTJQRXjiIjIt3KeeAKF894AbLb9G41GJE+fhow77mj363IyEzckwP7yyy8YP368CritUlsBfHQJkNwLOPEJJgmJiMh7McdJ5UuTEFWRh/yhVyPNX5KEch2yrgqoKACqCoDqUqBGljKgphyoq9DiZl2ltp8slhptlmZZbBanpU77A8hu1YZVS9Wkvujb67fJ9U/7/rW6DadtLg+2DT+YocFK3TDodwyO+863nRa1zei47xjUYXC+77yv03bnfer3a7TdGLZ/u1H2CdMek+2GMKf9HY/rz5HH1H3n/RzbwuTPRHkNk7Y0eI5sk/uyjwkIczwvTB6XfZ0el+cYwx1r/b7s41iHhTv2NWuPyX2Dvtbf0+nnJfLjJOHem25u8rvGkpOjbZ8z2+vJQm/HGyIi8qMk4WuvN33AZqvf3t5kIROFbpSXl2Pp0qUYOXJk64OonOCk9QeO/hdgjm7XF0JERKGnXTFHt/gJROf/jfJOh6Fo6GVIa88BVBQCeeuB/C1AyW6gLBuozAOqirTEniT0VBJPFknaWV0n54iCQkvJSD0Z7Gb/+kSxm8Ryg+3Oz3VOMuubGu3flm0Nktgu3svVz9H4dfT79YluF8fqNlHu9DznfZwT6S5fx+j6tRu/VoP7jZ/f+HWdk/WNkvctbXde1yf4Hcl8/bbBCLvNjpwn/nB9QUK2GQyq0jDumGNgkIR6IMYbIiLyCzK8WFUSNkMeT7vpJhjN5ja/PocesyyfiChkBN3Q44JtwHOjYDHHY9vp36vqrP79++9/3GIBtv8EbFkIZP8NlOwBqou1ocpSpSdJvjZxOlmurzyTijCpEgsHTBFAmBkIiwDCIwBTpLaERznWcj8KCI/WtkXEAuGxQEQMYI4FzLKOcezv2EcuvMn+egVbKJKqSUnQSnJWrS3aWvqe6RWXapt1//dqdarGVPcdCV61zbG262vb/vtW58ckCaw/rldz6tsd9+H8mG3/fT2BXL+PUxWoy0UqPq2OtXMC2vlxx21JStv0x/RKUef9HdsaV5eq56sP1CmZ4/wajm0Nnqc2OG1D0/0a3EfT/ervt7RNv9vGytc2dxFiUt8bKnLM2PVTaov7dX/zTcSMGe2VY+DQY6Ig0SBmNoq79Wu14/4Y5Wqbiquqcar2umrtHCMd7+W8v7ZRe179cFbnWOf0t6P+XPWesnKKLw1ey018dR4uC/0YnR53GWcbv5fTY/Xx0KkvrL6f/vdDkxje6Djqfz57w2O1N/cZOB2HfnxNfr5Gx9rk/Zx3a3QBvkGc124XLNqI3M//QkvS774bKdMuQVuxopCIiChQvXO6+gPDdMmX6N95MLYv/y+K3nsSUbmrEFm2Q0sONeEYShruSMpFJgLRyUBMKhDbCUjoAiR2B5L7ACl9tSQe+ZYalhvBb4GosfqksN6KwCmZLSeKahIRu9M2SZo7HmucrFbPdToxbJD8dryHnrgWKgnu2G6zw7J4BfDTmy1+R5a8PH6PdODk37NU+6vK/xKt+r+6TGvnYakEaqu0UQCqrUe14+JSLWDR23vIfYtTqw+5mGRpdFHJcWFJv6ik/z+hLibp/080urjT4MJN4ws2jRI/LhMwLpI/Lu87bau/2dJFEF4koeBRu1YKEGJb3m/37na9PhOFbuzbtw+vvvoqLr/8cnTu3LldHy4REZHXYs4vTwFFO4BBU4DfngU2/YBectIgfwpLf7ioBCAqCcgYCvQ4HOh/IpDUlV8IEQUP556ePmYqkpO2lhOFprR2NYjwGJ7jeFBtNVC0HSiWlh37tH680pe3WhJ3pVoiT7XukD681fv78NokWeeciNMT0M4JNv1NmNwiD7XQaNJ+onGrDFfPd9M+w1WLDVfPb9KKoqXjadzmovG+To836Aftan8X+7lroeHqZ0Tj43Z3v/Fn4KoFRzOfg9rmHMPcfeYNX8ecWQVs1v7ub465Wze0BxOFbkRGRqrhW7ImIiLyp5izacN69Fj2GsIN4TCs/1Jts0Yko7zPsSjudzZqkwc0HIJMREReFX3IKDW7sUxc4nI4uMEAU0aG2s+XeI7jpDwfyP4LyN8EFG4HSvcCFblAZRFQK5NuVTlV3OkVpvYO7IvqjffSJ5kyNp1oSk0sJe1Dwvcv6nFTw4mmnCeYqr/tWNdPoKVPpqW3KWk8qZbTBFotvp6LxxpPctVgoq/m7hu8uL8j4ePR/Z0TXo17qVIoS6qtRe7wES6GNzsxGpF0/tR2vT4ThW4kJyfjvPPOa9eHSkRE5M2Yk/rns4io2KtOIapShiLvkDtQkzJIJQcT+dETEXU4maAk454Z2uzGchLvnCx0nNTL476cyCQkznHkpHnfKmDHUiBnnVZ5L8k/qfKrrTzA/rzyvbYhiSdJNumxq/fe1fvzOt9WvXwd/X1Njh6/DW7r/X/d3TY79o9wSvaZmi76LPJMMBEFBaPZjOTp01zPeuwgj7dnIhPBRKEbdXV1KCoqQlJSEsLDw9v14RIREXk85ix+Askb34MlIhl7jpmL2sQ+/JCJiPxA/OTJwJzZanZjS3Z2/XapJJQkoXrcx4LiHEf67/3zBbBlAZD7D1Ceo/XoU315m0vgOVWHNZ4soH4Xk9azV1p3RMYDEbLEaUuD+/H7t5njXCcDpeqNiMhLMu64Q63V7MfOlYVGo0oS6o+3B2c9djML5a5du/Dwww9j5syZ6N69e7s/YCIi8h/+Outxq2PO4ieAn2apmztOfB+1iX05xJiIyM/YrVbk//ILpk2Zgje+/BKp48d3SCVhUJ7j7FoG/PEqsHcFUJatDQd2mQzUh2vqk2w4kaRfXGcgPhOIywRi04HoVCA6RZvMSy1yOwUwx7LqjogCiq22Flnz5mHufffh2oceQub06e2uJNQxUegmiFZXV2Pnzp3o0aMH+xQSEQUJf00UtibmZM3/DzJ/uxeWiERUpw7DvglPqe3sRUhE5H86Ot4ExTmOTA7y2xxg3efaJCEyW28DTr3dZCZeXXwXIKkXkNxTWyf1BOI7a0lBWcL97OckIvLzmMOhx25I4BwwYMABf8BEREQHGnO2r1yIHssfQWX6SETnrkLscfeif3dOVkJERAF+jvPP18AvTwB5GwBrjdMDMhmGSZtERFUQGoCUPkD6ICD9ICBjMJA2EEjswUQgEZGH+UWi0GazobKyErGxsa1+Tm1tLcLCwtTirYzs//73P4wdO7bDrgISEVFoajbm2O3IWDYLlsgU2ExRqE4aiF3VSWCakIiIPBpvOsqqt4ElTwHFO5wmfZHEYLg22YhI6AZ0PQToeqi27jRU6/tHRERe56jd9g273a76YyQmJqoZuHr16oVvv/222ed8+umnKrDJ/pJYnDBhAlavXu3xY5OSzR9++EGtiYiIvKm5mLNn8RuqirBg2JWIyfodpb1P4ZdBREQejzdeVbgDeG0y8GAS8NX12tBiORU1OIo+YjOAoWcBp78M3LoBuGUNcPY8YOy1QLfRTBISEYVKReGcOXPw/PPPY/78+TjkkEPw9NNP44wzzsCaNWtc9lyyWq14//33MXv2bIwcOVJVFV577bU47rjjsHHjRpVw9JRu3brhmWee8djrERERtTnm2GxIXf08KtNGIKyqAHaDEaU9fT9rJhERBaYOP8fZ+hPw+dVAeXajIcUWbSjx4NOAwacCGUM4iQgRkZ/waUXhf/7zH1x++eU47LDDYDKZcOedd6Jz58546aWXXO4vw4w/+eQTjBkzBuHh4YiJicEjjzyC3NxcLF++vEOPfdOmTfULERGRN+z9+TVEFm9G/vDrEL/9W1R0GQ9bhOcuihEREXnFloXAYz2At0/TkoQyrFjEpAJjrweu+R9w3XLg6JnasGKDgV8EEVGoJwrz8vKwbds2jBs3rsH28ePHY9myZa1+HZm1S6SlpXn0+LKzs/HYY4+pNRERkTe5izmJmz5BVcoQWKLSVMKwrMcktZ0zHRMRkSfjjceU7AVmDwPeOQOoLgbCzNr2LiOBs+YBt/wDTHpQm4yEyUEiIr9k8mWi0FWCT+7//vvvrXqN6upq3HjjjTjyyCMxYsQIt/vV1NSoxbmJb0ukYlGqG2VNRETUGu2JN25jTk0ZIkq2Iu/g6xCzbynsRhMqM8fwiyAiIv88x/n+bmDZC9ptfWKSbmOACXcCPY9kYpCIKED4LFFocFxBkr6DziwWC4zGlgsdZb/zzjsPBQUF+PLLL5vd99FHH8WDDz7YpuNLSUnBxRdf7PZxVnMQEZEn4o27mLNtbx4sU75St7ssvhVVacNhC4/lh05ERF47x2mXqlLguVFARa7WgxB2rf/g8Y8BfY7it0VEFGB8NvRYrmSJnJycBtvlfmZmZotJwqlTp6rZjn/++Wd06dKl2f1nzJihZvbSl927d7d4fJLAlH0bJzKJiIg8GW/cxRyJddLw3WCrQ1TOSpR3OVJt54UqIiLym3OcnHXAM4O1JKHRrA01nvwwcPVSJgmJiAKUzxKFCQkJGDZsGBYsWFC/TQLWokWL1FBiXXl5OYqLixucOJ1//vn4448/VJKwR48eLb5XREQE4uPjGywt2bt3r5pcRdbOOIkJERF5Mt64ijnOE2VFZ/8Bo60WFZ2P4AdPREReOcdpl80/Ai8eCdSWAwYjkDEIuOoX4PDrgTC2byIiClQ+nfV45syZmDdvHt588011UnT11VerROA111xTv8/NN99cP+GJzWbDRRddhMWLF6vZj2NjY5Gfn68W5/4cniC9Eq+//nqPT5JCRETUlpgTnbMCdTGZqIvvwWpCIiLyj3OcNZ8A756lDTOWZfj5wGU/AukD+Q0REQU4n/UoFOecc46akGT27Nm45557MHToUFVR2KlTp/p94uLikJSUpG5LZeGPP/6obh9//PENXkte48ILL/TYsUVFRanjISIi8rbmYk5U3mrVn5CIiMib8abV1n4GfHoZYAgD7DbguEeAw67lZCVEREHCp4lCIc10m2uo+8wzz9TfTk5OVtWDHaGsrAwrVqzAIYccopKVOvaGIiKijoo5BksVIoo2oaTPFH7oRETktXjTaruWwf7JdG2osd0Gw2kvAMOn8pshIgoiPh167M+KiorU8GZZExERdVTMce5PGFnwDwx2K6pSh/ELICIij8abNivPB946VZvZ2G5HzmH3MUlIRBSEfF5R6K+6d++O559/vsl25xM4VhcSEZGnY45znIko2ghbWARqE3rxgyYiIo/GmzZ77RjAUi1pQuSOvBWlvU/G/oZRREQULJgoJCIi8lMy7Lg2oQ9gNPHiFBER+c63twJFO7QhxyMvRvrJ9yHdIClDIiIKNhx67EZOTo7qjyhrd6TqY9vqJdjz85vImv8cdi39CFtW/+qt74qIiEIs5kQWbUR18gCfHRcREYXeOU5jW//6DbaV78JuMAEZQ4ATHufEJUREQYwVhW6EhYWpBr+y1jkPBzNVZCN9xROI3ftLg+fZAVi+T0RJ3zNQMPQKVoEQEVG7Yo7BWgtzyXYU9zuLnyAREXkt3rQkdfVzgMEOuyEMhjNfA0wR/DaIiIKYwW63S24rpJSWliIhIQElJSWIj49v9fP0RKG5eAu6LrwW9jAzCoZeicpOh8JmjkN4yQ4kbXgXsXt/hdFaBZsxHMX9z0H+8BsBo5HDxoiIAvT3f0e+n/NFKWNNMWAwwWaOZQwhIgogHR1vvPaee1YArx6DvIOvU/1yuxx9hWdel4iI/Pb3PysK3bDZbKipqUFERASMxv0jtI21pejy882wRKViz9FzYYtMdJrYZCRw+BnYtHEjEjZ/gtS/X0LyhneRsPVL5IyZKTsd8BdGRETBHXMabI/QYgwREZE3z3FcknqSH2agOrEfigZdBBhbX4VIRESBiz0K3dizZw9uvvlmtXaWvuIpGOsqsG/C0/VJwsb6DxiAjJNnIuyeXcgbdi0M1hpkLp0BvHI0ULLX898iEREFZcwhIiLyWbzZvhjYsxyRJz2G/gMHsbKdiChEMFHoRkpKCq688kq1dlbZ6RDkHjoDlphO9ZWEWjWha2lnPArjXTtg6D0R2LsSeGawujJHRETUOOYUFxe7/FCaizNEREQHeo7jSuV//43qpIHYZOvGD5iIKIQwUehGTEwMRo0apdbOPaNKe5+Csp6T2/YpR8QCF38JnPofwGAEfp8LPN6H1YVERNQg5kRGRvITISKiDjvHcWfXb58hOmcFCg+azhmOiYhCDBOFbpSXl+O3335Ta3faXOEx8mJgxj4gbQBQma9VFy54sG2vQUREQRtzqqqqfH0oREQU4uc4ImHLp6iN6YzyrhM67NiIiMg/MFHoRmFhId5880219ugwMHMUcN1y4KRntI9/6dPAkwOAstz2vR4REQVNzJEZy4iIiHx1jiM2r/sTcbsWorTPqWoCE7a/ICIKLUwUutGtWzfMnTtXrb3i0EuBu3cBSb2A8mzgqf7AL094572IiMivSay55ZZbkJ6e7utDISKiED/HkSShwVKN0l4ndeixERGRf2Ci0A2DwYCwsDC19prIOOCm1cCkWdr9RbOAZ4YAlUXee08iIvI7EmuMRqN3Yw4REYW81pzjJGz7CpWdxqjJG1lNSEQUepgodCMvLw/PP/+8WnvdETcAd20HEroBJbuBx3sBvz7r/fclIiK/ILHm888/dzvrMRERUYec45TlICrvL5T2PJ4fOBFRiGKisBX0GY+9KioJuGUtMPFe7f6P/wLmDAeqy7z/3kRE5LdYzUFERB0le+nbsMOAys6H80MnIgpRTBS6kZaWhuuuu06tO9TEO4DbNwNxmUDRduCx7sCylzr2GIiIqENJrDn99NORmJjIT56IiHx2jhOz71dUpwyBNTKJ3wIRUYhiotANu90Oq9Wq1h0uNg24bQMw7jYANuD7O4FnRwHV5R1/LERE5HUSa2w2m29iDhERhYxmz3EstYjOWoaKLkeou6xoJyIKTUwUurF7925ce+21WLp0KXzm2PuAW9YDMelA4Rbgsa7AYs6MTEQUjDHnmWeeQW5urq8PhYiIQuAcR9ZNHvvtY4RZKlDReZxPjo2IiPwDE4VuJCcn45JLLkF8fDx8KqEzcMdmYPyd2v2fZgFP9AUKtvn2uIiIyKMx57jjjvN9zCEiopA4x5F1Y9HZy2GJTEZNUn+fHBsREfkHJgrdiI2NxeGHH46oqCj4haNnAnfuAJL7ABV5wH9GAB9cKOMHfH1kRETkgZgzZMgQ/4k5REQU1Oc4sm4sKv9vVKUNBwwGnxwbERH5ByYK3aioqMDKlStRXV0NvxGdCNy4CjjzdSAsHNjwNfDvNGDFG74+MiIiOsCYs3HjRv+KOUREFLTnOLJuwFqHyIJ1qE4dqu6yPyERUehiotCNgoICvPzyyygpKYHfGXomMDMXGHgKYKsDvrlJG46cvcbXR0ZERO2MOd98841/xhwiIgq6cxxZO9u5/FsYrTWoSh3ms2MjIiL/YPL1Afirrl274vrrr0d4eDj8ktEInPcOUJYFvH4CULQdeHEckDkcmPYNEBHn6yMkIqJgiTlERBQ08Wb27NmIiIhosN0SnYGcQ+5ETfJAnx0bERH5B1YUuvtgjEYVQGXt1+IygZtWAxd8CphjgazVwKNdgQ8uAKxWXx8dEREFU8whIqKAJnFG+uE2jjfWqBSU9D8b9jCzz46NiIj8A89I3MjPzw+sYWD9jgXu2QscdS9gNAEbvgFmpQJf3sCEIRGRnwu4mENERAEbb1599VW1dof9CYmIQhsThW5YrVZUVVXBZrMhoEy4A7ivABg5Tbv/51vArDTg+7s5QzIRkZ8K2JhDREQBF2/KysrUmoiIyBWD3W63I8SUlpYiISFBVW7Ex8e73W/Tpk3Nvo7fX22TPwA+uxxY9zkAO2AIA4afD5w8BwgL8/XRERH57e9/X7yfu5jj97GGiIh8Hm8O5D0bxx/GHSKi0I45rChspYAMmJIMPHse8K88YOCpWrLwz7eBf6cA754N1FT6+giJiIiIiIiIiMhPMFHoxq5du9SMYDk5OQ2ShXHbvkXszvkIKGHhwHlvA/fmA8MvBIxhwOb5wKOZwAvjgPzNvj5CIqKQ5irmEBEReSPeXHfddWpNRETkChOFbiQlJWHChAmIi4trsD127y9I3PwJApJUGJ72vNbDcOIMwBQF5KwBnjsEeLw3sOINXx8hEVFIchdzWtMGg4iIqC3x5qyzzlJrIiIiV5godENO1kaMGIHo6OgG26vSDkZkwT8wWGuRlZWFgDXxbuDebGDqh0BcZ6CyAPjmJuChZOCds4HyPF8fIRERQj3mEBEReTreHHXUUS4vTBEREQkmCt2Q2Se3bduGmpqahtvTDobRWoOIwg1qxrCAN+B44Lb1wG2bgd5HaTMjb5kPPNlXqzJc/IQ2KQoREXV4zCEiIvJ0vFmzZo1aExERucJEoRt5eXn4/PPPUVxc3GB7TdIA2ExRiM5ZgaASlw5c/AVwfxFw0tNAbIZWZfjTLG3yk2dHAWs/8/VREhGFVMwhIiLydLx57rnn1JqIiMgVJgrd6NKlC6666ir8f3vnASZVkbXhM8Mw5JyzEgRUzJhQDChizmExIOa4iC6Ci6uYUMB/zTmtGFARxbDmNaBiFsUAAhKVnDNMuP/z1nDbOz3dPT0zPfQw93uf5zL0jXXrVtWpOnXOqcaNG0flWJata9nDas/7yP2slIO67ueb/WOa2XV/mO1yhlnV6mbLZ5i93N/spgZm93U3mzw23akUQojKL3OEEEKIFMubkSNHur9CCCFELKQojEOVKlWsdu3a7m8QVj5e0+ZQq75iqlVd84ctXrzYKi3V6pid9IjZ0IVmV35v1uFQs8yqZsummb1ygdmw+mZ37Wz20e1meTnpTq0QQlQ6mSOEEEKkWt7Uq1dP8kYIIURcpCiMw7Jly+zdd9+11atXFzm2rtWBlle1jtWb8ar7PWPGDKv0NOpgdvarZv9abHblJLMd+hRYGq6aZ/bJHWa3NDYb3tJs9Ilmc79Od2qFEGKbljlMSgXRysdCCCFSJW9Gjx7t/gohhBCxyIq5V1hOTo4ToLm5uUVyw8uqbqvbH2v1fh9vy3fub/lVa4crxxq1N+v7YsH/N6wy+/AWsymvm61dbDbzw4LNMsxqNjLb7kCzAwaatdw13akWQohtTuZk5G12f70q2WlKmRBCiMomb+bPn+/+CiGEELGQRWEcmjdvbn379rWGDRsWOZaRkWEruva1jNyNVn/qGLeP1SpDSY16ZkffWRDTcNhKs75jzdodYJZdy2z9UrNfXzV7tGeBm/KI7cyePs7sh+e0krIQQhQjczJy1tn244+2OrPfUV4JIYRImbwZMmSI+xuLaIt2IYQQ4UMWhaWgU6dONm2aZys7n2ENf33a1mzXx3LqtHELm9SvX99CzQ69CzbwPLOfx5l986TZwslmG1aYzfqkYBt/WUG8w9pNzVrtabbzqWZdjiZwSrrfQAgh0o5zNa5ayzY16Gx1Z75pqzscJxkjhBBCCCGEKHdkURiHefPm2QMPPJBwsZJl3S6w3BpNrMXnQy0jb5M7d/r06eX1rbY9MjLMup1idt5bZv/8w2zYKrMLPixYSble24JzVv9Z4LY89myzWxqa3dSwwPLw0YPN3rnObMHkdL+FEEKkTeasbn+M1VwyybJXzXTHFixYoK8hhBCiTPJm4MCB7m8sQhF7XQghREJkURgHVgPbe++9rVatWhHrjqApPv9n34IDbrc2719gLT6/3ub3GG5elaqRoPMy3Y9B6z3NWj/y1+/8fLPp75r9NNbsz+/N1iw027DSbMMks/mTzL58sOC8jCpm2TXNajU1a9TRrM0+Zl2PNWsi9wghROWTOdC0aVNbkneo5dR60Br/+JDN7znK1qxZYzVq1JD1uhBCiFLLmz59+ri/scinby6EECLUpF1ROHHiRGdFsWjRIuvWrZuLmdGsWbOUX1NS6tata927dy/2vE0Nu9iCA+6wFp9ea60+HmAL97/V8moUxJiSwjAJMjPNOh9ZsAVZu9Rs8hiz3z8yWzbdbN1Ss01rzTatMVv+e4Fy8cOb/7JcJNB/dp2CBVTqtzVrtqNZ673Ntj/IrHqd0hQBIUQlI2/DBlsxcqQ92qq1+1tr6FCrUqNGupMVV+YQygIrwqW7XmEtJg51sQoJdcG+5cuXW/v27dOWXiGEEPHJ37zZ1owZY/9s2tT9rd2/v2VmZ1cYeXPEEUekOxlCCCEqsMzJ8DwCyaWHCRMm2GGHHWZXX3217bfffnb//ffbrFmz7IcffrDatWun7JpoVq9e7WbRVq1a5YRlLDZu3Giff/65U0Bmb8nkWBaCvjKwxqLvrMWng61KzlpbvV0fW9R9iFlW9Zj3zszMtMaNG8sipDRQXLE8nPpfsz+/NVs5x2z9crOc9Wb5RVeo/osMs8wqZlWqmWXXMKte36xmY7N6rcwatjdr1Mms6Y5mTbuYValaqqQJISou8y6/3Nb+jxXZC1O716HW5oEHyu25ycgbX+Z8/fXXbjGToMyZM2eObdq40Zp/Mcxqz33fWbGva31QoWvr1KljLVq0KLd3EEIIkTyLRo2y5U/9p8Brxicz0xr2P9eaDRpUrlmZ7BgH2dKuXTurXr36X+MZz7OaC76w9S33t2rVqrnjQgghwilz0qooPPDAA93g5qWXXnK/161b534PGzbMKQJTdU1phOjcuXPttttus7POOitpa8WqK2da648HWNX1C83LyLQNjXezFTucYuva9CqwnEsCDfjKCMV58S9mMyeYLfjBbPlMs7VLzDauMsvdYJaXY+blJXmzLcpFp2DMNsuqYVaVraZZtdpm1euZVatXYMVYi62ZWd3mZnVbmdVtbVazQYG1oxCiQioJt4ayMFlFYbEyJy+nwKpw3ke2ssMJtnzn8yy3VumVg9ETXyzGhZUiisrQL8olhBBlGbA98WTc4w3PP69clYUlGeMMHTrU2rZtG1EU1vrjE2s14R+2aK/BtmqHU0oVQkmyRAghKofMSZuicP369U4p9vTTT7uBkc9JJ51kGzZssLfffjsl15RWiObk5NiKFSts6dKllpVVMg/tWnPetyaTH7aqa+aiajLPMiyvWn3LrdHIvCrVbVPddrapXnvLqdfe/c2r0azIar88U25l5QyrMP/xrdnCn81WzDZbM7/AxXnjarPNawsUi7mbzfJRLuYXbGUmo0B56BSImWYZWzZfIZmZFdiqblFS8pctyywr+6/f/MVC0v/rjqHQrL5lyy5QbGZVM8vccswd33IPzuE393LnZBU+7p7D/f3fWpFabJvuxtN236PY83aY9H25uCEnqyiMJ3Oqrp5rOSgEqYNevtWf9rI1+ulRy9y82jY27GpeVnXb2Ghn29BoJ9vUoFOB8pC6XEaIjyiFoRBClMz167fddi9s1RFNZqZ1/mFSubkhl2SM06BBA6ta9S8vmrkTx1mb9y90E+rrWuxnKzqfYRua7lXQLywjeFN17NixzPcRQgixdWRO2mIUstIWwXJbtWpVaD+/P/zww5RdA5s2bXJbUIgWB4KTgRIzY0Gaf369VV/2q+VXreUWLvEyspzux/3jeVZtJaseZ7jjv5/ykdWbMc5q/fmZZa+ebdVW/u7UhjWW/VzonnlZNez30yYU2pebmxtxay4JskgsATUamHU6vGArKTkbzVbONVv1h9nahWZrFhUoGTcsK1iMZdPqgpiKuRvNcjeZ5bHlFigd8/MKrBrZqNj8zdvsyoaziOSvSJKMFF5WGa0/K8k7leE1Fn9DSIpaxZ83cpS1uPEGKyulkTdxZU5+rrV7u69l5Odabo3Glp9d1/KrZNvmOq0tc9May175u2Xmb7Kai7+PXPJX64EVu9+eBDMww1a3O8wW9bgtYXqIgxi9AnNp0cJeQogwsOL5MYkHbJCf785rdG6/lDyzLGOcaDY27mZzjnjaWn56rdVe8IXbCmRKpnlMXOfnWkYp+qiLd7vSVu14TqnGNaVBMkcIEQZWlLPMSZuikNks8GNj+LCa4+bNm1N2Ddx+++120003lSh9uGC999571rt3b2fh4bOu5f6WW7OJZeast4z8zZaB0scXmvm5VnXdQvffvOzalp9d21bs2M9tETavtVoLv7bqy6da1ro/LWvjCttUL3UzbKyIqVhVW4Gq1QtWXN6aqy6jRMzZVGDtyEZcxs3rzHLYNm75//otysmNBft8d2sUlLlb3K7d79yoDcVlfkB5mR/Yt2V/8Ljxfy9wPPDbpdX/6ysqOBbYH+lobtkf2ef/DnREI0bPsfYlOCfmM6LvEzezE36KEp+X1GlbW0FcguelRXedmoduXptczNHNc+em5HmlkTfxZU6G/XHI/VZt1e+WtX6xZeastUwmHRisefmWs6mVZa+aZRn5OZZbo6ltaLaHZW1Yapmb11hm7oaCa3LXuXML6l5BXcir3jgl7yqEEOIvNs+bl9LzkqGsYxzCTQQVbOjyZh//mmWt+dPqzHnPqq2cZlkblllm7nrLWrfAjX9i97VwU4s9YM2vUvxknRBCiIolc9KmKPQF07Jlywrt53dQaJX1GrjuuusKxS9ktq1NmzYJ00egX2a+evbsuUVwFsyCrdn+KFtjZSC7tq1re6jbygMsCkUlBXfl7OoFm2mgL0QyZOfebOvHjCn+vC1xmspKaeRNXJmTWcU2Nt3NbUIIISo22Um09SU5LxnKOsaJZ42HCFqxc/+UpVMIIcS2JXPSuphJ8+bN7dJLL7Ubb7wxsq9bt27Wo0cPe/jhh1N2TWljRgkhhNi22VZiFAohhNi22VZiFAohhNj2yS9nmZPcUrzlRP/+/e3xxx+3BQsWuN/jx4+3n3/+2e33GTFihJ1zzjklukYIIYQAlH+sapwIjpeHklAIIUR4YCDWsP+5Cc/heHkpCYUQQoSHzHKWOWlzPQasAn/77Te3Cla7du1s9uzZds8999g+++wTOWf69On2/fffl+ia4vCNKBMF/J0/f76zULzkkkusZcuWpX5HIYQQ6aXe7bdb7qBBtvGTwotG+UrCNg88UG7PTkbegGSOEEJs+9S4+GKrvXmzrX3u+cJWHpmZbsDWbNCgcn2+xjhCCBEeapSjzEmr67HP3LlzbdGiRS4uBubyQWbMmOEW6Nh9992TvqY4Zs6caR06dEhJ2oUQQmwbMJ82qElTa5edbT1PP9063npLuVsSSt4IIUT4wBLjb/UbWJvsqtbv2sHW8cortooloWSOEEKEj6xykDkVQlG4tVm5cqU1aNDAKRtLqmQMI35g5Hnz5ineifJM5awCobpZcojb1LZtW1uxYoXVr1/fyhvJm5Kjcq082xqonCm/Kpu8AcmckqO2QHlW3qiMKc+2RZmTVtfjdJGZWRCaESWhAv0mD3ml/CoZyrOSozxTnm1NObC1niN5U3LUFijPtgYqZ8qvyiJvgs+SzCk5aguUZ+WNypjybFuSOWldzEQIIYQQQgghhBBCCFExkKJQCCGEEEIIIYQQQggRTkVhtWrV3OrJ/BXKL5WxioHqpfKsMpYzlWvlmcpZxUR1U/lVGcuYyrXyTOWs4qF6qTzbFstZKBczEUIIIYQQQgghhBBCFCaUFoVCCCGEEEIIIYQQQojCSFEohBBCCCGEEEIIIYSQolAIIYQQQgghhBBCCGGWFaZMIBzjhx9+aNOmTbO2bdta7969rWrVqulOVoWFvJo8eXKhfY0bN7azzjorbWmqiPz000/20Ucf2Z577mk9evSIec6ECRPs119/tRYtWlifPn1CvZCOXw/Jt2OPPdY6dOhQ6Pjnn39u33zzTaF9derUsfPPP9/CyqRJk9xWr14969mzpzVp0qTIOStWrLC3337b1q5d68rhTjvtZGElLy/PPvvsM9fWt2zZ0nr16mXVq1cvdM69995r+fn5hfYddNBBtvvuu6csHevXr7d33nnHFi9ebLvttpvtu+++Kbt3ZWT06NG2fPnyQvvIt4MPPjhtaaqI7ef777/v5MmJJ55o7dq1K3LOpk2bXLlbsGCB7bjjjq7NCDMbN2608ePH28KFC+3SSy8tIn9ffPFFl1dBunbtakcccYSFkdzcXPv0009txowZ1rp1azv00ENj9ll+//131/fJzs52edWsWTMLK6tXr3b9PMpY586d7cADDyx0fP78+fbSSy8Vue7MM8+MKc9LC+X4vffec9/wkEMOsfbt26fs3pUN5POjjz5aZP8xxxxjHTt2TEuaKiIbNmywV1991fVjrrzySqtSpUqRc5YuXepkDucib6gDYYa8Is/q1q1rf/vb3wody8nJsQceeKDINegkkNdhZOXKla79XLJkiZO9+++/f8zzJk6c6PQSTZs2tSOPPNJq1KhhYWXevHluvEx52muvvVy+Bfn6669dfgVBjtMHKgmhcT1GaKKUOOecc+zLL7+0AQMGuME0wl3Ehk4Njdns2bMj259//qns2sL06dNdZxAhMGzYMHvjjTdiDuo4fuqpp7oKe9111zmFIkI1jLz77ruuMWNFpoEDBzplYTTk47///e9C5Y4GMYwsWrTItVMXXHCBEwiPPPKI6/iPGzeu0Hk//PCDderUyR566CH73//+Z3vvvbeNHDnSwshXX33llKTUSQTl9ddf7/Lml19+KXTe1VdfbZ988kmhcpZKefDHH39Yt27d7KabbnLf7qijjrKLL744ZfevjAwfPtxee+21Qt9k2bJl6U5WheHNN9+0HXbYwZUp2s8pU6YUOQfZgoxB1iBzTjnlFCeDwrpu3Z133ukmo5Ap5BkD2Wjuuusu198JljsGLGGECRYGq7feeqtrPwcPHuwG/Uy6BHnqqadc+8bk1LPPPusUKygNw8jjjz9uu+yyi5PPjC+ob/QN161bFzln5syZrvyhXA2Ws82bN6csHR988IGTdWPGjLH//ve/Tg4y+SJig7znm3z33XeFvknwu4UdZDJ1228/UUpE88UXX7hznnzySaekZrI1liIsLJPU1P899tjD5dn//d//xZzIIy9pK4Lljkn+MPLggw+6CWHaUfosJ598spucipbVGIugx6E/Tf+eNpcJmDByySWXuAl0JkBR0KMovOqqqwqdQ10cMWJEoTI2d+7ckj/MCwkPPfSQV6dOHW/u3Lnu9/Lly73WrVt7Q4YMSXfSKiwXX3yxd/LJJ6c7GRWW3377zfvkk0/c/3faaSdv8ODBRc4ZM2aMl52d7c6FtWvXep07d/YuueQSL4x8+umn3tSpU701a9YwavVeffXVIueQj7169UpL+ioaCxYs8CZOnFho39ChQ73atWt7OTk5kX177rlnobpKuatSpUqk3IWJSZMmeb///nvkd35+vnf44Yd7Bx98cKHzyJ+333673NJx+umne927d/c2bdrkfn/zzTeuzL/zzjvl9sxtHdrG++67L93JqLB8/PHH3vTp070lS5a4shSr/CK3u3bt6q1bt879njJlipeVleW98MILXhhBxpBfb7zxhsuzFStWFDlnn3328W655Za0pK+i8e2333qzZ8+O/M7Ly/N69uzp9enTJ7Jv0aJFXs2aNQvVVcpdu3bt3Plh44MPPvBWrlwZ+b1s2TKvadOm3rBhwwr1fSh/GzZsKJc00B9gTDNgwIDIvlGjRnm1atVy6RGx+1d8k59++knZE4dx48a58jN27Ni45bdLly5ev379Ir8fe+wxN+7xx9thgnr4/PPPu34fdZG+eTT++OeLL75ISxorGu+99563evXqQvKlYcOG3h133BHZh/zOzMz0fvzxR/d748aN3q677uqdddZZXhgZP368l5ubW0S+0Ef0oU9D36ashMaikNliLDratGnjfjdo0MBp/WO5AojCbgyY5uOagzZa/AWWHcW5dFG+cP/gXKhVq5azag1ruTvggAOScknAiuixxx5zM+O4P4WV5s2b23777VdoHzNtzDz6M2lYKjAjzgyTDxastHHRlodhgJnJoLtVRkaGm3n77bffipyLq8PDDz/sLF1xT0wVWIkw03feeec5tzxgxq979+6hrfvJgnUslrFYFuOOIgq7xhfnEjd27FgnY2rWrOl+d+nSxcmgsJa7E044wYVMKQ5cuSl3WLSG1eIfsEYNurNnZma6chdsP7FsxXKmf//+kX2XXXaZzZkzx1l0hw1CWxAWxKdhw4a26667xpQ5L7zwgj3xxBPOCiuVYImDFXuwH3DhhRc6WYR1oYgPVrGMcwiJQ7kWf3HSSSe58hwP3ECnTp1aqNydffbZrt9DHyhsZGVlOd2C3+8rzgIYK2T+xrLUDAuHH364Cy/lg1sx1tDB9pP+C2MhrAh9F1r616+88orzGA0bxx9/fKEQAIytKXPRMoc+NPLmueeeiymPkiE0ikI6gXSYg/CbQXYqB4iVDdxvMI/GpJz8GjVqVLqTVCnKHXG4cCsVsaFxw7ycxg2B8a9//UtZtQU6X8SC8ic9KGN+ufJBgOCC5B8LM7hcvv76605RF4Q8IhYmG3F3KGfRMVlLC3IF95JYdV/fJD4odckfFN833HCDm2AhHp9IDuKjIVtU7koXSoRyh6sdbWcYB7mxQHGC0j7YflJHiV3IxKePX+bUvhWEDEERGC1zGAyjZEUhRRw8Jv3WrFmTku9EvqPU9SelAeUlk436JvFhcE0IEhSt/fr1cy6jpXLPCymx+p8ocbbffnuVu2IUioR5YHyNQp+JBWSQMBfi7Ntvvy0ic2L1a4gzygRV2HnrrbfcpFC0zCF/MIhA0YqSlZBLJSU0i5kgjOvXr19oHxY3gHVOdKB7YXbRRRe52AF0PuD55593C5lgRbfPPvsoi8pY7jgW5uDf8TjjjDNcfCQEKTAbTqeacsfMU5hB4UXsFxSoKFXAH2jEKmepGoRsy6BkJhYm8baCoIj2hSqzuZQxZsJ//PHHMj9T36R0PPPMM5FvgoIXKwVkDorXoFJCqNylkvvvv79QB/vaa691SgPiySVjjViZIUYh+RC0SI3Vr0HhghVr2GUOsgSLIhZMDFpZbbfddi7OI4o7X5mI9TsxdO+5554yP5d8RxHp99d91A+IT+3atZ289xUQxCbEModg/7LCTL7cQdCiVuUuMbSVTEr51nEYKzFpQCxylNZhhgn2008/3U14BBewLG4sHWbmzZvnyo4/0eFz3HHHub6Mb9368ccfO+t34ueyEF6yhMaiMFYHxg9c77voiMJQ4IKdjr59+zqTYBZLECp35QWdZ19JCEcffbRzVw67ZRH1DiXq7bff7v76+O1XrPYt7G2bH0ya1eeiV4EOKgaqVq3qrAqxKGS1urKib1I6gt8ERTgBv/keqVDehgGVu9IRPQvPrDvtZ/TkQtjAuhJ3bCaosLJM1J/G/Yvg82GWOeQBsnnWrFnOnTWYF1hg+kpCYJKYFY9T1a/hWRg9RC9apH5AYkVh0EqJySgWHJMLcsnKHUQvxKFyFx8UN76SEDBUInQDFoaxFtsKC1jEsZAJkyhYyGGZ6iMdTnwvksMOO8xZpOLGHoQyFnSBJwQTCw2VVOaERlGIdppZ0SD8btmyZag7NiWFQrdq1ap0J2ObL3d0UFq0aJG2dG1rhL3c0XFldgjrOGaIgviuRtHljMFKcHAXNu6++24bOnSoUxL27t272PN9gZqKcobbDcruWHU/zN+kpKTym4QBZAqyReWubKjcmd1xxx3Osh+3YwYY0TKHeHhYf/hg9YuSKqztG0pCLAmxFGL1ZywKt2a/hm+Cm3jQDQ+lA3HGw/pNSgPfBAuvYNkW8YnV//TLocpdycpdfn5+aFc+RklIbHXiXdJ+optJZizNJD/W2mFVEh5yyCFuvME4J6hYTaXMyQxT4EdMyf3g6AgBXCkIdC2KQkMfHS+ByouJK6b5Ivlyh/bej0dIZxIXbpQ+vuuoKMyUKVMK/SZWBfEpwlruMBc/9thjnYvSddddV+R4165dnRB99tlnI/sIjkycD8pfGLn33ntdXhHouE+fPkWOo0SNHgiMHj3aKVo6dOhQ5ucz+YSbPC7ivoUHnRriIEnmxIYBbXQH5umnn3adHxaBEcWDBwBtBYtA+UH5yVfaA5W72LBwSfTiJZQ7YphGLyQVFohFffPNNzslIS5x0WDlz8COwUmw/WzSpIn16NHDwgZ1DY8b4t0ir2MNXBkAR8eOevnll1PWr8GdDFe8YD+ARQhRPrCQoygKY5zg4iXkFfmHN5UMSJJf/Ahr2WC5o91AljPOEUVhgcbgAhz0EQm7gucUbWgYwzWcdtpp9ssvvzg9A+UpGsYyxNrz44f6dfXII49MauGYysaiRYucbGbhMeIpxwqfFz2WJn+ZyCqpzAlNjMIrrrjCCU3inOGbTceZWSMtkhAbGi60+zvuuKNz2aNy0hEkZgCxvERBR4+V0vxVelFoYcWEsoEYC8CqgDRmrBrIPkzLUeDQQQwjKEvoRDDIAP7PatqYQ5NHwEpWCApMqZkx+c9//mOnnHKK64iHsUNBfWMV3xo1arjy5YOLk+/KRCxRBm/E2GnVqpU9/vjjdvnllxeKVxEWGLwOGDDA5RurfAVX+rrqqqsigzY6sQhaOmbIA9xbUeJHx3gqLXfeeacTyKSD70A7gGUjZVnEXjiLMo2MZqEeBt2sRk38uLDHifMhxhkuOdRzoINIWUaR6itocBfdd999XVljH/0eBnPnnnuuhRFiPk2aNCkSWB9XWtpSFKpMCuAiRx0lr5iZpx1g5eORI0eG0lKBVXmxWkexTGxXNsBCmn40YC134403uiD81FOsYJ566ik32A3joO2aa65xq40jd4KL4NCP8dt78pVJY/o5yBjqJcpoylkqYKB43333uf4T1p4ounBFQ+FLn0AUhTjF9MvpBxDfkf7o/PnzXf0Xf3mzEJLFD/+BPKYtYByNkoKyTP+Tcs5CWshqxkWDBg1yiq8wQl+PySfkDqFT/H47fXIs4L7//nvnYku8OOLuEaaAsdG4ceMsjBD2h/AWhPwI5gHy15/gpG/IBB4WdP6kDDKdOhxGjjjiCGe4dc4559jDDz8c2U/fj83P17p167rxNeWRsTTXBWM/JkOGFx3QohKDYtBfIpqODkHSo4Njir9gpg2BSWPHTCUzlrLs+Ati9MRSNNO4+QoJf7YECw+0+SgRiUsTxlkjYNDBUu3R0Hn2g6syU4T1L4KAztv+++8fSisFX1FIxywWxG+joxZUIjBYYdBGXQ2rFQGxHOnwxyKoaGVAgFIRiysUBHRIGjVqlNK0cG9kDkowYm8ya8rgUMQGi386irgxMshG+Z2MC19YQBbTWY6GGDXBCTzKG+WO8sdEHy6RDFDCCHU8VoB4OsvdunVz/6fNZPKONhSXJ6yQO3bsaGHknXfecVs0lB8sDYNgPYfyC+Ug7SeTe2EEhVy09QZQhnzlKvzwww9u8oOxCJPw5Fmq6yXPQFmJxRKDQvoCInEfi5WomezHVRYFjhbO+gv6lLGUMSzUE4zviNIG2Y27O8qcMC88OGLECCd7o2FSwJ9IwUAC5RiyGkMAyh1KnTDCGId6GMtbipihQZ0EEyworVkvgbF0MO5rmBg0aJDTLURD38X3okK9hyz/6quv3MTR3nvvXSSMSDKESlEohBBCCCGEEEIIIYQIeYxCIYQQQgghhBBCCCFEfKQoFEIIIYQQQgghhBBCSFEohBBCCCGEEEIIIYSQolAIIYQQQgghhBBCCCFFoRBCCCGEEEIIIYQQQopCIYQQQgghhBBCCCGEQ4uZCCGEEEIIIYQQQgghpCgUIix89NFHduGFF9qYMWPSnRQhhBCVnAcffNAuv/xy+/rrr9OdFCGEEJWcv//97zZ48GCbP39+upMiRKVAFoVChIQaNWrY+vXrrW/fvjZlypR0J0cIIUQlpkmTJvbdd9/Zcccdl+6kCCGEqMR4nmetW7e2Z555xgYOHJju5AhRKcjwqFlCiFCwefNmq1evnj388MPWr1+/dCdHCCFEJWbChAl20EEH2ezZs61du3bpTo4QQohKzM0332xPPfWUzZo1K91JEWKbRxaFQoSI7OxsN+M2efLkdCdFCCFEJadDhw7ur2SOEEKIrSFz5syZY6tXr1ZmC1FGpCgUIkSMHTvWZsyYoUGbEEKIcmf48OHurxSFQgghypPc3Fy78847nRvyTz/9pMwWooxIUShESFi+fLldeeWVtssuu2jQJoQQolz57LPP7IknnrCuXbtK5gghhChXRowYYatWrbLatWtL5giRAqQoFCIkENyXAduoUaNs8eLFtnDhwnQnSQghRCVk48aNdsEFF9iQIUPsxBNPtB9//DHdSRJCCFFJmTp1qt16661ucgqDCMkcIcqOFIVChID33nvPxo0b5wTobrvt5vbJFUwIIUR5cNNNN1m1atVs6NChtuuuu7qQFxs2bFBmCyGESCm4GjMxde6559ohhxziZI7GOEKUHSkKhajkrF271i666CIXK6p9+/bWtGlTa968uYSoEEKIlDNp0iS7++673cqTVatWdYO2vLw8++WXX5TbQgghUsr9999v8+bNs5EjR7rfyJyff/7ZKRCFEKVHikIhKjnXXXedtWnTxq644orIPqwKNdsmhBAi1cHkzz//fLv66qttjz32cPs6depkNWvWlMwRQgiRUljhGMv1xx57zOrUqRMZ46xZs8ZmzZql3BaiDEhRKEQlZuLEic6q48knn7TMzL+qu8zyhRBCpBpi4G7atMluuOGGyD5kT7du3aQoFEIIkVIuvvhiO+2006x3796Rfcgb5I4MIoQoGxme7HKFEEIIIYQQQgghhAg9sigUQgghhBBCCCGEEEJIUSiEEEIIIYQQQgghhJCiUAghhBBCCCGEEEIIIUWhEEIIIYQQQgghhBBCikIhhBBCCCGEEEIIIYRDi5kIIYQQQgghhBBCCCGkKBRCCCGEEEIIIYQQQkhRKIQQQgghhBBCCCGEkKJQCCGEEEIIIYQQQgghRaEQQgghhBBCCCGEEMKhxUyEEEIIIYQQQgghhBBSFAohhBBCCCGEEEIIIaQoFEIIIYQQQgghhBBCSFEohBBCCCGEEEIIIYSQolAIIYQQQgghhBBCCOHQYiZCCCGEEEIIIYQQQggpCoUQQgghhBBCCCGEEFIUCiGEEEIIIYQQQgghpCgUQgghhBBCCCGEEEJIUSiEEEIIIYQQQgghhHBoMRMhhBBCCCGEEEIIIYQUhUIIIYQQQgghhBBCCCkKhRBCCCGEEEIIIYQQUhQKIYQQQgghhBBCCCGkKBRCCCGEEEIIIYQQQji0mIkQQgghhBBCCCGEEEKKQiFEbJ599llbtmxZzGNPP/20rVy5skJkXUVKS0Vg4sSJ9s0336Q7GSJJpk+fbm+99VbMY1OnTrV33323QuRleaYlUR6kmry8PHv44YctNzc37jlr1qyxsWPH2uOPP75V0lRZ2bx5s8trz/NClZYPP/zQHn30UZs7d66FjXnz5tkrr7xSqmufeOIJV/fSRbqfXxF49dVXS1Ruf/31V3vqqafss88+K9d0iYrNt99+WyHLwA8//GCffPLJNpNeISoasigUYhtQzKXjPkOGDHGd/lhcc801tnDhQqsIVIS0jB49OiV5ngpeeukle+2119KdjApLqpRSqbrPV199Zffee2/MY3RkH3roIasIlGdaEuVBqsnJybFLL73UNm7cGPM4iqSDDz7YDX5//PHHrZKmysr69etdXqOcDUtabrvtNrv88svtu+++s1WrVlnY+OWXX2z48OGlunbAgAFplaPpfn5FYMSIETZ58uS4x19//XWbOXNmpN3u2bOnkw1//vnnVksjbTRK/+g2PNY+UbR+kk9//PFHof3IuyVLlpQ6u95880174YUXKpxy8J133rFnnnmmyP7SpDee0lGIyowUhUJUIAG+YcOGCnMfkTzXXnttXKWqqFisWLHCfv/99wpzH1GxYMCLEvi///2v3XfffelOjtjGeOONN+zuu++2Rx55xLp165bu5AiRUmbMmBFRgL/99tt29tlnO0vM008/favlNMp+lP5r164tosipCJMSFZmPPvrI5d11111XaP/AgQNtzpw5VhlYtGhRzP54vP1lva8QlZmsdCdAiMoI7rDHHHOM/fTTT7Z48WI75JBDrEmTJoWOH3vssU6ph3A+66yzbKeddrIaNWpEjh933HHuemb+mLVt3bp1oWewnxndBg0auPtnZGS4/dH3SZSOl19+2ZYuXWrVq1e33XbbzW3Jkp+fbx9//HHS75foWWV5X3+GecKECXGvTUSidK1bt87ef/9956aIlVHjxo2LXI87JopZ7vPll1+65++4444lzoPi3pEOCvevU6eOO1atWrXIMaxXpk2bZnvvvbeFCdxhyVsG5Fg1NG/e3OV/9PFdd93VHe/UqZPL2w4dOhQ5/umnn1q9evXs8MMPL5TvlHPcucn/Aw88MFK2Yt0nXjq4FsUT9+XYQQcdZPXr10/6PefPn5/0+zVs2DDus8ryvj5Y78a7tjiKu7cPViHM3BNSYP/997c2bdpEjtFGMCAk7zkWvPfnn3/u3Ob23HNP69KlS+TY6tWr7X//+5/VqlUrYR3BogKXUd4JRc/2229vRxxxRNz0xMp/nsVzatas6eol6SA95NsHH3xgLVu2tEMPPdTCBPnHt8Gq77DDDnNtmO8O/OSTT1q/fv3ccdrb448/3ikesPysXbu2+1477LBDofPPPfdc196jrKcMUuaDoOgl7/l+++yzT6FjmzZtcq7B8a6lHeVa6g5tvl++abe5jrab70faonnuueds9uzZ7jvPmjXL+vfv7yx1ot8PeUJ5QnaSvvbt27vruRYrVsoY78ez+vTp4/ICyxiuO+qoo1zZisdvv/3mQk9Qt6j7pJ9yPW7cOHccOU0b4svrkj7TP3+//fZz7QBtC/IoMzO+3QFyi0kV2sdddtklsp/yQF5lZWW5tBZHrHcr7hlleX6i51V26IdgOdijRw9r27ZtZH/Hjh1d28+3Z6MfgoUaZYQy3qtXL2vatGmkrabs+e0dbs20hZR7jp155pmWnZ3tvg2uoDyHcuVDH4q+Fe1p9+7dI2069/GPc4xncy39qSpVqkSuR07Q/yLNfjuAIvGxxx6zc845x8kiLEhJc6y+Xbrw8vJs/bffWe6SJZbVpInV3GtPywi8V1mhDmAZits4fdVokGv07SnvyDrawWCb8/XXX7u6sfPOO9vuu+9e6Frk4RdffOHkXLCvEgvac+QmCji++3bbbRc5RnuLUpPvgnzFS4b2FLiGdmqvvfZyv5HLHKedhWbNmrnj0cTaTztNWac/QRnzoTwit3h/3odjweuLyyMhKg2eEJWAvLx8b+majVtt43mJaNSokbfnnnt6ffr08Q4//HCvWbNm3tSpUwsd33vvvb0jjzzSu+aaa9y+Vq1aeZMmTYoc33fffb2jjz7aO+aYY7x69ep5M2fOjFz/9NNPu30nnHCCd9hhh3nnnntu5Fj0fRKl49Zbb/Uuvvhi75xzznHH+B3rPql4v0TPKsv7FndtccRL14oVK7x27dq5551xxhneTjvtVOgdfR566CGvRo0a3imnnOLuM2HChFLlQaJ3fO6559z9Tj/9dO/AAw/0dt99d2/NmjXu2O233+6O/e1vf/O6dOnidevWzRs6dKgXBh577DGvY8eO7r15f8os+Rs83qlTJ2/nnXf2+vXr573//vveM8884x1xxBGFju+6667eWWed5W233XbeBRdcELl+7dq13gEHHOB17tzZ3X/HHXf0vv76a3cs+j6J0vHLL7+432x829atW3tz5swpcp9UvF+iZ5XlfYu7tjiSzculS5e6Mty9e3dXp+rXr++98cYb7tiDDz7oNW3a1Dv77LO9nj17ehdddJHbv379eu/ggw/2dtllF+/MM8/0mjdv7j366KPu2OLFi126999/f1e3qJN0ffz6E4R8Ou2001x9Jv+o24nSEyv/uY5322OPPdx7Vq9e3bv++utd+0G+tWjRwrvtttu8MEAbSl7vs88+3kknneT+8v3J0+DxHj16eCeffLI3YsQIt3/AgAEuH/v27es1aNDAtX/B82kDTz31VFcG2rRpU+hb3nLLLV7Dhg3dd0Qu8DvZa++44w5Xvnjubrvt5h111FFefn6+N336dHfP4447zr0H33bZsmVF3vef//ynKx/HH3+8Sz/nRL/funXrXLooq6SR8yn/8Oqrr7r62rVrV1eO+T9lhvNp+3ku6Y7Hiy++6NLJtdR9yqtfrv02ATnJO9JOlOaZnE++cT7le/vtt3fv5vP222+7vgHk5ua6POObc0/uTR4D+U5bwv1JJ9dkZ2d7s2bNKtG7JXpGWZ4f73mVHeooeeG3l3Xr1vU+/vjjyPGDDjrIGzt2rKuTtIvkH+Vq8uTJXocOHbwvvvgicu5dd93l8i94b9pR6iDX0G6PHDnS1XHqJM8M9l3oN3Ee9+BbPPnkk24/7Sf1ijbXfzawb8mSJe7/gwYNcnKAMtq2bVuvf//+bv+GDRvcecgiyu0hhxzi2mTah4rAqnff9aYddLD3a+cukY3f7E8F9913n9erVy9vyJAhheotfc9vvvnG/f+zzz5z+Yp8pe2i/qxatcod4/uQn+Q93/Lmm292+2+88UZXHmg3qWv0b4cNGxY3HchlzqWd4RvRJr322mvu2LRp09y3Y2zBGGOvvfZy6fO5/PLL3fN8pkyZ4vrAPvSJzz///IT/53rktt+34npfVgTfh+28885zeRO8PlEeCVGZkKJQVApQ3rUb/OZW23heIhA6AwcOjPy+7LLLXKc7eDxaiEYr+O68887IMTqpw4cPL3jXpUu9OnXqeB999FHk+Jdffhn3PonSEWTevHlu0LJ69eoi90nF+yV6VlneN9G1JSWYLgb9KBWCHRsGjLGgUxSdVyXJg0TvuHz5cneer1QBFJcMOhcuXOiUGj/99JPbv3LlSq9JkyahUhRWq1YtogibP3++V7t27ci34DgDHb6dT7SCr3HjxpFBwowZM7wqVap4mzdvdr/5fgxq/N98K3+AHX2fROmI5uqrr44oj4tTFJb0/RI9qyzvW9y1xZFsXjKA4f8oaGD06NFugJ+Xl+cGOK+88krknhMnTowMHHv37u3OAV+xgzJg8ODBTlng8+9//zuuohCoS9Rnn0TpiZX/DB4Y8Ppp4b05xx/AMuhmoBUGfOXcAw884H6Th+Sl3z75x5999tm49+AbM2ETPH/8+PGR4ww2X3rpJfd/FAY1a9Ys1E777Whx1/7666+unZ07d25EyYRiY9y4cU5hjPLQh/vHq3MMGD/99NO474esQq7k5OS432+99ZZTlKBIRwlH+v/8889I2rn+9ddfd783btzo0khaY4EM9hXkft7FAvnIQB9K+kzOz8zMLCJzkJfRisJHHnnEKRP8Or9gwQJXL/k7atQop6whn/16xXPjKQrjvVuiZ5Tl+cnmZWWDMh/dXvrfM6go9BX6wb5GMopClEg+TLzSfwmW52DfLsj333/vlEdA3QkqBX38fZRN7uvLTfpXfPcPP/wwoih84YUXItehrOL7pxuUgb926VpISeg29nXpmhJloa8oZBID5Rv5Gq0ojIYJDb6l374F+6J+vUCxtsMOO3ibNm2KyLmWLVvGTcell15aaDIcxRsTEECZ4XiwD1MeikLaLdovoMwwqee3gxxHTjOxE+u+ifJIiMqEXI+FKCdOPfXUyP+J3+KbxfvgEpwI3KJ8cA9YsGCB+//333/vXDswdfeJdq9KNh24YWA+j7sAbgC4geBugql/qt+vuGeV5X3jXZsMidKFiwzB6Y888kjnYhF0r06GZPOA58R7R94fty7cvXCloT+MqxQuUbiQ4F6HCwjgEoTb2Nbg8H/HDur82Dl72XaNa9nspevswtHfxjzn/asL3Lw+mbbEbn3z17jHk4F88l2jWrRo4VxacSXx3bpxXUz03XAp8V1zcT/BdQl3KVxncMXDRalq1aruOC6TsVx1kkmH7zq+fPly54KYbDyg0rxfomeV5X0TXVscyeYl6Sbule/md8YZZzhXU9zye/fubXfeeadzM8atyXdTw0UJtyDcUrdMgLq04R7F/c4///xCbdXVV1+dVN4Xl554+Y8rm++KidssbYnv2sbvkrRPpWLzerOl06zcabyDWXbNpGUFeXjaaafZmDFjEraTuBvyTXG5xwWW8kw5Lq69xyWN+oGrYUllBeUTd2NCSfhliLJOO9u3b1+74447XMxKXKe7du2adBZFvx/l6eSTT3ZtOCBbeBZl1Q8d4tcn3+Wa8gS4edIWkOZYaeDdHnjgAecWjats0I0T13dcQ3G1ZMMl06ekz8QFNFrm0CaRN0H4htwXF1E/TzkfWUY+nHTSSRFXUcpFdB8imXdL9IyyPD9RXpYXxP4j7l6rVq3cb8o/ro64x1MP+Ab0E9hHiAPO98Mg8H1pWxs1auT6GcRapV0iDA0rOdNm8u7JcMoppxRqL//xj39E+itlJVgXcP2l/QyW5WB99cME+O0A8oyyW9x7UBb33XffiNwkT5AduJD637EsfcbycjdeNPx23PxiHPRoPN3xOr16pcQNmTJ11VVX2b/+9S+3sEc0fvgGPx6l316QjzfeeKOLcxiUwUA98ctIcXlK3aS9ePzxxyN1k/NxQ6Zu4h4eLIOEo0g1lAG/LNGeETpk0qRJkbYQl/lE7sTx8kiIyoQUhUKUE8FOFf+noxWE2CrJXs8Ai46e33kqSYctXjqIz0NcIjqXDBTofHKMeB9luW+s90vmWWV533jXFkeidDG4p9NALBcGiHReiEG1xx57JHXvkuRBondk0Mw7ETMleF/is8TqvKeiM78tEev9g2WxJPWsLHUtUTpYifqSSy6JxLlE8VGaehZ931jvV9yzyvK+ia4tjmTzMrpMM5BnYz+LBtF5J3Yaq3MSc4wBBHWEAUawjqAEIG+i71fS+pEoPfHKV3R7VNr2qdSgJHw0eWV7qbnoE7OWu6VUVqAUQHnAoI1JEP9ayrB/XnnICsoQ6QqWIWJmUcbYUDIgC2644QYXU42YWMHYmYkIvl+8NtvPk+j0JUpzNCjEyTtWY2dwjfKclT0ZlKMIY2CPoon4X4lkb3HPLK5N8iFPUewE8xRFA4qbWPUqUZzDeO+W6BlleX685/kK3vIAZTXKbto2QImC4pbJCWJqMmnJJEfnzp1deaQdvOuuu9y5//nPf5yCg8kYlI2ce8UVV7iyy/uzj5jJyRBdX/n2xKosrm5Fx3CMtbBIsC4kqq9MQDEx1a5dOzcpxXkokyi3xSkKi6tj0e+4VdrkYnAxCRcujH+C57njnFdrn9TEoqYs0cZSloLcc889rvzQhyAWM22ynz/33nuvi69KzN+hQ4e62OK33nprzDwtMPKMDXWTvgkKYB9/Qq84mZ1MOSvvvmOiPBKiMiFFoRDlBMKUwM2AFZk/A19WUGARgJfV53zLCYRUPKueeOmg84jyiuDtQAfs2WefTSjcS/t+ZXlWSd83VjoR4ARcL0m6eAaKFjrebHSKCNrNYgfRYHUR7PCUNA8SvSPH6LzcdNNNbrACXMOiDXTesUTxLRJ5TwKMB609y4virP6wKizunIN2aGIHlcB6MBbM6GJtRKeO4NModAcMGGCpgPLNyo58fz/fUUhheVSSdDCIGzVqVKQjTMc61ix+Kt6vLM8qyftGQ9p4NoPaWAu1JHtv2hGsSFj8B/wFFhgwspACCnK2IUOGOGsf6iX3pi5gAeSDFSUWJdyPNsBflZO2qiQkSk+FBUs/lHhb4zlJQP4zoExGVqD8QLlBWfGDxrOwTDKygnJAecfCw1cmJCsruJYBJysW+wHraXdRNPll6eKLL3YbZQmrSBTXJcUvT1jzAIs6IAtQ/mAVVhaoH75ik7Tx3likP/PMM66+DB482J2HHOO5pYVvEi1zfGVBdJ7+/PPP7nk+1Pm6detG6uXll1/u9qMgSzTgj/duiZ5RlufHe155LhiGIjc4EXnBBRdEyiLKCNo6f6EQLLmCFtlYOfvW2n676Fs6016WRIkR3V6y2E4yCzVgpUZ9C8quRMpfvg/lkjqG8jZYX1lEDiUWSm7/e/jtAEpdFLbx+lx82+uvv94pR8kLzqPd9tugiggLl6TyvGSgHgwaNMjlVRAm32gzWMgLmHhkcsH/DlgOsmFViPUrVoklhW9PuQyuvkwfmD6uXzdZSCeWzI5VzkoDdZ56QRlFMc3iLkziJ0OiPBKiMiFFoagUNKiZbd9df9hWfV5x3H///U5w0Pl88MEH7Y033kjJs7FiGDhwoJvJuuiii5xbCconLBxKkg4UUgxMrrnmGufSiCVSok5dWd6vLM8q6ftGw6qTuN/EUhQmShcKOFbTY5VKrsd9afjw4TGfwWAC1zRcKehAxXKpTPSsRO/IMa6h0+S7RrGqLdYCKC9wE8JKghUEWcERl6QwwYCBzhrfCYsfBtyxvnVpYBBDZxZXQVyZcEukYx1LcZYoHbiIo4Dg29DRZvXrZK2RSvp+ZXlWSd43GpQdDBxwQ4ylKEz23uxjMM5gEIsuLBhQkjMIpo4wYOU+uOFzLSuSMijGZY06wAAEhTsDw8mTJzurCZ5HXWOQjVVQSUiUngoL7sBJWPptLf75z3+6b4G7NuUxaOEVDYNElGjDhg1zFh5jx44ttJJpInA7xuIUy23cxVHw8d2DCuRE17LRzmJ9h5KB+oacw4KQCSLcJlEeosSg/S0Nf//7393kD2037/rQQw+5MoYiqKzccsstrh7yDrjFoVTBMpM2AWUZbQkyiDwti2UcdfDoo492+YTMQZl14oknFjmP70i9xLr3gAMOcN+DvMOCifwjH8477zwnG1G8JkpTvHfDbTXeM8ry/HjPK09Qbget5YIKbtqb4OrDKHnYfILtKPUleK6/yniy0O/w20tkiW+1WBxYLFKWCaeC0oU2OBhOJRosBlHe+X0b3KWxMsTtFIUNbv8ooZgke/HFFyNtLhZlHKfdp232Vz32oR6zH/d5+kdYhfIuJ5xwQrETuumC1Y1TeV6yXHnlle77BvuNtBc333yzTZkyxSna6duTp0AYBvKeDSUuspiJ8pJCX5p+DGWFOszEBYpClIIoD2lfmPChLEfLbNphyhVKReqlv6J7SaGfTegH+u14C1E+/NALxZEoj4SoTCSvFRCiApOZmWGNalfbahvPK47nn3/ezejS4cJMP9hhYvY3emDAwMaPYxV9HGEcFEIIWWa0sOJhRo9nxbpPonTQCWXWjs4xlm4MJOjk+Z3T6PsEIX1YfCT7fsU9qyzvW9y1WAEwGIhFonTRiUGZR0eFAQPWUr41VDS4CBEzjs4Os+OlyYNE70hMGOKvYTXFxuDVt3BCEcqgB6UtnT4UGeVp9VDRQClA3uGaxaAAiyQfOqDRMRvpCNIJjXf8wgsvdFYIgEKXTiDKX/KXQYs/gxy8T3HpoEPJN0JRgnLglVdecYPXWPcJQvq4tiTvl+hZZXnf4q5lVp+BGcq0WCSblwzaUQLiboayhg48CkJgQMBglHejo85AEmUSg0DqHvUeSwMUAMSpom0inhpWmFghMKCh3cIqLJ6ij/OCscoSpSdWnmAV5Fta+9cHXf5QsvD8MEB+865MbNDu8Z34Lr7VtH88OGlE2zV+/HiX17S9KLVQQFPOYp1PmaMs+KBQQMlIfeE70B7Ge1b0tViIcC0DVCaHeDZlirYcVzMse5kYQ9kUb1CIRS1lPd4zGdwSIw95QRoJa+Fb42FBxWA1Ov+C12MtjnI8FsgP5DZ1gHpInUQGUV6xGkIRw37ylwF/aZ9JuUf5Sj4R5wuFkK9kQ2HDZICvoEL+UrdJE4o24tKhDEPuUX+xzGWwj3IK6754Sq1475boGWV5frznVXaQFSjImfykDqKkCbaHKPZoCwEFX7CvwYQA7TpWmyhgRo8eHYl16d872hKbc3DhpI/FM5l0BtpwFHz0h/g+pAO55itSkQWUSeqSHyOOcku9BRQ3WHmRFqwj6Xv5lojR7T99V2JQp5Oae+1pWSh7o9xqI2RkuOOcVxboEwTlEUpYJiuYoPatVbHcpK+BnEVeo0RnMhpQ5GHNikcL+5goiNXv5jskknNMeDJ5RHqoY/S3aVeB+2B1zfdiDEKbHq1gpmygVCbNfGvaaB++pT8eifd/0kubzsQN/ZHLLrvMlUWf6PeJvj5RHglRmchgRZN0J0KIygbCDbN2BqlKR/pAqTZy5EjXgRWVDxS0uNUy8FU60otvtUEHWwhROaGtZUEh+jdCiNSx+r337M8BBSEJCi1qskV52Oqeu61uCJVReAjQr0g2rrMQInXIolAIUWlh9lhKQiHKH9y/pCQUQgghSg5KQJSBWVtiUfvwO6xKQiFEelGMQiHKgViuxWFOhxDlAS5wWI2mm4qSDiGEKE+iXZWFEKkDZWCdXr0KVkFessTFJMTdOCPJOK2VEdzN44UPEkKUL3I9FkIIIYQQQgghhBBCyPVYCCGEEEIIIYQQQgghRaEQQgghhBBCCCGEEEKKQiGEEEIIIYQQQgghhBSFQgghhBBCCCGEEEIIR2bBHyGEEEIIIYQQQgghRJiRolAIIYQQQgghhBBCCCFFoRBCCCGEEEIIIYQQQopCIYQQQgghhBBCCCGEFIVCCCGEEEIIIYQQQghy4P8BC8Zh7bRvJgkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1300x400 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "principal3 = np.array([[q.lam] + [float(q.profile[s]) for s in g3.strategies]\n",
+    "                       for q in branch3])\n",
+    "closed_lams = np.linspace(0, LAMBDA_MAX_3, 200)\n",
+    "closed_form = np.array([[pr[0] for pr in principal_at(lam)] for lam in closed_lams])\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(13, 4), sharex=True, sharey=True)\n",
+    "for k, ax in enumerate(axes):\n",
+    "    ax.scatter(on_locus3[:, 0], on_locus3[:, 1 + k], s=1, color=\"0.85\")\n",
+    "    for lams, profiles in paths3:\n",
+    "        ax.plot(lams, [pr[k][0] for pr in profiles], color=\"C1\", lw=1)\n",
+    "    ax.axvline(branch3[-1].lam, color=\"0.4\", ls=\":\", lw=1)\n",
+    "    ax.plot(closed_lams, closed_form[:, k], color=\"C0\", ls=\"--\", lw=1.2, zorder=6)\n",
+    "    ax.plot(principal3[:, 0], principal3[:, 1 + 2 * k], color=\"C0\", lw=3, zorder=7)\n",
+    "    ax.scatter([LAMBDA_MAX_3] * len(nash3), [eq[k][0] for eq in nash3],\n",
+    "               marker=\"o\", color=\"C3\", zorder=5, clip_on=False)\n",
+    "    ax.set_xlabel(r\"$\\lambda$\")\n",
+    "    ax.set_title(f\"Player {k + 1}\")\n",
+    "    ax.set_xlim(0, LAMBDA_MAX_3)\n",
+    "    ax.set_ylim(-0.02, 1.02)\n",
+    "axes[0].set_ylabel(\"P(first strategy)\")\n",
+    "axes[0].plot([], [], color=\"C0\", lw=3, label=\"principal branch, as traced\")\n",
+    "axes[0].plot([], [], color=\"C0\", ls=\"--\", lw=1.2, label=\"principal branch, closed form\")\n",
+    "axes[0].plot([], [], color=\"C1\", lw=1, label=\"branches from sampled seeds\")\n",
+    "axes[0].axvline(np.nan, color=\"0.4\", ls=\":\", lw=1, label=\"bifurcation\")\n",
+    "axes[0].scatter([], [], marker=\"o\", color=\"C3\", label=\"Nash equilibria\")\n",
+    "fig.legend(*axes[0].get_legend_handles_labels(), loc=\"lower center\", ncol=5,\n",
+    "           fontsize=\"small\", frameon=False)\n",
+    "plt.tight_layout(rect=(0, 0.07, 1, 1))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04d3db17",
    "metadata": {},
    "source": [
     "## Remarks\n",
     "\n",
-    "The upper side of the second branch converges to the payoff-dominant equilibrium (Stag, Stag), and the lower side to the mixed equilibrium — neither of which can be found by following the correspondence from the centroid.\n",
-    "The two sides stop just short of each other at the fold, which fixed-$\\lambda$ continuation cannot go around.\n",
+    "In both examples the sampling method locates branches of the correspondence which path-following from the centroid does not reach: in the stag hunt a second branch carrying the payoff-dominant and mixed equilibria, and in the three-player game branches carrying both totally mixed equilibria.\n",
+    "The three-player game also shows that the principal branch is not always traceable all the way to an equilibrium: Gambit's trace of it stops at a bifurcation, well short of any equilibrium, so the profile returned there is worth checking with `max_regret` rather than assuming it is an equilibrium.\n",
     "\n",
-    "Some natural directions from here:\n",
+    "Limitations of what is shown here, and natural directions from it:\n",
     "\n",
-    "- Gambit's internal path-follower could trace the whole branch (including around the fold) starting from any polished point; the C++ implementation accepts arbitrary starting points, although this is not currently exposed in the Python API.\n",
-    "- The sampling method needs only expected payoffs, which Gambit computes for any finite game, so the same code applies well beyond $2\\times 2$ examples; [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) discusses performance in larger games.\n",
+    "- Fixed-$\\lambda$ continuation cannot turn a fold, and stops once a probability saturates at a vertex, which is why several branches above end early. Gambit's own arclength tracer handles folds; its C++ implementation accepts arbitrary starting points, so it could in principle trace a whole branch from a polished point, although this is not currently exposed in the Python API.\n",
+    "- The random-walk sampler used here is only adequate for small games. [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) uses Hamiltonian Monte Carlo, and discusses performance in larger games.\n",
+    "- Nothing guarantees that sampling finds *every* branch. In the three-player game above the branches found lead to all nine equilibria, but that is an observation about this example, not a guarantee; drawing more samples, or seeding at more values of $\\lambda$, is the only remedy on offer.\n",
     "- [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) builds a Bayesian estimation procedure on top of this sampling approach, in which the penalty acts as an equilibrium constraint inside a posterior sampler; see also [BlaTur23](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) on maximum-likelihood estimation along the principal branch with `logit_estimate`."
    ]
   }

--- a/doc/tutorials/advanced_tutorials/quantal_response_branches.ipynb
+++ b/doc/tutorials/advanced_tutorials/quantal_response_branches.ipynb
@@ -1,0 +1,608 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "49aaba9e",
+   "metadata": {},
+   "source": [
+    "# Finding non-principal branches of the QRE correspondence\n",
+    "\n",
+    "Gambit computes logit quantal response equilibria (LQRE) ([McKPal95](https://gambitproject.readthedocs.io/en/latest/biblio.html#general-game-theory-articles-and-texts)) by path-following:\n",
+    "`logit_solve` and `logit_solve_branch` trace the branch of the LQRE correspondence which starts at the centroid at $\\lambda = 0$, called the *principal branch*.\n",
+    "In many games the correspondence also has other branches.\n",
+    "These are not connected to the principal branch, so they cannot be reached by any method which follows the correspondence from the centroid.\n",
+    "\n",
+    "[Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) proposes a simulation-based method which in principle can locate points near *any* branch:\n",
+    "sample strategy profiles from a probability density constructed to concentrate near the graph of the correspondence.\n",
+    "A sampled point close to a branch can then be polished to high accuracy using Newton's method, and the branch containing it can be traced out from there.\n",
+    "\n",
+    "This notebook illustrates the method on a small example, using Gambit for the game representation and the expected payoff calculations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6282bc79",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:05.854013Z",
+     "iopub.status.busy": "2026-07-22T11:38:05.853695Z",
+     "iopub.status.idle": "2026-07-22T11:38:07.284888Z",
+     "shell.execute_reply": "2026-07-22T11:38:07.283933Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import scipy.optimize\n",
+    "\n",
+    "import pygambit as gbt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2a3a15c",
+   "metadata": {},
+   "source": [
+    "## A game whose correspondence has a second branch\n",
+    "\n",
+    "We use a symmetric $2\\times 2$ stag hunt.\n",
+    "Hunting stag pays 3 if the other player also hunts stag, and 0 otherwise; hunting hare pays 2 regardless of what the other player does.\n",
+    "The game has three Nash equilibria: (Stag, Stag), (Hare, Hare), and a symmetric mixed equilibrium in which each player hunts stag with probability $\\frac{2}{3}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "999fb419",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:07.287766Z",
+     "iopub.status.busy": "2026-07-22T11:38:07.287224Z",
+     "iopub.status.idle": "2026-07-22T11:38:07.296176Z",
+     "shell.execute_reply": "2026-07-22T11:38:07.294948Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[[Rational(1, 1), Rational(0, 1)], [Rational(1, 1), Rational(0, 1)]],\n",
+       " [[Rational(2, 3), Rational(1, 3)], [Rational(2, 3), Rational(1, 3)]],\n",
+       " [[Rational(0, 1), Rational(1, 1)], [Rational(0, 1), Rational(1, 1)]]]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g = gbt.Game.from_arrays(\n",
+    "    [[3, 0], [2, 2]],\n",
+    "    [[3, 2], [0, 2]],\n",
+    "    title=\"Stag hunt\",\n",
+    ")\n",
+    "for player in g.players:\n",
+    "    stag, hare = player.strategies\n",
+    "    stag.label = \"Stag\"\n",
+    "    hare.label = \"Hare\"\n",
+    "gbt.nash.enummixed_solve(g).equilibria"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2111ab8",
+   "metadata": {},
+   "source": [
+    "The principal branch starts from uniform play at $\\lambda = 0$.\n",
+    "Following it with `logit_solve_branch`, we see that as $\\lambda$ grows it converges to (Hare, Hare) — the risk-dominant equilibrium.\n",
+    "The other two equilibria are invisible to this computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b7cd5985",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:07.297983Z",
+     "iopub.status.busy": "2026-07-22T11:38:07.297724Z",
+     "iopub.status.idle": "2026-07-22T11:38:07.482405Z",
+     "shell.execute_reply": "2026-07-22T11:38:07.481058Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAGxCAYAAACKvAkXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOz5JREFUeJzt3Qd0lFX6x/EnnQRIoUvoEEro0jECIgLS7BQFVhSwr4i7IKuLZQXU/9pYd9VVURexIIINK1UE6b1DaKGEFkICSUhI5n+eGyYmSCBlkndm3u/nnDkz8067vATml3ufe6+Pw+FwCAAAgI34Wt0AAACA0kYAAgAAtkMAAgAAtkMAAgAAtkMAAgAAtkMAAgAAtkMAAgAAtkMAAgAAtuMvNpSVlSWHDx+W8uXLi4+Pj9XNAQAABaBrNycnJ0v16tXF17d4fTi2DEAafmrWrGl1MwAAQBHExcVJjRo1pDhsGYC058d5AkNDQ61uDgAAKICkpCTTgeH8HvfoALRt2zZ5++23Zfv27fLSSy9JixYtrviadevWyVtvvSVHjx6V5s2by9ixYyUiIqLAn+kc9tLwQwACAMCzuKJ8xdIi6EmTJsmtt94qZcuWlR9//FESEhKu+Jrly5dLp06dJCAgQO644w5ZtGiRXHPNNZKSklIqbQYAAJ7Px8rd4OPj46VatWpy8OBB06W1cOFC6dat22Vf0717dwkLC5M5c+aY+6dPn5bIyEiZMmWKPPLIIwXuQtP30NfSAwQAgGdw5fe3pT1AGn4KIzU1VX755Re5+eabc47piejRo4f88MMPJdBCAADgjSyvASoMLVrOzMz8wwwurQTX3qP8nDt3zlxyJ0gAwO9Lg6Snp3M6YDktb/Hz8yuVz/KoAOT8BxocHJzneEhIyGX/8erw2LPPPlvi7QMAT6P/d+7du9eEIMAdhIeHmxGikl6nz9/TToq6uFj65MmTl50FNmHCBDNT7OJpdABgZ1oCeuTIEfMbt/6fWNyF5YDi/jzqhKZjx46Z+1dddZWUJI8KQDrUValSJTMNvm/fvjnH9X6bNm3yfV1QUJC5AAB+d/78efOFo6vqak86YDXnCI+GoCpVqpTocJjbx/3XXntN7r///pz7w4cPl/fee09OnDhh7uv0eQ1Af/rTnyxsJQB4Hq2pVIGBgVY3BcjhDOMZGRnitT1AP//8s7z88ss5Bcrjxo2TChUqyNChQ81Fbd682az94/Tcc8/Jpk2bJCoqylz09uTJkyUmJsayPwcAeDL2RIQdfx4tDUDR0dEyZswYc3v8+PE5xxs0aJBz+7HHHpPExMSc+7po4k8//SRbt241K0Hre1StWrWUWw4A8EQff/yxnDp1Sh566CG3fs+CvO/7779vitfvvfdecVfvu3EbLQ1AuoChXi6nadOmlzyuwUcvAAAU1LJly8ziu64MKyXxngV538WLF5s6LncMF57QRo8qggYAoDjuuusuOXv2rNu/J0oeAQgA4FGcwyo6CqC7ACQnJ5u9IXWfyIufo6MIs2fPNgvs6f6TuuaRDivpDgK5n9eyZUuZO3eunDlzRvr16yddu3bN85m6/Mr06dNl165d0rBhQ7nnnnukXLly5rH83vNy7dPPcm7ppDsaXH311TJ48OAizXr67bffCn0e5hbg811xbpxWr1592fewgtvPAgMA4OJhlSeffFJGjBhhZgylpaVJly5d5KuvvsrznKeeesrMItbp1K1atcoZVtIJOBc/74EHHjA1pjoz7oYbbpDvvvsu5znbtm0zYUYDQ926dU3g0ec4Xeo9r9Q+Lf/o2LGjuWgdq07muemmmwr9Fz1v3rwinYfIAny+K86Nmj9//mXfwyr0AAEAchaiS83Inhpf2oID/Ao1+0cnx6xdu9asYeRcKPcvf/mLDBgwIOd9dIaxfolrD8fl6PMXLVpkvqCVLrOiy6306dPH3Ncv79atW5svbed7a21OcdqnQcQZRtTIkSPNWncrV66U9u3bl/h5aFXAz3fFubnSe1iFAAQAMDT8RE/80ZKzsfW5XhISWPCvpM6dO+d86atBgwaZbY8OHTpkvsidz7lS+FE6ZOT8claNGjWSr7/+2tzW2p4lS5bIzJkz8wQ052cUp33aM6LBQBf9054RHZ7SHpXCBKDinIf5Bfh8V5yby72HlRgCAwB4nIoVK+a5r7sEKOc2Crm3T7qSi/eX1DoY5yKR2sOidTCFXW7lSu3Tde+0eFr3YmvRooUZiipTpoyp43Hl5+R3HsYV8PNdcW4u9x5WogcIAJAzDKU9MVZ9dmHExcXlub9//35z7ep9HitXrmy2UoqNjS3UgruXa58ONb755pvy0Ucf5dTdaCB49NFHC92+opwHV31+5SKeG3dBDxAAwNBhDB2GsuJS2NV/tVbFuUuAfqG//vrr5ktYv5RdSbcJue222+SVV17JsyivFh8Xt325e1umTp1q9mUrrOKch+Rifn5Rz427oAcIAOBxdOaR1rvoRtgHDhwws49K6otXw0H//v2lSZMmcu2115peF+1hcU57L2z7NOzp7gejR482tTDHjx83PTdFCW9FOQ+u/PypRTg37oIABADwODqDSXs7VqxYYXoy9As3dz2MrkWj9SlXWrTwUs/T2Un6he6k77t06VKz3s6ePXukcePG0rZt23zfsyDt0+nluh6O7nepx7t162bWycm9w8GVFljUtt99993SvHnzQp+Hpwrw+a44NwV5D6v4OLTPzGaSkpJMRfzp06clNDTU6uYAgCV03RjtMdD1W7QA1lPol75ur6A1LO7I3dvnyT+XSS78/qYGCAAA2A5DYAAAj5LfsI67cPf2IRsBCADgUXS7B3fm7u1DNobAAACA7RCAAACA7RCAAMDmbDgZGG6stOqnqAECAJvSzS91UTxdCE8XwSvsasyAq4O47k2mP4++vr5mpemSRAACAJvSTSl15+6DBw/Kvn37rG4OYISEhEitWrVMCCpJBCAAsLFy5cpJVFSUZGRkWN0UQDSU+/sXfm+4oiAAAYDN6ZeOXgA7oQgaAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYDgEIAADYjr/VDYiNjZVp06bJ0aNHpXnz5jJ69GgJDg6+7GsWLVok3333nZw6dUpq1aolw4cPl9q1a5damwEAgGeztAdo48aN0rp1a9mzZ48JPxqEunbtKunp6fm+5qWXXpI+ffpIQECAtG/fXjZs2CDR0dGyfv36Um07AADwXD4Oh8Nh1YdrkMnMzJQff/zR3D927JjpyZk6daqMGjXqkq+JioqSW265xQQhpc1v1KiR3HzzzTnHriQpKUnCwsLk9OnTEhoa6sI/EQAAKCmu/P62rAdIe3nmzZsnAwcOzDlWpUoV6d69u3z77bf5vq5OnTpy8ODBnPtnzpyRxMREqVevXom3GQAAeAfLAtCBAwckIyPjD7U7el+HxPLz4YcfmtDTrl07uf3226VVq1byyCOP5NtjpM6dO2dSY+4LAACwL8sCUGpqqrkuV65cnuPly5fPeexSFi9eLL/99pvpKerZs6epIZoxY4bs378/39dMmTLFdJk5LzVr1nThnwQAAHgaywKQBhGlM7lyS0hIyHnsYmlpaWaW2IQJE+TFF180t2fNmmWGzp544ol8P0ufr+OFzktcXJyL/zQAAMCTWBaAtBcmPDxcNm/enOf4pk2bzIywSzlx4oQZ/mratGme43p/7969+X5WUFCQKZbKfQEAAPZlWQDy8fGRwYMHy3vvvSfJycnm2LJly2TlypVy55135jxPH9ceHBUZGWl6e2bPnp3zuL72p59+MkNhAAAAbr8O0OTJk03NT7NmzcyU+F69esljjz1manuctN7nm2++yQlNWgT9xRdfmOLnW2+9VRo2bGh6kiZNmmThnwQAAHgSS9cBUroO0NKlS3NWgm7cuHGex5cvX26Gvvr165en12fNmjVy8uRJM2usTZs2JhwVFOsAAQDgeVz5/W15ALICAQgAAM/jFQshAgAAWIUABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbIcABAAAbKdIAejdd991fUsAAADcOQA9+OCDkpmZ6frWAAAAuGsAatKkiaxbt871rQEAACgF/kV50ahRo2TIkCHy9NNPS3R0tAQGBuZ5vFmzZq5qHwAAgMv5OBwOR6Ff5ONz2ceL8JalKikpScLCwuT06dMSGhpqdXMAAEApf38XqQfoyJEjxfpQAAAAKxUpAFWrVs31LQEAAHD3dYASEhLkww8/NHVATqtXr2Z2GAAA8M4AtHHjRjMTbNKkSfLcc8/lHH/77bdl+vTprmwfAACAewSgsWPHyiOPPCI7d+7Mc/yhhx6SV1991VVtAwAAcJ8aoFWrVsns2bP/MCMsKipKtm/f7rrWAQAAuEsPkK+vr5w9e/YPx7VHKCIiwhXtAgAAcK8A1KdPH1P7k5WVldMDFBcXJw888ID069fP1W0EAACwPgC9/PLLsnjxYqlRo4YJQa1bt5YGDRrImTNn5IUXXnBtCwEAANxhJWh17tw5UwekU981BF199dUycOBACQoKcnUbXY6VoAEA8Dyu/P4uUgDS4NO/f38JCAgQT0QAAgDA3t/fRRoCGzp0qERGRprp8Js3by5WAwAAAEpbkQJQfHy8/OMf/5ClS5dK8+bNpUOHDmYRRE1mAAAAXhmAtNvpvvvukxUrVpgeoJiYGJk4caLZI2zYsGGyaNEi17cUAADA6r3AnJo2bSqPPvqojB492uwDNmfOHOnRo4eZGbZ+/XrXtBIAAMAdApDOAvv000+lZ8+eUrduXfn555/l3//+txkeO3DggBkWGzx4sCvbCgAA4BJFmgX28MMPy8cff2wWQdSC6FGjRkmzZs3yPCcjI8NMidcp8u6GWWAAAHgeV35/F2kvsK1bt8obb7wht912W77r/ugU+QULFhSrcQAAAG61EKInowcIAADPY/k6QAAAAJ7Mt6gF0LoOUIsWLSQ8PFzKlSuX5wIAAODOilQD9PTTT8s333wjf/3rX2XEiBHyySefyMqVK+XNN980q0MXxtGjR01BtV7rooqDBg0Sf/8rN+uXX34xNUYhISFmtlmtWrWK8kcBAAA2VKQeIJ3+PmPGDLn77rvNfQ0tr7zyikybNk2WLFlS4PfZtWuXCT0//PCDKZrWYNW7d2+znlB+dFaZLrZ4++23S2pqqrkMGDBAtm3bVpQ/CgAAsKEiFUH7+flJenq6udYhr4MHD5qhsDNnzkjlypVNKCmIW2+9VU6cOGFWjvb19TXrBzVo0EDee+89E3Iu5fXXX5cnn3xSNmzYIPXr1zfH9HNTUlKkSpUqBfpciqABAPA8lhdBay+Mhh+lIcQ53X3dunVSvnz5Ar2HrhP03XffyZ133mnCj9JhrG7dusmXX36Z7+v+85//yF133ZUTfpSGsIKGHwAAgCLVAJUtWzbntm6DoYshakH0pk2bzP2C0N4eLabOHWSU3tdNVvNLfjt37jQ9QLNmzZI1a9ZI9erVzXpEep0f/Ry95H4fAABgX0XqAdIhJ6d77rlHvv/+e7n55ptNXdDkyZML9B46ZKUu7jHSLi3nYxdzBpf/+7//k/fff9+8dt68edKoUSNZvnx5vp81ZcoU02XmvNSsWbNAbQQAAN6pSD1AF+vatau5FIYz+CQmJuY5furUqXyH0ZzHdbhr7ty5Ocf79u1reoXmz59/yddNmDAhz+w0DVKEIAAA7KvAAehyPSwX69ix4xWfo/U+Wruzfft2M/PLSe9HR0df8jXaexMZGSlt2rTJc1zvT58+Pd/P0u068tuyAwAA2E+BA1CnTp0K/KYFmVimhc9au/PBBx/I/fffL2XKlJGNGzea+p/Zs2fnPO+zzz6Tffv2yfjx4839IUOGyMKFC81UeS3E1oJsLcJu2bJlgdsHAADsrcDT4HPX/VxJQVeDjo+PN0NngYGB0rp1azMrTIezPvzww5znjBw50vQ+bd68OWf46oYbbjBT7bWnadWqVWY6nNYC1atXr0CfyzR4AAA8jyu/vy3fDFWDjBZRO1eCjomJyfO4BhsNSjrTzOn8+fPy888/y/79+81Q2vXXX1+oIS4CEAAAnsctApCGD12Tx7kCs9btPPjggx6xJQUBCAAAz2P5Qog6VNWwYUP58ccfpWrVquai21noMb0GAABwZ0XqAdJ1d3SriqeeeirP8eeff96sBeTu+3LRAwQAgOexfAhMV4I+dOiQ2f8rN13TR6epnz17VtwZAQgAAM9j+RBYkyZNcmZl5aZbYeS3hg8AAIBHrwQ9fPhwueOOO8wKy+3atTPr/qxevdpsOfG3v/0tTzhq1qyZK9sLAABQbEUaAvPx8Snwcy2eZX9JDIEBAOB5XPn9XaQeoCNHjhTrQwEAAKxUpABUrVo117cEAACglBSpCBoAAMCTEYAAAIDtEIAAAIDtFCkA6W7tuhcYAACAbYqgn376aROA6tSpI926dcu51K5d2/UtBAAAcIceoH379snevXtl4sSJkpWVZQKRhqG6devKiBEjXN1GAAAA6xdCzO3cuXOyYsUKef/992X69OmSmZnplosf5sZCiAAAeB7L9wL79ddfzc7v119/vURERJheH19fXxOC4uLiitUgAAAAt6wBuvbaa6VSpUry+OOPm4LoGjVquL5lAAAAJaRIPUBa86O7vj/zzDPSvXt3ue++++STTz5hiwwAAOD9NUBpaWny22+/yaJFi8xl2bJl0qBBA9m2bZu4M2qAAADwPJbXADkdP35cDh48aOp+Dhw4IOfPn5fk5ORiNQgAAKCkFSkAjRw50vT01KpVSyZMmGBmgv3tb3+TnTt3mkAEAADgdUXQOvQ1fvx4s/hhVFSU61sFAADgbgHoo48+cn1LAAAA3DkAOa1evdoUPGsdtc4Ka9u2retaBgAA4E4BSIufBw8eLAsWLJBy5cqZY2fOnDFT4j/99FOpXLmyq9sJAABgbRH0o48+KqmpqbJp0yYz60svejslJcU8BgAA4HXrAOkc/LVr10r9+vXzHI+NjZU2bdpIYmKiuDPWAQIAwPNYvg5QRkZGztBXbmXLlpX09PRiNQgAAKCkFSkAdenSRcaOHZtn0UNNZWPGjDGPeYoz585b3QQAAOApRdCvv/663HjjjVK9enVp0qSJOaazwbT4+fvvvxdP8dhn6+WjB7pJgF+xFsQGAAB22QtMV3/+/PPPZcuWLeLj42Omwd9xxx0SFBQknjKGWHPMTBnUuaG8dHsL82cAAAD2qAEqUg9Q//795ZtvvpGhQ4eKJ/P1Efl8zUFpUKWc3Nc1b0E3AADwXkUa+1m4cKGZ8u7pxvduZK5f+GG7LNx+zOrmAAAAdw5AN9xwg3zxxRfi6e7sUFuGtK8lOgj46KfrZN+Js1Y3CQAAlIIiDYFp8fOIESPkq6++MrU/gYGBeR5/6qmnxBNo3c8zA6Jle3ySrDuQKA/MWCtzHuwsZQL8rG4aAABwtyLojh07Xvbx5cuXiycVUcWfTpM+U5dIwtl0Gdqxljx/c3OrmwgAAEqwCLrIs8C87QQu2nFM7n5/lbn99rA20qtpNYtbCQAA3GolaG/UrVEVua9LPXN7wuxNciw5zeomAQCAEkIAymVsz4bS5KpQMxT2xBebxIadYwAA2AIBKJcgfz95fXArCfTzlQXbj8mX6w9Z9zcDAABKDAHoIg2rlpdHe0SZ289+s1WOJ58rubMPAAA8PwClpXlH3czoLvUk+qpQSUzJkOe+3Wp1cwAAgDsHoODgYLnmmmtk1ars2VSeSjdH1f3BdKuMbzYclmW7T1jdJAAA4K4B6M0335SYmBi59957xdM1iwyTYR1rm9sTv94i6eezrG4SAABwEdYBusw6AqdTM6T7PxfJybPp8rc+jWV0FzZMBQDA1usAnTp1SjZv3mwuetsbhQUHyPgbG5vb/1qwW06dTbe6SQAAwAUKFYCOHz8ukydPlhYtWkjFihWlefPm5qK3W7ZsKS+88IKcOOFd9TK3XV3DrA2UnHZepi7YZXVzAABAaQagF198UerXry8//PCDDB06VObPny9btmwxF7195513yty5c81zXnrpJfEWfr4+8mSfJub2R8v3y/6T7BgPAIBtdoNfu3atrFy5Uho3zh4Syk13hL/uuutk/Pjxsn37dnn66afFm8REVZKuDSvL4p3H5eWfdsrUIa2tbhIAACgGiqALWES19XCS2THex0fkpzFdJKpq+eKcdwAA4IlF0HYTXT1UejetJro92GvzqQUCAMAWQ2C5jRkzJt/HgoKCpF69enLLLbdIlSpVxJvoFhk/bImX7zYdkR3xydKoGr1AAADYZgisV69e8tNPP0nlypWladOm4uPjI5s2bTIzwLp06SJ79uyR5ORkWbJkiZkl5k1daA/OWCPfbYqXvi2ukn/feXWJtREAALjZEFiDBg3kwQcflIMHD8rChQtlwYIF5vb9999vAs++fftkyJAh8vjjj4u3+fP12Rulfr/piBw4mWJ1cwAAQGn1ANWoUUM2bNhg1v/JTXuAWrduLXFxcXL48GEThk6ePCneliD/NG2lmRE2vFNtee6mZiXSRgAA4GY9QLry89GjR/9wPD4+PmdV6ICAALM5qje6r0s9cz1zdZwksDo0AAAep0gB6KabbpKBAwfK999/b1aHPnbsmLk9aNAgGTBggHnOnDlzzPO8Uaf6FaVZZKikZWTJ9N/2W90cAABQGgHorbfekrZt20r//v3NTK+qVaua2+3atTOPqcjISLN6tDfSom/nxqj/+22fnDufaXWTAABAaS2EmJCQIDt37jSBICoqSipUqCB2GUM8n5klMS8ulPikNHl9cCu5qVWky9sJAADcqAbISQNPx44dpUOHDkUOPzpdfvr06fLPf/5Tfvzxx0K9Vvche/755+Xnn3+W0ubv5ytD2tfK2SMMAAB4+UKISjuO9u7dKwcOHJDz58/neaxHjx4Feg+dOh8TE2OG0dq0aSOvvPKKXHPNNTJz5kzTq3Q5Z8+elTvuuMO8xz333CM33HCDlLbB7WuaHeJX7Tsl2+OTpHG14qVRAADgxgFI1/m5/fbbZc2aNZd8vKCjarp5qi6muHTpUjNrTFeY1oUVv/jiC/P+l6PrEPXt29eS3h+nqqFlpGd0Vfl+c7zpBXr+Zvdb9BEAALhoCEyDiq7x45zynpqaKosXL5YmTZrkFEFfSWZmpnz55ZcyfPhwE35Uo0aN5Nprr5VZs2Zd9rUzZsyQjRs3yqRJk8RqwzrWNtdz1h6SM+fy9oQBAAAvCkC//vqrTJ48WcLDw819f39/swXGRx99ZGp5CkKHzlJSUqRhw4Z5juv97du35/u63bt3y9ixY00ICgwMLNBnnTt3zhRO5b64ckp8vUpl5Wx6pny38YjL3hcAALhZANLVna+66ipzW1eDdi6KqD04GmwK4syZM+Zaq7lz01DlfOxi6enpZq2hiRMnSnR0dIHbO2XKFPM5zkvNmjXFVbRW6bY2NcztWWsOuux9AQBAySnWLDClxcuvvvqqWQVar+vWrVug15UtW9ZcX9wbo1PbnI9dTHuYYmNjzdCbzv7Si4avlStXmtv51R5NmDDBvK/zolt1uNKtV0eK1myv3JfA/mAAAHhrALrrrrtybutQmE5j1x4hXfiwoENgtWrVMltl6JBWbrt27TI9SZeiBdIPP/ywpKWl5Vw09Gg9kfP2pQQFBZn1AnJfXOmqsGCJaVDJ3P5iLb1AAAB45UKIOvVcN0R1ysjIMD0zeiwxMTHPY5ejw1k6ZLZkyRJTR6Tv0bhxYxOoBg8ebJ4zd+5cOXTokIwePfqS79GqVSvp1q2bvPbaa5YspOT05bpDMuaz9VKzQrAs/st14ut7+Wn8AADAwxZCvLiGRmdxaXApV65coeprtMdIA9B1111nCpv1unfv3mafMSfdU2zq1Kni7no1rSblgvwlLiFVVu1LsLo5AACgJBZCvBSd1VWYHeDr1Kkjmzdvls8//9zU8mjQ0c1UfX1/z2X9+vWTli1b5vseo0aNKnDdUUkKDvSTPs2ryczVB+XL9YekQ72KVjcJAAC4YgjsqaeeMte6/s6TTz6Z57GsrCxZu3at6Z5atmyZuLOSGAJTS3efkLveXSERIQGy6skeZrsMAADgft/f/oVd/+dSt53DYNqj89e//lXsqkPdClKhbKAknE2X3/aclGujKlvdJAAAUNwAtGjRInOt21RcabVmO9Ien97NqsnHKw7I3I1HCEAAALipIo3RXCr8XLwhql31a569QOQPW+IlIzPL6uYAAIDiBiBdofm///1vnmMffvihVKpUySxeeOutt0pycrLYWfu6FaRSuUBJTMmQZbEnrW4OAAAobgB644038mx1sWfPHjML6/rrrzdT2jds2GAWRrQz5zCYmrvxsNXNAQAAxQ1AH3/8cZ5VoGfPnm3W/fnkk0/MDvEffPCBOWZ3fZtXN9c/bT0q5xkGAwDAswOQbluRe82dpUuXSq9evXLW7dF9wXSVaLtrVydCwkMCzDDYmv2nrG4OAAAoTgDSWp8dO3aY27r/lgagTp065Tyum5RGRESI3ekwWPdGVczteduOWt0cAABQnADUt29fU/Ojw1x//vOfTVG0bl3htGbNGunQoUNh3tJr9Yiuaq5/3no0301aAQCABwSgf/zjH2a212233SbTpk2Tf/3rX1K58u+L/elWFrpbO0S6NKwsgX6+su9kisQeP8spAQDAUxdC1CGwhQsXmiWoQ0JCzOrPuX322WdSsSJ7YCndGLVT/YqyeOdxMwzWoEo51/7NAQCAku8BOn78eM5t3Yfj4vCjnOEn93PtzDkMNm8rdUAAAHhkAGrWrJn8/e9/z7MO0MX27t1rNklt2rSpq9rn0Xo0yS6EXnPglJw8c87q5gAAgMIOga1YsULGjx8vDRo0MGFIp7xXrVrVFPjGx8fLqlWrZNu2bWY16JUrVxb0bb3aVWHB0rR6qGw5nCS/7Dout7SuYXWTAABAYQKQ7vSuNT779u2TmTNnminwOuvLx8dHatSoIcOGDZOBAwdK7dq1ObG5dG1Y2QSgxTsIQAAAeGQRtDMIjRs3rmRa46UB6D+LYuWXXSckK8shvr4+VjcJAADbK9Q0+PT0dJkwYYKp8YmOjja39Rjyd3XtCDMjLOFsumw+fJpTBQCApwWg5557zqz907FjR7MCtN7WtYGQvwA/X7mmQfbsuF92MjsOAACPC0C66emcOXPkvffeM5dZs2aZY7i8rg2zZ4PpmkAAAMDDAlBcXJx069Yt53737t0vOy0e2bo0rGSu1x5IlNOpGZwWAAA8KQBlZGTkWQAxMDDQHMPl1YgIMStBZ2Y5ZNnuE5wuAAA8bRZYv379rnjs22+/LV6rvHQ22O5jZ8ww2I3Nr7K6OQAA2FqheoB0E9QyZcrkuVzqGP4opkH2MNjSWHqAAADwqB4gLXpG0bSvW0H8fX0kLiFVDpxMkVoVQziVAAB4Qg8Qiq5skL+0rhVubtMLBACAtQhApahz/QvDYBRCAwBgKQJQKYqJyg5Ay2JPmm0xAACANQhApahljXAJCfQz22Jsj08uzY8GAAC5EIBKUaC/rymGVgyDAQBgHQKQRdPhf6UOCAAAyxCALCqEXrk3QTIys0r74wEAAAGo9DWuVl4iQgIkNSNTNh5M5IcQAAAL0ANU2ifc10c61K1obv8We7K0Px4AABCArNGp/oUAtIcABACAFegBsjAArdl/Ss6dz7SiCQAA2BoByAJRVcpJpXKBkpaRJRviTlvRBAAAbI0AZAEfHx/pUI86IAAArEIAskgnZwDac8KqJgAAYFsEIIvrgNYeSJS0DOqAAAAoTQQgi9SrVFaqlA+S9PNZsvbAKauaAQCALRGALKwD6nhhGGzFngSrmgEAgC0RgCzkDEDLWQ8IAIBSRQBygzqgddQBAQBQqghAFqpTMUSqhgZJeiZ1QAAAlCYCkJvUAS2nDggAgFJDALIYdUAAAJQ+ApCbBKD11AEBAFBqCEBuUAdULbRMdh3QftYDAgCgNBCA3KIOqIK5/RvT4QEAKBUEIDdAHRAAAKWLAOQGOtevZK7XxyVKSvp5q5sDAIDXIwC5gZoVgiUyPFgyMh2yeh91QAAAlDQCkJvUATlXhV4We9Lq5gAA4PUIQG6i04Xp8BRCAwBQ8ghAbsLZA7TpYKIkpWVY3RwAALwaAchNVA8PNmsCZTlEVrItBgAAJYoA5EY6XZgNxjAYAAAliwDkRiiEBgCgdBCA3LAQetuRJEk4m251cwAA8Fr+VjcgPT1d5s+fL0ePHpXmzZtLmzZtrviaAwcOyIoVK8Tf31/at28vkZGR4g0qlw+SxtXKy/b4ZFm6+4T0b1nd6iYBAOCVLO0BOn78uAk8Y8aMkblz50qPHj3k/vvvz/f5DodDhgwZIt26dZPPP/9c3nvvPYmKipLXXntNvEVMg+w6oF93nbC6KQAAeC1Le4AmTJhgrtetWychISGyZs0aadeunfTv31/69u17yQB00003yYwZM8TXNzu7TZ8+Xe6++27zmvr164unu7ZhZXn3172yZNdx8+fVRRIBAICX9ABlZWXJzJkzZcSIESb8KO0N6ty5s3z66aeXfI2GnsGDB+eEH9WrVy/zXjt27BBv0L5OBQn085XDp9Nkz4mzVjcHAACvZFkAiouLk+TkZImOjs5zXO9v2bKlwO/z7bffip+fn7Ro0SLf55w7d06SkpLyXNxVcKCftK0TYW4v2Xnc6uYAAOCVLAtAzhASHh6e53hERESBA8q2bdtk7Nix5lKjRo18nzdlyhQJCwvLudSsWVPc2bVRlc31r7upAwIAwKsCUHBwsLnWXqDcNPw4h8QuZ8+ePdKzZ0/p06ePvPDCC1esNTp9+nTORXuf3Nm1URcWRIw9KRmZWVY3BwAAr2NZEXTt2rUlMDBQ9u7dm+e43m/QoMFlX6vP0ZlgWi+kRdC5a4IuJSgoyFw8RfRVoVKhbKBZC2jdgURpX7eC1U0CAMCrWNYDFBAQIL179zYFzzrbSR0+fFgWLlwoAwYMyHne4sWLTbG00759+0z46dSpk5kNpvU/3sbX10euuTAdXmeDAQAA1/JxONOHBbZv3256cWJiYqRjx47yv//9T6pUqSILFiwwixyqkSNHyvLly2Xz5s2SlpYmTZo0kZSUFJk4cWKe8KOhqHHjxgX6XB1m01ogHQ4LDQ0Vd/T56jj566yN0jwyTL55JMbq5gAAYDlXfn9bug6QBpaNGzea4KMrQf/lL3+R4cOH54QfZ7DR4TKVmZlppr2rTZs25XkvXUXam3RrVMVcbzp0Wo4lpUmV0DJWNwkAAK9haQ+QVTyhB0jd9O+lsiEuUV68rbkMalfL6uYAAOA1399shurGrm+c3Qs0f9sxq5sCAIBXIQC5se4XApCuB5SWkWl1cwAA8BoEIDfWtHqoVA0NkpT0TFmxN8Hq5gAA4DUIQG5MN0Lt3riqub1g21GrmwMAgNcgAHlKHdD2YznrJQEAgOIhALk5XRAxyN9XDp5Kld3HzljdHAAAvAIByM3p7vCd61c0t3/YHG91cwAA8AoEIA9wY/OrzPXcTUesbgoAAF6BAOQBekZXFX9fH9ken8wwGAAALkAA8gDhIYESE5W9Oep39AIBAFBsBCAP0dc5DLaRYTAAAIqLAOQhekZXkwA/H9lxVIfBkq1uDgAAHo0A5CHCQgIkpkH2MNjcjcwGAwCgOAhAHqRvi+rmeu6mw1Y3BQAAj0YA8iA3RFc1w2A7j56RHfEMgwEAUFQEIA8SFhwgXRtmb40xa02c1c0BAMBjEYA8zKB2Nc31F2sPSfr5LKubAwCARyIAeZjrGlWWKuWDJOFsusxjh3gAAIqEAORh/P185Y62NcztT1cxDAYAQFEQgDzQwLbZw2BLdh2XuIQUq5sDAIDHIQB5oNoVy5od4h0Okc/XHLS6OQAAeBwCkIcXQ3++Ok4ysxxWNwcAAI9CAPJQvZpWk/CQADlyOk0W7zxmdXMAAPAoBCAPVSbAT25tnV0M/e6SvVY3BwAAj0IA8mD3xNQRf18fWRZ7UtbHJVrdHAAAPAYByIPViAiRAa2y9wd7a1Gs1c0BAMBjEIA83P1d65vrH7fGy+5jZ6xuDgAAHoEA5OEaVi1vNknVKfFvL6YXCACAgiAAeYEHumX3As1Zd0gOJ6Za3RwAANweAcgLXF0rQjrWqyDnsxzMCAMAoAAIQF7igW4NzPXHK/fTCwQAwBUQgLxEl6hK0r5OBUnLyJIp32+3ujkAALg1ApCX8PHxkYn9o8XHR+SbDYdl5d4Eq5sEAIDbIgB5kWaRYTK4XS1z+5mvt7BHGAAA+SAAeZm/9Gwo5cv4y9YjSfLZqjirmwMAgFsiAHmZiuWCZOwNDc3tf/60Q06nZFjdJAAA3A4ByAsN7VhboqqUk4Sz6fLqvJ1WNwcAALdDAPJCAX6+8nT/pub2B8v2yaIdx6xuEgAAboUA5KVioirJ8E61ze2xMzfI0aQ0q5sEAIDbIAB5sb/1aSLRV4WaobA/f7KOWWEAAFxAAPJiZQL85I07W0tIoJ+s2JsgU+fvsrpJAAC4BQKQl6tXuZxMvqW5uT11wS5ZFnvC6iYBAGA5ApAN3Nw6Uu5oU0McDpFHP10vcQkpVjcJAABLEYBs4tmbmkrDquXkePI5ufPd5XLkdKrVTQIAwDIEIJsICfSX/93TQWpXDJG4hFS5850VcoyZYQAAmyIA2Ui1sDLy8aiOEhkeLHtPnJW73l0hJ8+cs7pZAACUOgKQzWj4+XhUB6kWWkZ2HTsjQ99bKYkp6VY3CwCAUkUAsqHaFcvKjFEdpFK5INl2JEmGvLOCwmgAgK0QgGyqfuVypieoYtlAE4L6Tl0i87cdtbpZAACUCgKQjTWsWl6+eSRGWtUMl6S083Lvh6vlpR+2y/nMLKubBgBAiSIA2Vz18GCZeV8nubtzHXP/P4tiZdh7K810eQAAvBUBCBLo7yvPDGgqU4dkb5vx256TZkjsq/WHJCvLwRkCAHgdAhByDGhZXb5++BqJqlJOjiWfM6tG3/KfpbJybwJnCQDgVQhAyKNBley6oL/2aiRlA/1kw8HTMvDt3+S+6avN2kEAAHgDH4dDd4iyl6SkJAkLC5PTp09LaGio1c1xW1oH9Nq8nfLJygOiI2H+vj4ytGNtUy9Up1JZq5sHALCZJBd+fxOACEBXtOtoskz+bpss3HE851inehVlcPua0qtpNSkT4FesH0IAAAqCAFRM9AAVzdLdJ+SdJXtk8c7jZmd5FRYcILe0jpRB7WpKk6voTQMAlBwCkBudQDs6lJgqs1YflJmr48xtp8bVykuXhpXlmgaVpH2dChIcSM8QAMB1CEBudALtLDPLYXqFPlsVJz9tjZeMzN/LyQL9fKVN7QiJiapkAlHzyDDx8/WxtL0AAM+W5E01QPrxq1evlqNHj0qzZs2kTp06JfKa3AhArpdwNl2W7Douv+46Ib/uPiFHTqflebx8GX9pWj1UGlcLNStQN6qWfSkX5F8CrQEAeKMkbwlA+gfp06ePxMbGSuPGjWXlypXy2GOPyfPPP+/S11zqPegBKjn6I6VT5rV3SMPQstiTkpx2/pLPrRERbIbONBTVrVTWrExdLayMXBVWRkICCUcAgJL5/rb0G+app54yvTjbtm2T8PBwWbx4sXTr1k26d+9uLq56DUqXj4+P1KtczlyGdapj9hbbHp9sLjviky5cJ5vFFg+eSjWXeduO/eF9tMBag5BeqoUFm+uqoUESFhxoHgsPCTDXetEVrPVzAQBw6x4g/diKFSvKuHHj5Iknnsg53r59ezOsNW3aNJe85lLoAXIPp86my46j2WFIr+MSUszQ2ZHEVDmbnlmo9wrw8zFBKPRCINJL2UB/M0U/ONBXgvU6wE/KBGZfm4vzdqCfBPn7ib+fj6ld0usAP18J8PWVAH8f8ff1zXvcz4ewBQAW8IoeoIMHD8qpU6ekRYsWeY7r/fXr17vsNercuXPmkvsEwnoRZQOlY72K5nKxpLQMiT+dJocTU7OvT6dJ/OlU02t0OjUj+5KSfX0+y2EKsE+cSTeX0qCLQvr6+oifj48p7tb6br3Wi/ZE5Rz3FXPb+VxfH31c/nCtfVc+uY/pMu0XHnDeNnfN/ezbTs6er+z3uHDsouPZz/v9Xp7XX/Rnu7gjLbs1l378cp1uF7/uogeL8lCx0UuIkvTCrc2lLHWNHsOyAKTpTUVEROQ5rj08iYmJLnuNmjJlijz77LMuaDVKS2iZAHPR2qDL0V7BlPRME4QSLwQivSSlZkhqRmb2JT1T0nLd1uu897PkXEamZGRlyflMDVNZJlDptd5Pz8z6w+dq6DLLYwPABc/f1Ixz4UEsC0BBQUHmOiUlJc/xM2fOSJkyZVz2GjVhwgQZO3Zsnh6gmjVrFqv9cA/6G73+xqUXLaAuCRqyNPA4w9D5CwEp0+GQrCyHWQ4g57Yj+35Wlvx+O9e1HtdrjU56rTfM/eybv9/O9RznY46c29nBK/t5F9p44XHn7QtPyfvcnD9Prj9bztE/PpbrbS75hMLEv4IOtJfkiDxxFSUtKIDtNT2JZQFIA4i/v78cOHAgz3G9X69ePZe9xhmcnOEJKErI0rof3fEjWFjcEQC8gWVxVXtsrrvuOpk1a1bOsZMnT8r8+fPlxhtvzDm2Zs0a+fnnnwv1GgAAALddB2jt2rVy7bXXysCBA6VTp07yzjvvSEZGhqxYsSKnx2bkyJGyfPly2bx5c4FfcyXMAgMAwPO48vvb0gHLq6++2vTwaFGzrudz2223yZIlS/IEmbZt20rPnj0L9RoAAAC33grDCpocdRHFuLg49gIDAMBDOCcx6cxv7QkqDlvuNaB1Q4qZYAAAeOb3OAGoCCpUqJAze6y4J9DOnEmcnjTOpTvh55Lz6G74mXTtCE6tWrVyvseLw5Y9QL66PK/uNRUWxhCYC2ghWnGL0cC5dDV+LjmP7oafSdd/jxfrPVzSEgAAAA9CAAIAALZjywCkU+affvppps5zHt0GP5OcS3fDzyTn0tt/Lm05DR4AANibLXuAAACAvRGAAACA7RCAAACA7fjacfXIVatWSXx8vNVN8Wi6Aa1uULt3717JysqyujleYdu2bfLrr7/KuXPnrG6KR4uNjZUtW7bwc1kM58+fl127dsm6devk1KlTrvvLsYHjx4+bf8cJCQn5Pufw4cPme4hze3lbt26VZcuW5ft4SkqKrF+/Xg4dOiRF4rCRiRMnOoKCghzR0dHm+t5773VkZmZa3SyPkpqa6hg3bpyjQoUKjmbNmjmqV6/uaNiwoWPp0qVWN82jbdiwwRESEqITEhx79+61ujkead26dY7mzZs7qlSp4mjTpo2jadOmjvXr11vdLI+zcOFCR61atRw1a9Z0tG7d2hEcHOwYNWoU/1dewaZNmxxDhgxxVK1a1fw7njNnzh+ek5GR4Rg2bJijTJkyOd9DkyZNKqm/So81Y8YMR7t27RwRERHmHF0sPj7eMWLECEdYWJijVatW5vuoU6dOjtjY2EJ9jm16gL766iuZMmWKLFiwwPx2uGHDBpk1a5a88cYbVjfN45Yhr1ixouzfv182bdpkthPp1q2b3HTTTfRcFJH+FjNkyBB5+OGHXfuXZSNHjx6VHj16SExMjPntevXq1ebf/JEjR6xumsf505/+JN27dzf/xteuXSvLly+XadOmycyZM61umlvT75W+ffua6/y8/PLL8v3335ueDX3ed999J3//+9/lp59+KtW2urvt27fLv/71L3nppZcu+bhuv9SlSxc5ceKE6aXU76Hg4GAZOnRo4T7IYRMDBgxw9O7dO8+xkSNHOlq2bGlZm7zF6tWrzW882ouBwtPfZB5++GHzmzc9QEUzYcIE0/OTlpbGj2AxZGVlmZ7It956K8+x8PBwx9SpUzm3BZCcnJxvD5D2lo8ZMybPsZiYGMegQYM4t5fwzjvvXLIH6FI++OADh6+vr+llKyjb9ABpSmzTpk2eY+3btzd1LFrPgqLTsWw/Pz+pU6cOp7GQPv30U1mxYkW+v+mgYObPny833HCD2R9I/61Tm1Y0Pj4+MmnSJPPzOGPGDNMzMXLkSKldu3bhf7tGHmfPnpWdO3de8ntIf2ZR/O8h/Tn19y/4Fqe22QxVC9J06CY3vZ+ZmWl26r34MRS84PTJJ5+URx99lA1Ri3DuHnnkEZk3b57pvkXR6bBXZGSkNGvWzJxLneSg/6Y//vhjadmyJae2EAYMGCBff/21jBs3TipXriwHDx6UF154QSIiIjiPxeAseL7U99DlCqZxZYsWLZK3335b/vvf/0ph2CYABQQESFpaWp5jqamp5jowMNCiVnn+l06vXr2kc+fO5j9IFM6oUaPM+UtOTjazRrSmSmn9is6sq1evHqe0EP++586dK0uXLpW2bdtKenq6DBo0SAYPHmxm16Fg9P9Irenr16+fCebao6a95B07djS/Wd99992cymL8jDrP8cXfQ3wHFd2aNWvk5ptvNr+EjxgxolCvtc0QmHaNXTxVTu+Hh4dL+fLlLWuXJ4ef6667Tho1aiRffPFFzj9uFFyVKlVk37598sQTT5iL87eXF1980RTwouB0+FWDj16UfqHcc889pphSCyVRMDo5RAtMH3jgARN+lPaqde3a1fQKoei0Ny0kJOSS30O1atXi1BaBFunr0LcGn3/+85+Ffr1tApCeJK241yEvJ/2S0eMoHJ1Zo+Gnfv36Mnv2bH57KUb9j/b8OC8660F9/vnn8thjj/FjWQjak6Y/l7nXpNKhGw1CoaGhnMtCfEk7z11uet/5GIpGA6XOrssdJLWnUmeF8T1UeLr+j563YcOGyauvvlqkvxPbDIGNHTtW/ve//5ku8eHDh5vucj2BOm6Iwk2Dv/76602QfPzxx03hmZP+pqg9akBpe/DBB+Wdd94x/7a1WFenxer0Yg2SDC8UnA676lRu7QF69tlnpWrVqmb6uw4jvv/++yX4N+j5tI5Hp7c7Syv0nFWqVMnUptWtW9cc03N6zTXXmOEaXbbh3XffNcHoz3/+s8Wtdy87duwwC0ru3r1bZ6qbXxCV1vPpiI0Wk+v50++cO+64I+dxZ1F5Qf/N22o3eJ0ZorMb9ORql6P+50iBZOHoD2R+dQC6xkWHDh1c8ndlRzoTRIuidX2qatWqWd0cj3Ps2DHz71t/sdEvHl2bSn/h0ZlNKDhdiVyHYxcvXmzq07Sn96GHHpKmTZtyGi9jyZIlMmHChD8cHzhwYJ6AozUrr7/+uhn6aty4sYwfP54hsIs888wzpgbtYvpzGR0dbWYnPvfcc3Ipc+bMKXBvpa0CEAAAgK1qgAAAAJwIQAAAwHYIQAAAwHYIQAAAwHYIQAAAwHYIQAAAwHYIQAAAwHYIQAC8wq5du+Stt94yCyECwJUQgAB4hdjYWJk2bZq0a9fOrFgOAJdDAALgFXr37i2LFi2SgIAAsy0BAFwOAQiA1wgJCTH7K23YsMHqpgBwc7bZDR6A99u8ebO5hIeHW90UAG6OzVABeIXMzEzp3Lmz7Nu3z9w+ceKE1U0C4MYYAgPgFV577TWJj4+Xt99+W06ePCmHDx+2ukkA3BhDYAC8YgbYxIkTZc6cOXL11VebYxs3bpTq1atb3TQAbooeIAAezeFwyOjRo2XIkCHSs2dPqVSpkkRGRlIIDeCy6AEC4NHeeecd2bFjh8yePTvnWMuWLU0PEADkhx4gAB5L63zGjRtn6n7CwsJyjhOAAFwJs8AAeKxjx46ZwucWLVrkOX78+HE5dOiQtGrVyrK2AXBvBCAAAGA7DIEBAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAADbIQABAACxm/8HmBjwEyVvsgMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "row, col = g.players\n",
+    "row_stag = row.strategies[\"Stag\"]\n",
+    "principal = np.array([[q.lam, q.profile[row_stag]] for q in gbt.qre.logit_solve_branch(g)])\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(principal[:, 0], principal[:, 1], color=\"C0\", label=\"principal branch\")\n",
+    "ax.set_xlabel(r\"$\\lambda$\")\n",
+    "ax.set_ylabel(\"P(Stag), row player\")\n",
+    "ax.set_xlim(0, 12)\n",
+    "ax.set_ylim(-0.02, 1.02)\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5fe6141",
+   "metadata": {},
+   "source": [
+    "## A density which concentrates on the correspondence\n",
+    "\n",
+    "A pair $(\\sigma, \\lambda)$ is a LQRE if for every player $i$\n",
+    "\n",
+    "$$\\sigma_i = \\operatorname{softmax}(\\lambda\\, v_i(\\sigma)),$$\n",
+    "\n",
+    "where $v_i(\\sigma)$ is the vector of expected payoffs to player $i$'s pure strategies when the others play according to $\\sigma$.\n",
+    "[Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) measures how far a profile is from satisfying these conditions with the penalty\n",
+    "\n",
+    "$$\\operatorname{obj}(\\sigma, \\lambda) \\;=\\; -\\sum_i \\bigl\\lVert \\sigma_i - \\operatorname{softmax}(\\lambda\\, v_i(\\sigma)) \\bigr\\rVert^2,$$\n",
+    "\n",
+    "which is zero exactly on the correspondence and negative elsewhere.\n",
+    "Rather than treating $\\lambda$ as a free parameter, it can be *eliminated* ([Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria), Section 3): given $\\sigma$, the logit conditions are linear in $\\lambda$ on the log-odds scale, so the least-squares fit has the closed form\n",
+    "\n",
+    "$$\\lambda^*(\\sigma) = \\max\\left(0,\\; \\frac{\\sum_i \\sum_a x_{ia} y_{ia}}{\\sum_i \\sum_a x_{ia}^2}\\right),$$\n",
+    "\n",
+    "where $x_{ia}$ and $y_{ia}$ are the differences in expected payoff and in log probability between strategy $a$ and a fixed reference strategy of the same player.\n",
+    "We follow the author's implementation in the [online appendix](https://github.com/JamesBlandEcon/ApproxQRE) of [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria).\n",
+    "Gambit's `strategy_value` provides the expected payoffs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eda34d1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:07.484403Z",
+     "iopub.status.busy": "2026-07-22T11:38:07.484142Z",
+     "iopub.status.idle": "2026-07-22T11:38:07.491479Z",
+     "shell.execute_reply": "2026-07-22T11:38:07.490602Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def softmax(x):\n",
+    "    \"\"\"Map a vector of logits to a probability distribution, stably.\"\"\"\n",
+    "    z = np.exp(x - np.max(x))\n",
+    "    return z / z.sum()\n",
+    "\n",
+    "\n",
+    "def strategy_values(game, probs):\n",
+    "    \"\"\"Expected payoff to each pure strategy against the mixed profile `probs`.\n",
+    "\n",
+    "    Returns one array per player, ordered as in `game.players`.\n",
+    "    \"\"\"\n",
+    "    profile = game.mixed_strategy_profile([[float(p) for p in pr] for pr in probs])\n",
+    "    return [\n",
+    "        np.array([profile.strategy_value(s) for s in player.strategies])\n",
+    "        for player in game.players\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "def lambda_star(probs, values):\n",
+    "    \"\"\"Closed-form least-squares lambda for a profile, from the logit conditions.\"\"\"\n",
+    "    num = den = 0.0\n",
+    "    for pr, v in zip(probs, values, strict=True):\n",
+    "        y = np.log(pr[:-1]) - np.log(pr[-1])\n",
+    "        x = v[:-1] - v[-1]\n",
+    "        num += x @ y\n",
+    "        den += x @ x\n",
+    "    if den < 1e-12:  # all strategies payoff-equivalent: any lambda fits equally well\n",
+    "        return 0.0\n",
+    "    return max(num / den, 0.0)\n",
+    "\n",
+    "\n",
+    "def obj_fun(game, probs):\n",
+    "    \"\"\"Bland's penalty objective; returns (obj, lambda*).\"\"\"\n",
+    "    values = strategy_values(game, probs)\n",
+    "    lam = lambda_star(probs, values)\n",
+    "    obj = -sum(np.sum((pr - softmax(lam * v)) ** 2) for pr, v in zip(probs, values, strict=True))\n",
+    "    return obj, lam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a7ea38f",
+   "metadata": {},
+   "source": [
+    "## Sampling near the correspondence\n",
+    "\n",
+    "Draws from a density proportional to $\\exp(w \\cdot \\operatorname{obj}(\\sigma))$ concentrate near the set where $\\operatorname{obj} = 0$, with the weight $w$ controlling how tightly.\n",
+    "[Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) samples such densities using Hamiltonian Monte Carlo (Stan); a random-walk Metropolis sampler keeps this notebook self-contained.\n",
+    "Each chain starts from an independent uniformly-drawn profile, so chains can land on branches which are not connected to the centroid.\n",
+    "\n",
+    "(The proposal walks on unconstrained log-odds, which implies a slightly different base measure than the uniform-on-the-simplex prior used by [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria).\n",
+    "This is immaterial here: the draws serve only as approximate locations on the correspondence, not as posterior samples.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2ab7419e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:07.493923Z",
+     "iopub.status.busy": "2026-07-22T11:38:07.493691Z",
+     "iopub.status.idle": "2026-07-22T11:38:08.830996Z",
+     "shell.execute_reply": "2026-07-22T11:38:08.829969Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(15790, 18000)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PENALTY_WEIGHT = 10_000.0  # w; the value used in the online appendix of [Bla24]\n",
+    "N_CHAINS = 12\n",
+    "N_ITER = 1_500\n",
+    "STEP_SIZE = 0.15  # std. dev. of proposal increments in log-odds space\n",
+    "\n",
+    "rng = np.random.default_rng(20260722)\n",
+    "draws = []\n",
+    "for _ in range(N_CHAINS):\n",
+    "    z = [np.log(rng.dirichlet(np.ones(len(p.strategies)))) for p in g.players]\n",
+    "    probs = [softmax(zi) for zi in z]\n",
+    "    obj, lam = obj_fun(g, probs)\n",
+    "    for _ in range(N_ITER):\n",
+    "        z_prop = [zi + STEP_SIZE * rng.standard_normal(zi.shape) for zi in z]\n",
+    "        probs_prop = [softmax(zi) for zi in z_prop]\n",
+    "        obj_prop, lam_prop = obj_fun(g, probs_prop)\n",
+    "        if np.log(rng.uniform()) < PENALTY_WEIGHT * (obj_prop - obj):\n",
+    "            z, probs, obj, lam = z_prop, probs_prop, obj_prop, lam_prop\n",
+    "        draws.append([lam, probs[0][0], probs[1][0], obj])\n",
+    "draws = np.array(draws)\n",
+    "on_locus = draws[draws[:, 3] > -1e-4]\n",
+    "len(on_locus), len(draws)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acbdbfa2",
+   "metadata": {},
+   "source": [
+    "Plotting the draws next to the principal branch reveals a second branch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "466c2627",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:08.833026Z",
+     "iopub.status.busy": "2026-07-22T11:38:08.832821Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.012358Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.011307Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAGxCAYAAACKvAkXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUZBJREFUeJzt3Qd8W9X5//FHnrGzd8je01mEkARSEsL8EcoqBCijQIEfUEpb2gIpBVpaCNBCKeX3L3sWyg60pRTKSEgCmWSSRRbZe5Dhbf1f3+NcIzu2Yzuyr6T7eeell6Qr6er4WvF99JznnBMKh8NhAwAACJAkvxsAAABQ1wiAAABA4BAAAQCAwCEAAgAAgUMABAAAAocACAAABA4BEAAACBwCIAAAEDgpFkBFRUW2ceNGa9iwoYVCIb+bAwAAqkBzN+/du9fatm1rSUlHlsMJZACk4KdDhw5+NwMAANTAunXrrH379nYkAhkAKfPjHcBGjRr53RwAAFAF33zzjUtgeOfxuA6AlixZYo8//rgtXbrUHnjgARswYMBhXzN37lx77LHHbMuWLda/f3+7+eabrWnTplV+T6/bS8EPARAAAPElGuUrvhZB33PPPXbeeedZ/fr17f3337edO3ce9jXTp0+3ESNGWGpqql1wwQU2adIkO/744+3AgQN10mYAABD/Qn6uBr9582Zr06aNrV+/3qW0PvnkExs9enSlrxkzZow1btzYJk6c6O7v2bPH2rVrZxMmTLAf//jHVU6haR96LRkgAADiQzTP3752gSn4qY7s7Gz79NNP7emnny7ZpgNx8skn23/+858qB0AA4nP0pv4G6DtbZmamGwGibTk5OVavXr1SI0IKCgps69at1qpVK7d9//797g9ny5Yt3XVaWprbnp6e7r6IaT+5ublWWFjorjXCZNeuXe7vS5MmTezrr792NQfKUqsNeXl5lpGRYSkpKe5aWez8/Hz3Wr2X2qPnqK3a1/bt291tPVfXzZo1cyNZ9JwGDRq4Nuu1+ln0etFz9Ad+27Zt7ufQc/Ue+tnVDr232q/XKQPu3Vd7tc3rJtB7aruOh34Gvb9OHnqObmub9is6LjoWO3bssObNm7tjpDbpZ9ax0P50/FR8umHDBnc8lY3Xz6s2aZ96f73n7t273b70mKiNOqb6mXRbF+1TP4+er+dG/m60H93XdXJycqnPgn5P2pd+LtHz9T56f11rXyqR0Ou0D30edL7Rz6l2aZuOr95LP4f2o+OnY6Ev5Hq+yir0XO1D90XP03t7JRdqg+57eQQdC/0s3nN0nPV7Fu1Hj6utuuzbt8+9p46p137RMdXx1jbvJK/9qQ16vff70+vUHv2sos+HtunzpIsG+2g/2q+ep/fTPr3fdb2Dx0mv0+dX7dPx00W/E+1Dx8nbrteqvbqtz6OOjXdcdNx0W79P7V+fBbVV+9E+dEz0+9Yx0THXMdHnS58t7+fQ51zP10X7Ubu8z7der+362fXZTIgMkKeqGaDly5dbr1697KOPPnKZIM+NN97oXvvll1+W+zrvl1q2iIoMEBAdkYGIeIGK/nBpu/dH2ntMf9z0x3DFihUlJ12dTPRHV/vQH2u9Tn8AddEfP/2diKQTg/4ve/Qc7UsBhPdHHolBZQ86aeozpYDo888/L/WZEp1IveCYkojEk5GR4c7j+hyceeaZ8Z8Bqi790fQORCR94L3HyqPusd/+9re13j4gXlWUSfHoG6i+1el5XvGh981dJxt9+dDr9VqdhGr6vUrfKiPpW6UCmvLqAyODH/GyCkg8CngOx/vM8RlITNnZ2VHfZ1wFQIr8pewfQ6XEKhsFNn78eDdSrGwGCAh6wKOUtroAdFGwoWxLnz59XAZG2RQFONo+f/78Ku8X8JOCeH22kZgZoMAGQOp3btGihRsGP3bs2JLtuj9kyJAKX+el0YEgBjkKZJRZ0f8B3VY9i2pSysua6g/MvHnzfGkvok+/b+/37NXW6DOh+gzVmohXA6QMyqZNm9zjqvvo2rWru9Z9ZVW8uiGP9tG7d29buXJllbIuXj1H2S6rsiJrU8rj1W559S19+/Z106ioDaplOfroo91+qQFKzBqgtWvXWmBqgB5++GH34da8P/Lzn//c3nrrLZs1a5YLhjR8/vTTT7cpU6bYyJEjq/R+jAJDogU53h+KyGsFMl4BJmrHUUcd5a71R987GZTtxvPoj7hOOnpe5O9Ff/vUxagTgS76oqeTgX6vOgnp96n966L303YVbqv+wTuBqMBX+9S+Vdyrk03r1q3dSSuycFwq6+qsrCu07GfNe05koP3FF1+UBENegKOfQVlFr9A5sjjde52CK++kF1lH5hWne6N+vAJy7TuynYfrwkXi+CaKo8B8DYD++9//2oMPPug+4JrPZ+jQoe7Dfemll7qLXH311W7un0WLFrn7qgc499xzXQDUo0cPW7hwod15552um6uqCIAQj8r+kdd9ZT914vNONt52faPzRhPFE50klc3VzzlnzpxyMwTeyCadaL3neyO9dAL2XuMdk4oyDVWl462RXJH7UjChv1VlRyeJghkFQV6XvXc78rmJesKOHKnndVkk2s8IfyVMAKS6AwUwZXXv3t1dRMWV+gOiyQ4jLV682KU4lf7UN53qIABCrJ48dFL3AhmdQLwTh06qOrnrJK9v1Op60MlYXwSq2uUQLd26dXNp6MiRVkp3a/vq1avde3qBggIxtd2ryYjMCvTs2dPtwxvNpUyAnh/5M3v1fjqJ6njoj56CibIZgMMFH3pPZR7U7aP3jMw66ITt3db767l6XWRGghM4EBsSJgDyCwEQYjH4UYCjfnqPggTVM4iyIWUzOnpcJ+jyaiX02MCBA+2zzz6rVvZDgYWGHHtz2HhBhtqntunLhuoADtcdErldFNhp35FztRBUAAjsRIhAEHmT9KmGTd1X+k+smo7I4Ee8uXCkvO4sPT548GDXDVaWai6UlVFdnLIZeg9vYjplQBTIeBPoiZd18rp1lCGRyAUH9UfHo+d6NSXedWXbvcn+ym4HAL8QAAF1wMugqLh13bp1JRN7VkZZEi+DokBEwZI3A7L2pW26KMhRd7BG8HjbvbmyFMxotIV4o348CpAiAxMACBICIKAO6npU61bdehzV1HjdRMr0RM60HFn/oovWw/NGCNG9BACHRwAERIlXgBtZWKv1eGo6M626o8rrWqqoG6nscwAAFSMAAqIU/EybNq3GMyFrjTvVBnkTimnCsPKGWAMAooMACDgCCnhUoKwpHSoLfrwRUh5vtloN89bEd6rHAQDUHQIgIIpD18ujifq8Fao1hNMbSl52ZBUAoO4QAAE1oHlyVqxYUWnwo7WUNIOwF+x4o7YAAP4jAAJqEPxogsGKqH5H8/B4c+kAAGIPARBQTcr8VESzHWdlZVHADAAxjgAIOAyNytIkg96q2xreXpYeU9ZHkw4yegsAYh8BEFBJ4KN5fFatWlUq+6OiZq3N5dGinipsJvABgPhBAASUQ8XNs2fPLvfYaCTXsccea4sXL7a+ffsy+SAAxCECIKAMzeJcUfAjWlhUw9qPOeYYjh0AxKnihYYAlFBmpyJaZ6t+/focLQCIc2SAgDLdW1p1vaz09HS3XEWTJk1KFigFAMQvAiAgIvjRzM7lUc0PRc4AkDj4KgscVFHwIwQ/AJBYCIAAM9u9e3eFx0ETGwIAEgsBEAJPq7nPmzevwuCnRYsWgT9GAJBoqAGCBX2yw1mzZh2yvVu3btahQwdf2gQAqH1kgBBoy5YtK3c7wQ8AJDYCIAS662vbtm3lrusFAEhsBEAIrIULF5a7fcSIEXXeFgBA3aIGCIFd6ysnJ6fUtrS0NLe8ha4BAImNDBACqbxRX23btiX4AYCAIABCIDVv3vyQbe3atfOlLQCAukcAhEDS2l6ROnbsaKmpqb61BwBQtwiAEDiq/Vm7du0hARAAIDgIgGBBn/unUaNGlpLCeAAACBICIARO69atDyl+BgAECwEQAqds99e6det8awsAwB8EQAiUwsJCO3DgQKltGRkZvrUHAOAPAiAEyu7duw/Ztn37dl/aAgDwDwEQAqVJkyaHbGPhUwAIHgIgBEpycrL16NGjVPDTrVs3X9sEAKh7BEAIlE2bNtlXX31Vcj8zM9PX9gAA/EEAhEDPAVT2PgAgGAiAECjt27ev9D4AIBgIgBAoXbp0sVAo5G7rWvcBAMHD/P8IXBH0yJEj3XB4jQjTfQBA8BAAIXAU9DRv3tzvZgAAfEQXGAAACBwCIARSUVGRWxJD1wCA4KELDIGjoGfu3Lm2d+9ed79///50iQFAwJABQuDk5OSUBD+ycOFC27lzp69tAgDULQIgBE69evUO2bZgwQJf2gIA8AcBEAInKSnJGjRo4HczAAA+IgBCIGVlZR2ybdeuXb60BQBQ9wiAEEjldYPNnz/fl7YAAOoeARACKy0t7ZBt+/fv96UtAIC6RQCEwBoyZMgh22bPnu1LWwAAdYsACIGVnp5+yLZwOGwrV670pT0AgLpDAIRAGzhw4CHb1q1bZ9nZ2b60BwBQNwiAEGhNmza1li1bHrJ91qxZvrQHAFA3CIAQeP369St3uYxvvvkm8McGABIVARBgZh07djzkOGiJDABAYiIAAsysa9eurjus7FxBkyZNsuXLl3OMACDBEAABEQXRRx99tKWmplrDhg1LFkzduHGjLV26lOMEAAkkxe8GaMjxM888Y1u2bLH+/fvbtddeaxkZGZW+Rt/K//3vf7ulC9R1cfnll1unTp3qrM1IXI0aNbLjjz/efcYibd682WWEOnfu7FvbAAAJkgHSCtyDBw+2VatWueBHgdCoUaMsLy+vwtc88MADdsYZZ7hv6ccee6xbvqBv3742b968Om07Elvbtm0P2bZmzRpbu3atL+0BAERXKKyZ33yiQKawsNDef/99d3/r1q0uk/PII4/YNddcU+5revToYeeee64LhETN79Wrl51zzjkl2w5Ho3saN25se/bscd/4gfKo20uZn7JGjx7NAQMAH0Tz/O1bBkhZng8//NDGjRtXsq1Vq1Y2ZswY+9e//lXh69QFsX79+pL7+/bts927d7siViCaevfufUiXF58zAEgMvgVA6krIz88/pHZH99UlVpHnn3/eBT1Dhw61888/3wYNGmQ//vGPK8wYSW5urosaIy9AVSgA8oIeXZc3XB4AEH98C4C8pQYaNGhQartG31S2DMHkyZPt888/d5miU0891dUQvfTSS/b1119X+JoJEya4lJl36dChQxR/EiQ6BT3q9iL4AYDE4VsApEBENJIr0s6dO0seKysnJ8eNEhs/frzdf//97vYbb7zhus5uu+22Ct9Lz1d/oXfRWk8AACC4fAuAlIVp0qSJLVq06JDZdzUirDzbt2933V9lly7Q/dWrV1e66reKpSIvAAAguHwLgEKhkF100UX29NNPl0w499lnn9nMmTPt+9//fsnz9LgyONKuXTuX7XnrrbdKHtdrP/jgA9cVBvjlwIEDNnv2bHcNAIh9vs4DdO+997qan6ysLDck/rTTTrOf/exnrrbHo3qff/7znyVBk4qg33zzTVf8fN5551nPnj1dJumee+7x8SdBkCnoUeCu7KSuCYIAIPb5Og+QaB6gadOmlcwEraHHkaZPn+66vs4888xSWZ85c+bYjh073KixIUOGuOCoqpgHCNGkzI+CH48K+7t16+Ym6dSEnVpio2yxPwCg+qJ5/vY9APIDARBqIwPkUVay7AKqqlPTSEXNWp6ZmckvAACCOhEikCgU0GhZFmV5dL1ixYpDnvPll1/SRQYAMYQACIhSEHTMMce464pGMXoWL17MMQcAnxEAAVHWtGlTV/cjqgEqO22DusEAAP6iBog5gVBHdULK/JRXA1TZYwCAb1EDBMRxF1kkhtADgD/oAgN8VLYeSPe1SPCaNWvcNQCgdhAAAT4qWw+kIfSaF0sBkK69IEhr5GkhYF0DAI4cARAQQ0PoywY4GzZscNsWLFhgmrJL1wqMAABHhgAIiKH6IK13F0n3tUBwJGWFGEoPAEeGAAiIIRo2f/zxx1vnzp3dte6XN6/Q1q1bfWkfACQKAiAgxijoUQCka2nWrFnJbU+rVq18ah0AJAYCICAOKBvkBT26ZjJFADgyKUf4egB1REFPbQY+2dnZtnTpUuvdu7dlZGTU2vsAQCwgAwTABT8zZsxwKyzrWvcBIJERAAFwmZ/K7gNAoiEAAuC6vSq7DwCJhgAIgKv5GTZsmDVu3NhdUwMEINFRBA3AUdAzePBgjgaAQCADBAAAAocACAAABA4BEAAACBwCIAAAEDgEQAAAIHAIgAAAQOAQAAEAgMAhAAIAAIFDAAQAAAKHAAgAAAQOARAAAAgcAiAAABA4BEAAACBwCIAAAEDgEAABAIDAqVEA9NRTT0W/JQAAALEcAN1www1WWFgY/dYAAADEagDUp08fmzt3bvRbAwAAUAdSavKia665xi6++GK76667rG/fvpaWllbq8aysrGi1DwAAIOpC4XA4XO0XhUKVPl6DXdapb775xho3bmx79uyxRo0a+d0cAABQx+fvGmWANm3adERvCgAA4KcaBUBt2rSJfksAAABifR6gnTt32vPPP+/qgDyzZ89mdBgAAEjMAGjBggVuJNg999xjd999d8n2xx9/3F588cVotg8AACA2AqCbb77ZfvzjH9vy5ctLbf/Rj35kf/rTn6LVNgAAgNipAZo1a5a99dZbh4wI69Gjhy1dujR6rQMAAIiVDFBSUpLt37//kO3KCDVt2jQa7QIAAIitAOiMM85wtT9FRUUlGaB169bZ9ddfb2eeeWa02wgAAOB/APTggw/a5MmTrX379i4IGjx4sHXv3t327dtn9913X3RbCAAAEAszQUtubq6rA9LQdwVBRx99tI0bN87S09Oj3caoYyZoAADiTzTP3zUKgBT4fPe737XU1FSLRwRAAAAE+/xdoy6wSy+91Nq1a+eGwy9atOiIGgAAAFDXahQAbd682X73u9/ZtGnTrH///jZs2DA3CaIiMwAAgIQMgJR2+t///V+bMWOGywCNHDnS7rzzTrdG2GWXXWaTJk2KfksBAAD8XgvM069fP/vJT35i1157rVsHbOLEiXbyySe7kWHz5s2LTisBAABiIQDSKLBXXnnFTj31VOvSpYv997//tf/7v/9z3WNr16513WIXXXRRNNsKAAAQFTUaBXbjjTfayy+/7CZBVEH0NddcY1lZWaWek5+f74bEa4h8rGEUGAAA8Sea5+8arQW2ePFie/TRR+173/tehfP+aIj8xx9/fESNAwAAiKmJEOMZGSAAAOKP7/MAAQAAxLOkmhZAax6gAQMGWJMmTaxBgwalLgAAALGsRjVAd911l/3zn/+0X/7yl3bllVfa3//+d5s5c6b99a9/dbNDV8eWLVtcQbWuNanihRdeaCkph2/Wp59+6mqMMjMz3Wizjh071uRHAQAAAVSjDJCGv7/00kt2xRVXuPsKWh566CF75plnbMqUKVXez1dffeWCnv/85z+uaFqB1emnn+7mE6qIRpVpssXzzz/fsrOz3eWss86yJUuW1ORHAQAAAVSjIujk5GTLy8tz1+ryWr9+vesK27dvn7Vs2dIFJVVx3nnn2fbt293M0UlJSW7+oO7du9vTTz/tgpzy/PnPf7bbb7/d5s+fb926dXPb9L4HDhywVq1aVel9KYIGACD++F4ErSyMgh9REOINd587d641bNiwSvvQPEH//ve/7fvf/74LfkTdWKNHj7a33367wtf9v//3/+ySSy4pCX5EQVhVgx8AAIAa1QDVr1+/5LaWwdBkiCqIXrhwobtfFcr2qJg6MpAR3dciqxVFfsuXL3cZoDfeeMPmzJljbdu2dfMR6boieh9dIvcDAACCq0YZIHU5ea666ip777337JxzznF1Qffee2+V9qEuKymbMVJKy3usLC9w+cMf/mDPPvuse+2HH35ovXr1sunTp1f4XhMmTHApM+/SoUOHKrURAAAkphplgMoaNWqUu1SHF/js3r271PZdu3ZV2I3mbVd317vvvluyfezYsS4r9NFHH5X7uvHjx5canaZAiiAIAIDgqnIAVFmGpazhw4cf9jmq91HtztKlS93IL4/u9+3bt9zXKHvTrl07GzJkSKntuv/iiy9W+F5arqOiJTsAAEDwVDkAGjFiRJV3WpWBZSp8Vu3Oc889Z9ddd53Vq1fPFixY4Op/3nrrrZLnvfrqq7ZmzRq79dZb3f2LL77YPvnkEzdUXoXYKshWEfbAgQOr3D4AABBsVR4GH1n3czhVnQ168+bNrussLS3NBg8e7EaFqTvr+eefL3nO1Vdf7bJPixYtKum+OuWUU9xQe2WaZs2a5YbDqRaoa9euVXpfhsEDABB/onn+9n0xVAUyKqL2ZoIeOXJkqccV2ChQ0kgzT0FBgf33v/+1r7/+2nWlnXTSSdXq4iIAAgAg/sREAKTgQ3PyeDMwq27nhhtuiIslKQiAAACIP75PhKiuqp49e9r7779vrVu3dhctZ6FtugYAAIhlNcoAad4dLVXx61//utT23//+924uoFhfl4sMEAAA8cf3LjDNBL1hwwa3/lckzemjYer79++3WEYABABA/PG9C6xPnz4lo7IiaSmMiubwAQAAiOuZoC+//HK74IIL3AzLQ4cOdfP+zJ492y058atf/apUcJSVlRXN9gIAokzzqeXl5XFc4bvU1NSSxdZrW426wEKhUJWf6/Mo+3LRBQYAxRT4rF692gVBQCxQeU2bNm3KjTWief6uUQZo06ZNR/SmAAD/6Quq/p7rG7fWR9QM/YCfn0cthr5161Z3/6ijjqrV96tRAKTIDAAQ3zSprE44bdu2tczMTL+bA1hGRoY7CgqCtPB5bXaHEe4DQEBpTUXRckRArPCC8fz8/Fp9HwIgAAi46tR1AonyeSQAAgAgSjQf3o4dO454Pyr23b59e62/JshqFABptXatBQYAAL6lFRJ++MMfHvEhuffee0stAl5brwmyGhVB33XXXS4A6ty5s40ePbrk0qlTp+i3EAAAIBYyQGvWrHHzRtx5551u7ggFRAqGunTpYldeeWW02wgAwCE0F4xGskXau3evrV+/3l10uzy7du1yF28eJO2n7D40Oq66r6uMzpXqnqpsbrx9+/ZZdnZ2lfd5uNdEtldLVG3ZsqVKxyg3N9ctdxVJ0yWoe8+Tk5NjGzduPOzvI5bVuAZIAY+CnSeeeMJeeOEFu+KKK2zdunX23HPPRbeFAABEePfdd905qGPHjtaiRQu3OoF3cn722Wdt+PDh7qJ5ZHr06GEffPBBqeP3s5/9zM4//3w76aST3BQAzZs3t1NPPdUt5H3iiSe6OZE0GZ/OcZEBi1534YUX2hlnnGGtW7e2Zs2a2f/8z/+UCgzK0uvvuece186ePXu6yftuuukmF2REBhOXXHKJe0+1+fjjj3dJhspU5TVq70UXXWRjx451P6d+5qoco6+//trat29fEgQpiNJ9rQDheeyxx9xxONzvI6aFa2DKlCnh3/3ud+ExY8aEMzIywl27dg1fddVV4RdeeCG8bt26cKzbs2ePPtHuGgCCKjs7O7x48WJ3HS+KiorCTZs2DT/yyCPufm5ubvjll18OT548udznPvbYY+HGjRuHt2/fXrL9Bz/4QTgUCoVfe+01d3/NmjXhRo0aufPZ22+/7bYtX77c3X/nnXdKvU7njj/84Q/hwsLC8KZNm8IDBgxw5z/Pj370o/DZZ59dcv+BBx4I9+7dO7xs2TJ3f+PGjeFBgwaFf/WrX5U859e//nW4c+fO4RUrVrg261yq9znttNMqPA5VeY3X3qeeeso9p6Lj+Vg5x6ht27bhv/3tb+72xIkTwx06dAhnZma64y36GX/yk59U6/cRjc9lNM/fNQqA9OYtWrQIT5gwIS4CnrIIgAAgugGQAoL9+/e769qUk5MTTk5ODn/wwQeVPi8vL88FGzpHtW7dOvyPf/yjVGBwwgknlHr+2LFjw6eeemqpbaNGjQrfcccdpV7XvXv3UsGEAia1Z+/evYcEQHpeq1atwv/3f//ngiW1Z8OGDeGHH37Y7cfTvHnz8F//+tdS7z1y5MhKA6CqvEbtHTJkSI2O0cUXXxz+4Q9/6G4r0PnFL34R7tKli0uA6Odq1qyZC4yq+vuIxQCoRl1gqvnRqu+/+c1vbMyYMfa///u/9ve//50lMgAggFTfMnfuXJs5c6a7rs11xdLT0+3222+3s846y84++2x7+OGHS41K1mLc3/nOd6x+/fo2YMAA182jYemqd4mkbq5IDRo0KHebhpZH0gLfkfPUDBw40E0oWV6XlWYz1uW3v/2tHXPMMW7x8GOPPdb+8Ic/lExCuXPnTte+/v37l3qt9luR6ryme/fuh2yryjEaPXq0TZo0yd3WtTfYSbfnz5/vusVOOOGEw/4+YlmNAiAFPpMnT3Z9fI8//rhbGkP9ger/69OnT/RbCQCIWapH8Yppda37tUkBxVdffWXnnHOOffbZZ+68849//MM99v3vf9/69evngoRt27a5k7rOUV7AcaRU/FzefQUCZXnLODz99NMlRcfeZdWqVaVeV9F+y1Od16SkHDrYuyrHaPTo0bZy5UoX7CxevNgFTNr2ySefuCBIgZNqoA73+4hlRzQRonfgVPy8du1aV/1dUdU9ACAx1atXzxo2bOhu61r3a4uXXVJRroqUX3vtNZd5+Nvf/uZO4F9++aUr/FX2RlasWHHIiKYjMXv27FIFzFOmTHE/s4qAy1JBsDIwb7/9doU/h7IwXbt2talTp5Y8pkqTyPtl1eQ1nqoeo549e7rCaQU3gwYNcsXbKhBXgPP++++7YOhwv4+EnAfo6quvdhGgosN27drZqFGj7Fe/+pU7IKomBwAEh1aRHzx4sMv8KPipzVXldaJWBkMjnNQFpC/hOilff/31LuOidvzpT39yC2nqS/pPf/rTqL6/hrLrRH/bbbe5KWF07rv55psrXE/tgQcesHHjxrlRYxpBpmP00UcfufPnU0895Z4zfvx4t49u3bq5biz1qCxbtsz1qlSkJq+R6hyjUaNG2SuvvGK//OUv3X11EWrUmAIglb4c7veRkAGQfoG33norAQ8AwFHQUxcryuskfN9997kT+MKFC61p06Z244032s9//nP3uHfCVk2KhrfrRK1tXrZD1HVTdr4aPVeZlbIZHA0zj6Sh4L169XKJAPV4XHfddXbHHXeUPK72RHYBnnvuufbhhx/agw8+aK+++qrb5ymnnGJ//OMfS56jfWk+nwkTJlhqaqo7tyqwUoBVkaq8pryfs6rHSDTE/9NPP3Xt9Si788Ybb7j6n6r8PmJZSJXQFjAqamvcuLGbtElpPQAIIp2oVbyrSWxrs9sqUWi+OwUU8dC9k6ify2+ieP6uUQYosi9UE0cphtKoMFW5AwAAxLoaBUDqM1QB1ccff1ySMlMqTkPilUZr2bJltNsJAICvKupSQnyqUaXaT37yE7f2iPr71Aeqi25r7RQ9Fi9UvQ8AQFU89NBD9sgjj3CwgpwB0rofX3zxhas+j5wcSv2iQ4YMsXjiTfAEAACCo0YZoPz8/EOqxUUV9JVN3gQAABC3AZCGv2n+gchJD1WZrbkEvKFx8SCnoHgA3NKlS/1uCgAAiPUusD//+c9ufgDNEuktfaHRYCp+fu+99yxePL4g1245vr5t3rzZTejozWQKAAASW40yQJoESgHPX//6VzvppJPs5JNPdre1TY/Fi6U7i+z5L/PcMP45c+b43RwAABDLGaDvfve79s9//tMuvfRSi2daz3fKhgI7qkHIzuiSRkE0AAABUaMMkFaD1ZD3eHdBr1R3/fqyfJu/raBkVBgAIDHde++9UZ+upTb2WZX9/vrXv3ZrgsWyWG5jjQIgrQvy5ptvWrwb3T7FXVQK/fj8XNuyv3hVW4IgAEhMGzdutK+//jrm91mV/Wrh0XXr1lksWx/DbaxRF5iKn7Ua7jvvvOOWwCi7Cq4ivngQCoXskr5ptm5vka3cU2SPzsu1O4bXs7TkkE2ePNmthAsASBy33367m8ol1veJGA2AVDCsdb8U2elSVrwEQBkZGZaUFLIbB6fbndOyXSD0ytI8u7xfuiuMBgDEHp1jFHBo9K4m5tWULBdeeGGp7iLvOe3bt7fXX3/djfLVc5999lnbsmWLG83sPU/LW3Tu3Nl9qdeyTqpz1WrmycnJJfubMWOGPfzww/bVV19Zz5493Qrw3ijo8vZ5uPY98cQTJbNKa3HPo48+2r2udevW1ToWOldpP9U9Dk9U4f2jcWy8Nj722GOV7iNuAqDp06dbIlAQpxmtm9ZLsmsGpNtDc3Lt43UF1q9Fsg1pnWKff/65jRgxwu9mAkCd0IkqO7/Ql6OdkZrssvJVoS/eL730kp1++un2q1/9ynUT6aSvE/0vfvGLkue8/PLLdv7557taGu/Erm6lyC/u3vO+//3vu0yOHr/22mvdZL833HCDe46mdzn33HPtpptushtvvNG95vrrry8plyhvn4drn/Z33HHHuds7d+60Rx991K1KoGWlUlKqfmp+7bXX3Dx81T0O51bh/aNxbESBV2pqaoX78MsRrQafCIYPH+4CugEtU+x/uhTZe6vz7blFudatSZI1sVzXd9mhQwe/mwkAtU7BT9873/flSC+++zTLTKv6KalRo0b26quvWmZmpruvzIIyDwoAdLL1yjVeeOGFwwYUWtZJWRwvAJs6darLkngnaGUrVPbxwAMPlLzmvPPOO6L2ad68yIXDFYy0atXKlV9oepnaPg4tq/j+0Tg2h9tHXBVBJ5J69eq5IEh1TOf1SLUODZNsb77Zs4uK5wdauXKl5ebm+t1MAECEYcOGlZz0ZcyYMS6TEVk0rG6dqmRTBg4cWCr7pIBh69at7vauXbvcHHfqtonkBRc1bZ+6q+655x43qEjvP2jQINu/f7+tXr26To7D3iq+fzSOTWX78FPgM0BeEKToVym76wak212fZdv8bYX2+aZCO65tcVcYC6YCSHTqhlImxq/3rtbzMzJK3feCAJ3Ey247nPKCJK8ONCcnp1r7qmr7Lr/8ctcddNttt1nHjh0tPT3ddZl57xet96mo7ZdX8f2jcWwq24efCIAijBw50qXmzu6eam9+lW8vLcm1fs2TrXF6yKUVy1sAFgAShb6lV6cbyk+LFy8udf/LL7907e/SpUtU30c1M02aNLG5c+dW64twZe0rLCy0f//7365+RhkbLyNTk6xITY5DtN6/dQ2PTayIahdYdSPXWONFqf/TJdU6Nkyy/flmLy8p7v6aPXu2z60DAHi0iPWTTz7pbqsI+De/+Y0bAaWamGhKSkpyRb2qcZk3b57bprKI++67r8bt0+inZs2auS/coqJlr3i5Lo5DtN4/qYbHJiEDIKXijj/+eJs1a5bFK/VNpiSF7KqsNLdUxozNhbZ4R/GoCI0YAwD4T/O0PfPMM+5vtjIRynr86U9/qpX3uvvuu+2iiy5yo4LVXXTUUUe5k/+RtE/rZz700ENufy1atHB1O7pdV8fhr1F6/5ocm1gRCkexI07j/FVApbTaggULLFYpSta8B3v27DkkStacB15U/OLiXPtobYG1rR+yu4/PcIHR0KFDrX79+j61HACim7XX32x1l6gWMl5cccUV7m/13/72N3fiVvdNp06dSj1nw4YNrs5E899E2rRpk8t0eCf78p63fft2d37Q6KVIWgJKdTN6r8hC37L7rEr7vGyJRhorG6OL5tFp3ry5u13efsuKbHt1j0NV3j8ax6Y6+6jK57Ky87evAVC8ONwB1AdXfZpbd++z26YcsL15Zhf2SnNdYxKPfZ0AkIgBUCyK9fbFupw6CoBqnKfS8LdFixa5i24nEtUCuUxPasjG9Sxe5uMfK/NsX17pyncAABCfqlXuv23bNlds9corr7jAx0seqc+xf//+dvHFF9vVV1/t+hMTgeqZiqZOtQ++LnDLZLyzMs8u6ZPuJk4kCwQA/tD8NbHceRHr7UM1M0D333+/66/7z3/+Y5deeql99NFHbridLrqtqbI1s6OeEzkjZDxTP2ZSKGQX9SrOAn28tsC2HiheMV59pQCAuqc1tsqraYkVsd4+VDMDpBFQM2fOtN69ex/ymFaEP/HEE+3WW291Q/LuuusuSxTqf+zXIsf6t0i2hdsL7a2v8uy6gfVcYVePHj38bh4AAKjNDJDWGikv+ClLz9FzE4Wm8JYLehYXQM/YVGgb9hVngWJ5pBsAVBXdNQji5zE+Buv7SHMbaY2Ujo20Qnyy6dfyzoo895iGHQJAvNKEeJKXV/w3DYgFGlJflfXWjlSN5jz/6U9/WuFjWk+ka9eudu6557qVZROBpvqWc7qn2Zwt2TZrc6Gt31tk7RsmuaGOVVlsDwBijf52aR0nDXBxNY9xMoEdEjfzc+DAAbckh867XoBeW2o0D9Bpp51mH3zwgbVs2dL69evnRoEtXLjQTW50wgkn2KpVq9yETFOmTHGjw2JNTecR0GKpj87NsdlbCu3YNsl2w6B6JWuIEQQBiEfK/mjOlaKi4q59wG8Kftq0aVNqBfnamAeoRqmL7t27u4um205LSyuZUVKZIUVsH3/8sd14443285//3AVKieTs7mk2+2AWSCPCWmUmuRFhffr08btpAFBt+huuAR10gyEWKBNZ25mfI8oAaXjf/Pnz3ZTZkZQBGjx4sJtaW1NiK/uzY8cOizU1jSD1Oo2Ge3B2jhsRdlLHFLusb7p7jHmBAACoXb7PBK2Zn7ds2XLI9s2bN5fMCq0oTgXEicQ72N6SGFPWF9jeg7NDAwCA+FGjAOjss8+2cePGuUVPVTyngiXdvvDCC+2ss85yz5k4caJ7XqLJysqyPs2SrFOjJMsr0uSI+W67sl4AACCBAyCt+n7MMcfYd7/7XTfSq3Xr1u621s/SY95MmJo9OtFomQ8VZnlZoA/X5lt+UdhWrlxZblYMAADEniNaDV7z4CxfvtwFBCqia9asmQWhD1GjwQqLwvaLydm2Kzds1w1It+Fti+vJqQUCACBBa4A8CniGDx9uw4YNq3Hwo+HyL774ov3xj3+0999/v1qv1Tpkv//97+2///2v1SUNe09OCtnoDsVBz8frirvBAABAfKjxDH5KHGnuiLVr17rJACOdfPLJVdrH+vXrXTChbrQhQ4bYQw895FZgf+2118od/x9p//79dsEFF7h9XHXVVXbKKadYXfHm/DmhfYq9szLflu8qcqvFd2iY5IaSelMDAACABAqA1qxZY+eff77NmTOn3Mer2qumxVM1meK0adPcqDHNI6SJFd988023/8rccMMNNnbs2DrP/ng078+SJUvs6FbJbmLET9bm2+X90u3zzz+3UaNG+dImAABQi11gClQ0x4835D07O9smT57sggKvCPpwCgsL7e2337bLL7+8ZL2PXr162Xe+8x174403Kn3tSy+95BYiveeee8wvKvyWMR2L2/7ZxgLLLgizqCAAAIkaAE2dOtXuvffekjWy1CWkJTD+9re/uVqeqlDXmdb86NmzZ6ntur906dIKX7dixQq7+eabXRBU1a4mzVKtwqnISzRoDR0NiW+TGbKcQrNZm4u7AmNx8kcAAHCEAZBO8EcddZS7rdmgveHfyuAosKmKffv2uWtVc0dSUOU9VpbqazTX0J133ml9+/atcnsnTJjg3se7dOjQwaLh2GOPdbVKI9sV9yRO3VAcAGldNAAAELuOeOlfFS9rTTDNAq3rLl26VOl19evXd9dlszEa2uY9VpYyTJpvR11vGv2li4KvmTNnutsV1R6NHz/e7de7RHPSwrZt29px7VJMJdsqhtb6YMLEiAAAJFgAdMkll5TcVleYhrErI6SJD6vaBdaxY0e3VIa6tCJpYVFlksqjAmktspqTk1NyUdCjeiLvdnnS09PdfAGRl2hRl12zeknWt3nxoZx2MAukQA0AACTQRIgaeq4FUT35+fnuhK9tu3fvLvVYZdSdpS6zKVOmuDoi7aN3794uoLrooovcc959913bsGGDXXvtteXuY9CgQW7ywYcfftiXiZS8iRFVBP3EglxrmRGy+0/IsKRQiEkRAQBIpIkQy9bQaBSXApcGDRpUq75GGSMFQCeeeKIrbNb16aef7tYZ82hNsUceecRiWdOmTW1I62Srl2y2LTtsX+0q7gbTkHgAAJBAEyGWR6O6qrMCfOfOnW3RokX2+uuvu1oeBTpaTDUp6du47Mwzz7SBAwdWuI9rrrmmynVHtUXt2zVpkg1tk2JTNhS4bFCvZslu9BkAAIjzAOjXv/51ubelqKjIvvjiC9clVd3sSUXdW3LOOedU+vof/ehHFgu0FMiItttcADRnS4Fd3jfNLZcBAADiPADS/D/l3fa6wZTR+eUvf2lBNGDAANu2/RNrmGq2N99syc4iy2qRfEi9FAAAiLMASMW+omUqDjdbcxAp4zOkTYpNWldgMzcXuABIo9wIgAAAiC01KoIuL/gpuyBqEGlSxGPbFMeU6gYrKKr2ADsAABBrAZBmaH7iiSdKbXv++eetRYsWbvLC8847z/bu3WtBNWLECOvVNMkapZntVzfYjkK3XcP4AQBAnAZAjz76aKmlLlatWuVGYZ100kluSPv8+fPdxIhBpbXJ1A12TOviLNDMzYUlkzsCAIA4DYBefvnlUrNAv/XWW27en7///e9uhfjnnnvObQs6DYeXL7YWWCHdYAAAxHcApILeyDl3pk2bZqeddlrJvD1aF0yjnoJs6NCh1rNpktVPLe4GW7G7qGQhVwAAEIcBkGp9li1b5m5r/S0FQKp78WiRUs3rE2SqhVI32MCWxVmguVuLi8M/++wzn1sGAABqFACNHTvW1fyom+umm25yRdFausIzZ84cGzZsWHV2mbAGt0p213O3Fla4SCsAAIiDAOh3v/udy3B873vfs2eeecb+8pe/WMuWLUse11IWWq096LTSveYASgmZbTkQtk37CYAAAIjbiRDVBfbJJ5+4VVgzMzPd7M+RXn31VWvevLkFXdeuXd1ouT7Nk23h9kKbt7XA2jZIc8dNq9gCAIA4yQBt27at5LZO4mWDH/GCn8jnBpUWhY3sBnPXc+f63CoAAFCtACgrK8vuuOOOUvMAlbV69Wq7/fbbrV+/foE/uoMHD7ZBBwMgjQT7Jo9uMAAA4q4LbMaMGXbrrbda9+7dXTCkIe+tW7d2Bb6bN2+2WbNm2ZIlS9xs0DNnzrSg06SIzeolWadGSfb1N0W2aHuhHdc2xdatW+fmTgIAAHEQAGmld9X4rFmzxl577TU3BF6jvrT+lRb7vOyyy2zcuHHWqVOn2m1xnOnfItkFQAu3FbgAaOXKlQRAAADEUxG0FwjdcssttdOaBA2A/rUq32WAisJhSwqF/G4SAACBV61h8JrNePz48a7Gp2/fvu42MxxXbNCgQdatSZLVSzbbm28uEwQAAOIsALr77rvd3D/Dhw93M0DrtuYGQvmaNGliKUkh69eiuBhaQ+Jl586dHDIAAOIlANKipxMnTrSnn37aXd544w23DYfvBhN1g8mCBQs4ZAAAxEsApBFMo0ePLrk/ZsyYSofFo3j6AM0K7Q2H35/PcHgAAOIqAMrPzy81AaKGemsbKp89u0VGkrWtH7KisNniHcVZIGqnAACIo1FgZ5555mG3/etf/zqyViVoN9jG/QWuDmhomxS3OnxkNg0AAMRoAKRFUKuyDaVpbqS+21ba+18X2JKDGSAAABAnAZCKnlF9Xbp0sV4r11hyyGxbdti2HiiyVpnV6n0EAABRxFm4jtRLCbk5gcSrA8rOzq6rtwcAABEIgOpQn2bJpQIgra8GAADqHgFQHWnXrl3JhIiqA9KyGAAAwB8EQHWkR48e1rVxkqUfXBZj/d7iZTGKilgeAwCAukYAVIe0LEavpsVZoC93FAc+69evr8smAAAAAqC617d56TqgVatW8UEEAKCOkQGqQ8cff7z1bV58yJftKrQCTQ0NAADqHAFQHdIyIu0bJlmDVLO8QrPVe6j/AQDADwRAdX3AQyHrdXA4/JKddIMBAOAHAqA61rZt25L5gJYeDIDWrl1b180AACDQCIDqWNeuXUsCoBW7iiyfOiAAAOocAVAdS0lJsbYNQtYozSyvyGzVbuqAAACoawRAPgiFQta7TDfYwoUL/WgKAACBRADkk95lCqF37NjhV1MAAAgcAiAf9OvX79s6oN1FllfIfEAAANQlAiAftGzZ0trUD1mT9JAVFJmtpA4IAIA6RQDkax1QUqk6oJUrV/rVHAAAAoUAyEdlC6HXrVvnZ3MAAAgMAiCfdOvWrSQAUhcYdUAAANQdAiCfdOjQwVpnHqwDClMHBABAXSIAirE6IAAAUPsIgGKsDmjOnDk+twgAgMRHAOSjYcOGHVIHtHfvXj+bBABAIBAA+SgjI8PVATU9WAekSRGFIAgAgNpFABRDdUDeshh0gwEAULsIgGKA1w22jEJoAADqBAFQDOjT/Ns6oFz1hQEAgFpFAOSzvn37WsuMkDWvFzKtifrVbobDAwBQ2wiAfNaqVStXB+RlgRbvKC6EzsnJ8bllAAAkLgKgGNGnzISI06dP97lFAAAkLgKgGDB69OiSQujVe4rsQD51QAAA1CYCoBjRPCPJzQmk0GfZruIsUEFBgd/NAgAgIREAxZA+3rIYO4oDoK1bt/rcIgAAEhMBUAzp7RVC7ywuhF6+fLnPLQIAIDERAMWIbt26lWSA1u0tsr151AEBAFBbUsxneXl59tFHH9mWLVusf//+NmTIkMO+Zu3atTZjxgxLSUmxY4891tq1a2fxrkOHDrZy5Upr3yBk6/eFbfGOQht2VIrt2rXLmjZt6nfzAABIKL5mgLZt2+YCnp/+9Kf27rvv2sknn2zXXXddhc8Ph8N28cUXu1FTr7/+uj399NPWo0cPe/jhhy1R9GtRnAX68mAd0Pz5831uEQAAicfXDND48ePd9dy5cy0zM9MtAjp06FD77ne/a2PHji03ADr77LPtpZdesqSk4tjtxRdftCuuuMK9Rt1I8S6rebK9v6bAFm0vdD+vJkkEAAAJkgEqKiqy1157za688koX/IiyQccdd5y98sor5b5GQc9FF11UEvzIaaed5va1bNkyi3dZWVnWs1mypYTMduaEbfN+6oAAAEioAGjdunW2d+9etxZWJN3/8ssvq7yff/3rX5acnGwDBgyo8Dm5ubn2zTfflLrEohYtWlh6csh6NC3+tSw62A1WWMj6YAAAJEQA5AUhTZo0KbVdBb9VDVCWLFliN998s7u0b9++wudNmDDBGjduXHJRwXEsy/LqgLYXBz4q+AYAAAkQAGVkZLhrZYEiKfjxusQqs2rVKjv11FPtjDPOsPvuu++wtUZ79uwpuSj7FMvdYP0OzgekdcEKisJupBwAAEiAIuhOnTpZWlqarV69utR23e/evXulr9VzNBJM9UIqgo6sCSpPenq6u8QDdYN1bJRkDVPN9uabrdxdZL0Ozg8EAADiPAOUmppqp59+uit41mgn2bhxo33yySd21llnlTxv8uTJrljas2bNGhf8jBgxwo0GU/1PokkKhazvwSyQVwc0depUn1sFAEDi8HUY/P333++yOBraPnz4cHvhhRds2LBhdumll5Y8Rxme6dOn27hx4ywnJ8dOPPFEd33CCSfYU089VXpF9d69LREoW5XVIt9mbC60hdsK7Xs9WBgVAICECYAUsCxYsMAFPpoJ+he/+IVdfvnlbobnyMBG3WXeaCgNe5eFCxeW2pdmkU4Umg5g6zfTNE+2rfmmyHbnFFmTeqxaAgBAtITCXv9TgKjQWqPBVBDdqFEji0WTJk2yuz/PtlV7iuzKrDQb1T7VDfVv1qyZ300DACDuz9+kFWLYwJbFdUDztxbXASlbBgAAjhwBUAwb1OrbdcHyCgOXqAMAoNYQAMUoTRDZsWGSNUkPWW6h2bKdxVkgLfsBAACODAFQjBo0aJBbCHXQwW6weduKA6Bdu3b53DIAAOIfAVCMG3iwG2z+tuLV4cuOfgMAANVHABTDjjnmGDchYmqS2fbssG1kdXgAAKKCACiGNWjQwK0O3+fgrNBzthT43SQAABICAVAcGNq6OACatbm4Dmjfvn0+twgAgPhGABTjunbtaoNbpVhyyGzd3iLbuK/IZs+ebfn5+X43DQCAuEUAFOPatWtnDdJC1u9gN9iszQUli8ICAICaIQCKcd5q90PblA6Atm3b5mu7AACIZwRAcaBXr152dOvibrD1+8KuGywvL8/vZgEAELcIgOLAUUcdZfVTQ9avRekskBaDAwAA1UcAFCd69Ohhxx7sBpt5MABiUkQAAGqGACiOskBD2qS5brAN+8K2fm+RtWnTxu9mAQAQlwiA4kRSUpJlJIdtwMG1waZuyLf169dbYWHx3EAAAKDqCIDiSFZWlp3QPsXdnrahwAqKwjZz5ky/mwUAQNwhAIojLVq0sAEtkq1Jesj25pvN3Vpoubm5fjcLAIC4QwAUZ5KTQjayXXEWaPL64mLoggLWCAMAoDoIgOJMp06dSrrBvtxeaNsOFNnUqVP9bhYAAHGFACjOKNvTKjPJ+jRLsrArhi7O/syYMcPvpgEAEDcIgOIwAySj2qe66ykbCqwoHLbs7GyfWwYAQPwgAIozaWlp1r9/fzu6dbLVTzXbmRO2BduKh8IfOHDA7+YBABAXCIDiUNOmTS0tOWTHty2uBXp/Tb67Zkg8AABVQwAUp5MiDhgwwE7tnOpmhl6ys8hW7S7OAu3bt8/v5gEAEPMIgOJUs2bNrH3TTBt+VHEW6N3VxVmg2bNn+9wyAABiHwFQHOvataud0aW4GPqLLYW2cV+Ru83yGAAAVI4AKI41b97c2jVMssGtkt2Q+PcOZoE2bNjgd9MAAIhpBEBxLDk52Xr06GFjuxZngT7bWGA7sots1apVzA4NAEAlCIDiXL169ax7k2Tr3SzJCsPfjghbuXKl300DACBmEQDFuSZNmrjrsQdrgSatK84Cbdq0yfLy8nxuHQAAsYkAKAG6wTIyMiyrRbL1bJpkeUVmry0rDnw+++wzv5sHAEBMIgBKAFlZWRYKheySPmkW0rpgmwtt2c7ieYG2bt3qd/MAAIg5BEAJoH79+m6NsE6Nkm3UwZXiX1qS59YIW7x4sd/NAwAg5hAAJYiOHTu66/N6pllGitnavUX26frileJVDwQAAL5FAJRAtUDDhg2zRmkhO697mtv25vI8258ftmXLlllRUfEkiQAAgAAooagYeuDAgXZixxRr2yBke/PNJn5VXBC9aNEi5gYCAOAgMkAJuFJ8SlLILumd7u5/uLbAFmwrsJ07d9rUqVMJggAAIABK3KLofi2S7aSOxQXRTy7ItV05xV1ga9eu9bl1AAD4jwxQAhowYIC7vrBXmnVsmOS6wh6bn+tGhSkAoh4IABB0BEAJKD093QVBackhu2FQuqUnmy3bVWTvrCheJmPNmjV+NxEAAF8RACWoZs2a2ZAhQ6xN/ST7Qb/ieqB/rMy3JTsKXRZoz549fjcRAADfEAAlsIYNG9pRRx1lx7VNse+0S7GwmT22INe2HSiyuXPnEgQBAAKLACjBde3a1V1f2ifN2jUI2Z7csD0wK8d25hQHQdQDAQCCiAAowaWmptqIESMsPSVkvzimnrXKDNm27LDdPzPHducU2aeffmrTp0+37Oxsv5sKAECdIQAKSFH00KFDrWm9JLt1aD1rXi9kWw6E7YHZOfZNXthycnJsxowZBEEAgMAgAArQ3EC9e/e25hlJduux9axpesg27gvbH2bl2L48VQeZLViwgC4xAEAgEAAFSJs2bdylVWaS3TK0nls3bN3eIrt/Vo4rjFY32LRp05gtGgCQ8AiAAqZ79+7u+qgGxd1hDdPMBUF3fZZt87YWWGFhoVsyQ0PlCwqKV5MHACDREAAFTEpKig0fPtzdbtcwyX4zIsO6Nk6yAwVmD3+Ra28sz7PCorCtWrXKBUJ79+6lWwwAkHBC4XC4uAAkQL755htr3LixmwenUaNGFkT5+fkuyNm0aZMVFIXtlaV5buFU6dMsya4bWM8ap4fc/eTkZBc0aUQZAACJcP4mAxRQCmZ69eplxx57rFs9/tK+6XbdwOJlM5bsLO4S+3xjgVs/TN1iqg3Kzc31u9kAAEQFGaCAZoAiqdZH3V2ycV+RPTovx40Qky6Nk+yiXmnWq1myu9+iRQvr2LGjNWjQwJKSiJ8BAPGZASIAIgByNCP0ypUrbcOGDZZXGLb31+Tbu6vyLaew+PEhrZPtgp5pbm0xT+vWrV1RNV1jAIC6QAAUQwcw0YIgzQzt0bIZb6/Is0nrCtw6YskhsxM7pNgpnVKtdUQg1KRJE+vSpYtbe4ysEACgthAAxdABTMQgaPPmzbZ8+fKSbRv2Fdmry/JswbaD6aCDhdIntE91maE0RUYHKQjKyspydUP16tUjIAIARA0BUAwdwESlAEZzAX399dcl2xbvKLT/rM63hdsLXUZI6qeajTgqxUZ1SLUODQ+tCdJq9Jp8UZkhXTIyMgiKAAA1QgB0hAiAqm7fvn02e/bsUtt2ZBfZ1A0F9un6AtuR8+0sCgqA+jVPtn7Nk6xns2RLj8gMedLS0tySHLt377bmzZu7YCgUCllmZiaBEQCgUgRAR4gAqHo0/H3ZsmVuqYzIVeM1RF5ZocnrC+yLLYVWGDGjVErIrEfTJOvrAqJk69w4yZJChwZEJc9PSbF+/fq5zFPTpk3d3EMAACRsAKS3V4Zhy5Ytrnakc+fOtfKaSARANaeZoefMmXPo9rywLdpe6AKiL3cU2s6IzJBkpJh1apRk7RskWfuGxdeaiTpDkVI5evbs6VapVxeaRqYpE6UPvVa2Vxv0Oz/SOiPVOx04cMBloJSZ2rZtm7Vq1coFYwCA2JMwAZB+kDPOOMMNv1a3yMyZM+1nP/uZ/f73v4/qa8rbBzVAR54V+vzzz8t9TB+pLQfCLhBafPCSXcGyYi0yQiVBUevMkFutXivVN6sXsvQKgqNIyhQpCNZcRl4wdLg6IwU+ymQtWrSoVEbL06xZMzdTtgItBUYa5aagSLcVlGnEm4Iv3dd/Qn2WtB8FaTt37rSuXbva/v37XbBWv3591xa9p16rNooCL+1Dr9F/YrVZ3YJ6jQIy3dc+dVuv0fHWY7r2fs7Iffo9+q6ituhn1M+l4nh9YfHmklJ9mX5u/d50/PRzeq/3jhkAJGwAdNNNN9l7771ns2bNcieZyZMn2+jRo+2jjz6yMWPGRO01ZREARe+kp2O5ceNGd60TWHm0tpgWXF2/r8jW63pv2N3enVv5R08F1i4YykiyZukha1ovZE3qhaxBasgyU0LWIE3Xel7IzWCtk6joWoXXClC8IELtUxCjE6v+49QVvadO6gqI9F9NbdFFx+5ItG/f3o3WUwCheZgUBKqOSkubKHBTYKj7Og66r/8rogBN7dBjkUHWkRSn62eZO3euex8FOoMGDXIB3q5du9xyK9WlQK9t27buWsdPbVfgp/eJDHD1syuo0h/ByKAplgJDANGVEAGQ3lZFsLfccovddtttJdu1NIP+mD/zzDNReU15CIBqT15enqsX2rFjx2Gfuy8v/G1QtK/Ith8I286cItd95k3AWFWqt1bAlJkasvopoeKgKMUsLak4OEpzl5C7Tk8KldwvfixkqUlmyUnFtUvJSaGD12Yp2h4KHbz27n8bbCF2eJmyyv6k6femxxU0KssnCpIUuHlBqm4r8FKQqGBKf3O8DKMeV9ZO3aV6XNks/T3R++o1+qOsCUK1ffv27XSpAlEWzfO3b8UO69evd98QBwwYUGq77s+bNy9qrxH9cYpcx0oHELVDWZf+/fu7rg9lG3TclSFSRqAsZXB6N0t2l7IO5IdtV07YduQUueudBy+anHF/ftj2FxRfH8g3V3ytyzd5uujkV/sxfXEQZJaki06i3u2DwdGh2759rssCuWsrvtYOI26XbD94LXqtldlW/LJvN5TsK2J/kbx9lnXI8w4T21U19KtsP7UTPpafgSz/fcs+N/Lzub/MYysq2ePKcrYVd/V5WrZsaSEyUYFw33n9rb6+eSEu+Pab8rohNOInkr5tqWYgWq+RCRMm2G9/+9sotBpVpS4Y/eH3umsia0EUyG7dutV9U/ZqaCLnGxJlcnRRoXRl9I08t9CKgyJ3MTtwMDjKKzS3rIcezysqvq1tuQev84q8+2b5heGSQKqgqPh2QZG678wKyomnCiuNsw4XgPk67gB1bfNmjnlA/P7sLL+bgHgIgNS/L2UzA0ove4Wi0XiNjB8/3m6++eZSGaAOHTocUftR/YBIgaqoSFiXSFpgVUGRug1UhKxuCQVMCpzUNVFesbK4IuEUs3opKqCund+Kgqxvg6ODGaeisBWFrfTFTQ1QPD1AuJzt3raw/rnrg5eDt0WPR15X9DyvXSW3Dz4eeT/yWjfKC7vK9hZVJ3Srjc7zWg0NfYo7u3brSi1SQKSrLx1xw7cASAGI+sw1GiSS7pc9OR7Ja7zAyQueELsBkoa86+KJvB05bF21G8oiqfBVnwdt90ZdKWjSNhXkKlNYWfBUVQqyVBOk/yyqGTq49Yj2mai8GhtvlNrhfud6rn5v+l2pq1SvV7++tuv3rGLmyEBPX3QqKrZXcbRXLH249lEDBMDXUWCnnnqq+0P07rvvuvsqnFWQ8+CDD9r111/vtmnOGdWSnHLKKVV+zeFQBA0AQPxJiFFg8sUXX9h3vvMdGzdunI0YMcKefPJJ961vxowZJRmbq6++2qZPn+7mbKnqaw6HAAgAgPgTzfO3rx2WRx99tMvwKP2t+Xy+973v2ZQpU0oFMsccc4zL+lTnNQAAADG9FIYfFDlqcrV169axGjwAAHHCG8Skek9lgo5EICcs8CbpYyQYAADxeR4nAKoBDbP2Ro8d6QEMMi8SJ5PGsYwlfC45jrGGz2R0e3A0bYp3Hj8SgcwAeesDKfg50iIqmDuGHMfo4FhGD8eS4xhr+ExGTzTW+WPWJgAAEDgEQAAAIHACGQBpyPxdd93F0HmOY8zgM8mxjDV8JjmWif65DOQweAAAEGyBzAABAIBgIwACAACBQwAEAAACJymIs0fOmjXLNm/e7HdT4poWoNUCtatXr7aioiK/m5MQlixZYlOnTrXc3Fy/mxLXVq5caV9++SWfyyNQUFBgX331lc2dO9d27doVvV9OAGzbts39P965c2eFz9m4caM7D3FsK7d48WL77LPPKnz8wIEDNm/ePNuwYYPVSDhA7rzzznB6enq4b9++7vqHP/xhuLCw0O9mxZXs7OzwLbfcEm7WrFk4Kysr3LZt23DPnj3D06ZN87tpcW3+/PnhzMxMDUgIr1692u/mxKW5c+eG+/fvH27VqlV4yJAh4X79+oXnzZvnd7PizieffBLu2LFjuEOHDuHBgweHMzIywtdccw1/Kw9j4cKF4YsvvjjcunVr9/944sSJhzwnPz8/fNlll4Xr1atXch665557autXGbdeeuml8NChQ8NNmzZ1x6iszZs3h6+88spw48aNw4MGDXLnoxEjRoRXrlxZrfcJTAbonXfesQkTJtjHH3/svh3Onz/f3njjDXv00Uf9blrcTUPevHlz+/rrr23hwoVuOZHRo0fb2WefTeaihvQt5uKLL7Ybb7wxur+sANmyZYudfPLJNnLkSPftevbs2e7//KZNm/xuWtz5wQ9+YGPGjHH/x7/44gubPn26PfPMM/baa6/53bSYpvPK2LFj3XVFHnzwQXvvvfdcZkPP+/e//2133HGHffDBB3Xa1li3dOlS+8tf/mIPPPBAuY9r+aUTTjjBtm/f7rKUOg9lZGTYpZdeWr03CgfEWWedFT799NNLbbv66qvDAwcO9K1NiWL27NnuG4+yGKg+fZO58cYb3TdvMkA1M378eJf5ycnJ4SN4BIqKilwm8rHHHiu1rUmTJuFHHnmEY1sFe/furTADpGz5T3/601LbRo4cGb7wwgs5tuV48skny80Alee5554LJyUluSxbVQUmA6QocciQIaW2HXvssa6ORfUsqDn1ZScnJ1vnzp05jNX0yiuv2IwZMyr8poOq+eijj+yUU05x6wPp/zq1aTUTCoXsnnvucZ/Hl156yWUmrr76auvUqVP1v12jlP3799vy5cvLPQ/pM4sjPw/pc5qSUvUlTgOzGKoK0tR1E0n3CwsL3Uq9ZR9D1QtOb7/9dvvJT37Cgqg1OHY//vGP7cMPP3TpW9Scur3atWtnWVlZ7lhqkIP+T7/88ss2cOBADm01nHXWWfaPf/zDbrnlFmvZsqWtX7/e7rvvPmvatCnH8Qh4Bc/lnYcqK5jG4U2aNMkef/xxe+KJJ6w6AhMApaamWk5OTqlt2dnZ7jotLc2nVsX/See0006z4447zv2BRPVcc8017vjt3bvXjRpRTZWofkUj67p27cohrcb/73fffdemTZtmxxxzjOXl5dmFF15oF110kRtdh6rR30jV9J155pkuMFdGTVny4cOHu2/WV1xxBYfyCD6j3jEuex7iHFRzc+bMsXPOOcd9Cb/yyiur9drAdIEpNVZ2qJzuN2nSxBo2bOhbu+I5+DnxxBOtV69e9uabb5b850bVtWrVytasWWO33Xabu3jfXu6//35XwIuqU/erAh9dRCeUq666yhVTqlASVaPBISowvf76613wI8qqjRo1ymWFUHPKpmVmZpZ7HurYsSOHtgZUpK+ubwU+f/zjH6v9+sAEQDpIqrhXl5dHJxltR/VoZI2Cn27dutlbb73Ft5cjqP9R5se7aNSDvP766/azn/2Mj2U1KJOmz2XknFTqulEg1KhRI45lNU7S3rGLpPveY6gZBZQaXRcZSCpTqVFhnIeqT/P/6Lhddtll9qc//alGv5PAdIHdfPPN9sILL7iU+OWXX+7S5TqA6jdE9YbBn3TSSS6Q/PnPf+4Kzzz6pqiMGlDXbrjhBnvyySfd/20V62pYrIYXK5Cke6Hq1O2qodzKAP32t7+11q1bu+Hv6kZ89tlna/E3GP9Ux6Ph7V5phY5ZixYtXG1aly5d3DYd0+OPP95112jahqeeesoFRjfddJPPrY8ty5YtcxNKrlixQiPV3RdEUT2femxUTK7jp3POBRdcUPK4V1Re1f/zgVoNXiNDNLpBB1cpR/1xpECyevSBrKgOQHNcDBs2LCq/qyDSSBAVRWt+qjZt2vjdnLizdetW9/9bX2x04tHcVPrCo5FNqDrNRK7u2MmTJ7v6NGV6f/SjH1m/fv04jJWYMmWKjR8//pDt48aNKxXgqGblz3/+s+v66t27t9166610gZXxm9/8xtWglaXPZd++fd3oxLvvvtvKM3HixCpnKwMVAAEAAASqBggAAMBDAAQAAAKHAAgAAAQOARAAAAgcAiAAABA4BEAAACBwCIAAAEDgEAABSAhfffWVPfbYY24iRAA4HAIgAAlh5cqV9swzz9jQoUPdjOUAUBkCIAAJ4fTTT7dJkyZZamqqW5YAACpDAAQgYWRmZrr1lebPn+93UwDEuMCsBg8g8S1atMhdmjRp4ndTAMQ4FkMFkBAKCwvtuOOOszVr1rjb27dv97tJAGIYXWAAEsLDDz9smzdvtscff9x27NhhGzdu9LtJAGIYXWAAEmIE2J133mkTJ060o48+2m1bsGCBtW3b1u+mAYhRZIAAxLVwOGzXXnutXXzxxXbqqadaixYtrF27dhRCA6gUGSAAce3JJ5+0ZcuW2VtvvVWybeDAgS4DBAAVIQMEIG6pzueWW25xdT+NGzcu2U4ABOBwGAUGIG5t3brVFT4PGDCg1PZt27bZhg0bbNCgQb61DUBsIwACAACBQxcYAAAIHAIgAAAQOARAAAAgcAiAAABA4BAAAQCAwCEAAgAAgUMABAAAAocACAAABA4BEAAACBwCIAAAEDgEQAAAIHAIgAAAgAXN/wfIYucCfiAdtAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.scatter(on_locus[:, 0], on_locus[:, 1], s=2, color=\"0.75\", label=\"sampled draws\")\n",
+    "ax.plot(principal[:, 0], principal[:, 1], color=\"C0\", label=\"principal branch\")\n",
+    "ax.set_xlabel(r\"$\\lambda$\")\n",
+    "ax.set_ylabel(\"P(Stag), row player\")\n",
+    "ax.set_xlim(0, 12)\n",
+    "ax.set_ylim(-0.02, 1.02)\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a389bab",
+   "metadata": {},
+   "source": [
+    "The second branch exists only above a minimum value of $\\lambda$, where its two sides meet at a *fold*.\n",
+    "As $\\lambda \\to \\infty$ the upper side converges to (Stag, Stag) and the lower side to the mixed equilibrium.\n",
+    "\n",
+    "## Polishing a draw with Newton's method\n",
+    "\n",
+    "A draw with $\\operatorname{obj}$ near zero is only an approximate LQRE.\n",
+    "Fix $\\lambda$ at the draw's $\\lambda^*(\\sigma)$; because probabilities on both sides of the fixed-point condition sum to one, dropping one component per player leaves a square nonlinear system, which `scipy.optimize.root` solves to machine precision in a few Newton-type iterations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6e9a86fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:09.014467Z",
+     "iopub.status.busy": "2026-07-22T11:38:09.014166Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.018940Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.018101Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def pack(probs):\n",
+    "    \"\"\"Per-player log-odds relative to the last strategy, concatenated.\"\"\"\n",
+    "    return np.concatenate([np.log(pr[:-1]) - np.log(pr[-1]) for pr in probs])\n",
+    "\n",
+    "\n",
+    "def unpack(free, game):\n",
+    "    probs, k = [], 0\n",
+    "    for player in game.players:\n",
+    "        n = len(player.strategies)\n",
+    "        probs.append(softmax(np.concatenate([free[k:k + n - 1], [0.0]])))\n",
+    "        k += n - 1\n",
+    "    return probs\n",
+    "\n",
+    "\n",
+    "def qre_residual(free, game, lam):\n",
+    "    probs = unpack(free, game)\n",
+    "    values = strategy_values(game, probs)\n",
+    "    return np.concatenate(\n",
+    "        [(pr - softmax(lam * v))[:-1] for pr, v in zip(probs, values, strict=True)]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def polish(game, probs, lam):\n",
+    "    \"\"\"Newton-polish an approximate LQRE at fixed lambda; None if no convergence.\"\"\"\n",
+    "    sol = scipy.optimize.root(qre_residual, pack(probs), args=(game, lam))\n",
+    "    return unpack(sol.x, game) if sol.success else None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "957626ef",
+   "metadata": {},
+   "source": [
+    "Take the best draw on the upper side of the second branch and polish it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "70e0fd70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:09.020775Z",
+     "iopub.status.busy": "2026-07-22T11:38:09.020562Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.027868Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.027054Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "draw:     lambda* = 6.7779, P(Stag) = 0.9988, obj = -1.05e-12\n",
+      "polished: P(Stag) = 0.998835, residual = 0.00e+00\n"
+     ]
+    }
+   ],
+   "source": [
+    "principal_p = np.interp(on_locus[:, 0], principal[:, 0], principal[:, 1])\n",
+    "upper = on_locus[\n",
+    "    (np.abs(on_locus[:, 1] - principal_p) > 0.15)\n",
+    "    & (on_locus[:, 1] > 0.85)\n",
+    "    & (on_locus[:, 0] > 2) & (on_locus[:, 0] < 8)\n",
+    "]\n",
+    "lam_u, p_row, p_col, obj_u = upper[np.argmax(upper[:, 3])]\n",
+    "seed_upper = polish(g, [np.array([p_row, 1 - p_row]), np.array([p_col, 1 - p_col])], lam_u)\n",
+    "print(f\"draw:     lambda* = {lam_u:.4f}, P(Stag) = {p_row:.4f}, obj = {obj_u:.2e}\")\n",
+    "print(f\"polished: P(Stag) = {seed_upper[0][0]:.6f}, \"\n",
+    "      f\"residual = {np.linalg.norm(qre_residual(pack(seed_upper), g, lam_u)):.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "637a02d4",
+   "metadata": {},
+   "source": [
+    "## Tracing the branch\n",
+    "\n",
+    "From a polished point, the branch can be traced by stepping $\\lambda$ in small increments, re-solving at each step from the previous solution.\n",
+    "This fixed-$\\lambda$ continuation must stop at the fold, where the branch turns around in $\\lambda$ and the Jacobian of the fixed-$\\lambda$ system becomes singular.\n",
+    "(Gambit's own tracer avoids this by following the path by arclength instead — the approach described in [Tur05](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria).)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "43c4b99c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:09.030119Z",
+     "iopub.status.busy": "2026-07-22T11:38:09.029786Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.127188Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.126075Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "upper side: traced lambda in [3.13, 11.98], P(Stag) at lambda_max = 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "LAMBDA_STEP = 0.05\n",
+    "LAMBDA_MAX = 12.0\n",
+    "\n",
+    "\n",
+    "def trace_branch(game, probs, lam):\n",
+    "    \"\"\"Follow a branch through (probs, lam) in both directions of lambda.\"\"\"\n",
+    "    points = [(lam, probs[0][0])]\n",
+    "    for direction in (+1.0, -1.0):\n",
+    "        cur_probs, cur_lam = probs, lam\n",
+    "        while 0.0 < cur_lam + direction * LAMBDA_STEP < LAMBDA_MAX:\n",
+    "            nxt = polish(game, cur_probs, cur_lam + direction * LAMBDA_STEP)\n",
+    "            if nxt is None:\n",
+    "                break  # no nearby solution: we have hit a fold\n",
+    "            cur_lam += direction * LAMBDA_STEP\n",
+    "            cur_probs = nxt\n",
+    "            points.append((cur_lam, cur_probs[0][0]))\n",
+    "    return np.array(sorted(points))\n",
+    "\n",
+    "\n",
+    "branch_upper = trace_branch(g, seed_upper, lam_u)\n",
+    "print(f\"upper side: traced lambda in [{branch_upper[:, 0].min():.2f}, \"\n",
+    "      f\"{branch_upper[:, 0].max():.2f}], \"\n",
+    "      f\"P(Stag) at lambda_max = {branch_upper[-1, 1]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2b9d921",
+   "metadata": {},
+   "source": [
+    "The same procedure applied to a draw on the lower side traces the other half of the branch, which approaches the fold from below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ef77347d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:09.129099Z",
+     "iopub.status.busy": "2026-07-22T11:38:09.128853Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.221745Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.220732Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lower side: traced lambda in [3.14, 11.99], P(Stag) at lambda_max = 0.6887\n"
+     ]
+    }
+   ],
+   "source": [
+    "lower = on_locus[\n",
+    "    (on_locus[:, 1] > 0.4) & (on_locus[:, 1] < 0.85) & (on_locus[:, 0] > 4)\n",
+    "]\n",
+    "lam_l, p_row, p_col, _ = lower[np.argmax(lower[:, 3])]\n",
+    "seed_lower = polish(g, [np.array([p_row, 1 - p_row]), np.array([p_col, 1 - p_col])], lam_l)\n",
+    "branch_lower = trace_branch(g, seed_lower, lam_l)\n",
+    "print(f\"lower side: traced lambda in [{branch_lower[:, 0].min():.2f}, \"\n",
+    "      f\"{branch_lower[:, 0].max():.2f}], \"\n",
+    "      f\"P(Stag) at lambda_max = {branch_lower[-1, 1]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fa4a36e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T11:38:09.223968Z",
+     "iopub.status.busy": "2026-07-22T11:38:09.223768Z",
+     "iopub.status.idle": "2026-07-22T11:38:09.345862Z",
+     "shell.execute_reply": "2026-07-22T11:38:09.345166Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAGxCAYAAACKvAkXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbbJJREFUeJzt3QeYU1XaB/A3mUzvM0xhBobeOwgCoiIoKKKoKyoutv3QtWFdFSy4tkVd3cXeXcvau2vFBigK0ov0OsMMU5jeSybf8z+ZGzIhmUkyJe3/e55wk5ubm5M7Ife957znHJ3JZDIJERERUQDRe7oARERERJ2NARAREREFHAZAREREFHAYABEREVHAYQBEREREAYcBEBEREQUcBkBEREQUcBgAERERUcAxSABqbGyUnJwciY6OFp1O5+niEBERkRMwdnN5ebmkpaWJXt+2OpyADIAQ/HTv3t3TxSAiIiI3ZGVlSbdu3aQtAjIAQs2PdgBjYmI8XRwiIiJyQllZmarA0M7jPh0Abd++XV544QXZsWOHPProozJ8+PBWX7NhwwZ5/vnnJS8vT4YNGya33HKLxMfHO/2eWrMXgh8GQERERN7PZDRK7bp1MiM6WurWrxfTSSeJLijIN5OgH3roITnvvPMkMjJSvv32WykqKmr1NatWrZIJEyZIcHCwzJ49W5YtWyYnnHCCVFVVdUqZiYiIqHOVLV0qe6aeKkeuuVYeS0tXSzzGenfpPDkbfG5urqSmpsqhQ4dUldZPP/0kkydPbvE1U6ZMkdjYWPnkk0/U49LSUklPT5fFixfL/Pnzna5Cwz7wWtYAEREReS8EOdk33oQM6OZPNLXmpD+xRGKmTfOtJjAEP66orq6WFStWyCuvvGJZh0Dm1FNPlW+++cbpAIiIfA+u1erq6tT9kJAQ1ZSNdfX19apG2LpHp9FoVD1FkCeAniI1NTXqFhUVJbW1tRIUFKTWY4kLImzf0NCgbtgntsN7hYWFSXh4uKqdxnuiphn7wTZ4T7wey9DQULUPlAU37Bu9TQEXWXid9hqUE/tEOfAavBbwOryn9hkjIiLUdngtasmxP2yPfeC3EPsxGAyW98RjlBGv0z6Htg7bVVRUqPuAfWqv0coO2A7vU1lZqd4TnwPlwf5wLLA9yo3PhOOLbVAevA6vwXYos3astM8MeB3KjcfYDvvFe2O/2B7b4thqfxftGGFp29sHZcT+sR3KhJu2XywbjUb1dwXt74XvAj4nyon94jhhv7gQRvlxPzQ0xPI67ftlD8qs7dv2pIz3x+u0v512bDV4H3xVrdfjc2jHCscUz+Ez4hhpx6ax0Wj5rJWVVaLXm//+5ucaLWXFMQ0NCZXSslJpNDaq7bF/HBtHgpqakbQy6XUiYeHhUlNdbfm/Zy08IkKqrVpdDMHBqjkpNCxMvU9tbU3TsQiR+vo69ZmxPiLi6HcKx99obLC8f1VlpdoPyh8RHq7KospdVye5Dz50bPBjLpgKgvL+sViip051uTnM4zlArkDSMg6KbQ8uZIKj9sgRfNlx02hfcCJqH9aBCGgncTzGeu0HVAti8IONH7ojR46oH0T8v8b/UWyPH3ycKLGNdoLGepxwreHHX/2oY98mowTrTKJrrBdjXbVa6hobpKSxXkTdNz+uaFpqj/E6HQIVU4PoTI0SjMcmo9Q3GkVvapQ63DcZxdBoFJOpUcJNRokwGUVMjaJrxNK8PR4HNxotrzc/jx93lM0kMWqJgMiEand1P6zpOV3T+mCTSSIEZTGJzmr7GOvH6jhi3dH74Xivpn1J0+sN2uOmfeC4R1q2EYnFffNfpNlC7Qf7N/+xmm/TJLrpfRMt25s3iWy2P3wW7bF5XYhJJNr6NVbbavfNYcXR9w5vWn+0BE3HTPB+1q8379cc3ongNOgoKzTO5nGyzWPXLsu9V5L4h8q8EDHmd3G8gckkDbm5UrV2nUQeP85/AyDtRxWRtTVEktpz9qB57L777uvw8hH5Kkc1KRqtVkCr1dBqFnDD/z0MLdHsChMnKWOt6BuqRF9fJfqGSvOyvkp0uN9QI3XGGgk31oquoUb0xlqJwX31Gqv7xhq1xDaJal2dJXjRNQU3eiyJyC811DhXq9NQUODyvn0qAIqLM8futsnShYWFLfYCW7hwoeopZtuNjijQAx4EMiUlJVJcXKzWo8oZTdOqmUiMEtJYLY2VhVJ4aI8E1ZZKUF2Z6OvK1P3GujKpU/fLpGt95dEgRwU9leaaEA9p1AeL6IPFpG6GpmWwmIKO3hddkJj0QealTlvqRbC9Tt+0Tm+1HdYZzEt907Y687ait91H02PUVajX6Sz3zXkLOvN2ah3qLo6uP2Z7bRt1Hw+xxDZ4gNfhhrqRpvtN2zTfHq/XAtumpe1jy3rzwlzP0rTimKDY/j4sr7FsrnP8fvbex265WnqfY8ulagZVU45rg9weLYeTXB5D19X9u/oGHby9rgOPZQvbN27dJvLbA63uwZCU5N8BEJq6unTporrBn3nmmZb1eDxmzBiHr1Ntok3t7ESBFuQgqEGTkspz0OmkOGev1ObvlaCqfAmqKRJDdaEkYVlTKEE1hWKoKZKw6kIJqq+w7MvcvOGeRkO4NBoipDE4smkZodaZgsLEFBQqjYZQtVT31TKsaV3T803PmQxN9/Uh5gDGKpixDnQQhLh+8vBP+NtreR3WeR4IfJHnZJ0DpI2wi5o8rE9ISFCvQQ0fvkfId7HNW0lKSlIXpC3VwNsrS0u0vBZH26JsWrMplhgRGB1qtPyf7j16qNe7lwMU6noOkA3ncoB0buQANVrlAFWq/TjMAQoNVZ9Le42rOUC6pjw1/G6A7XHAsbPuea3VHOO44H2046LVEGs5QNZ5ZeYcoKPfTXwmLZ9Oe06VO72n5D77ohjz8+3nASEXLiVFIo5zHAP4bAC0ZMkSNUYQxv2BSy+9VCVBX3311SoYQvd5BEBPPvmkp4tK5LEgR8uHMeAHozhLDKUHpWj/JpHSLAmuyhNDZa7oq3LVMsVY6/z+RSeNITFiDImRxpBoMYbifqx5Xai2PkaMwVEqsDEZIs0BjgpyEPCEq9oQf4UgQjtZa82DLQUD+DvhRIG/mcZ6QDecHFDTjYRl7YSuJWhrJ3Hcx8lNC1ywP6zXcqu0JGgtAdw6cRxaaurEb6qj522/a9o2eB8t0M7MzGz22QDlRK0i3h/ls05O116HEyZOnlqSt3YctcRvPKedjHES1Y6hVoZevXodU25HrQJaS4ImOTm5TZ1zvBWCU78ob0SEyF13mnuB4W9rHQQ1/a1T7lzo1nhAHu0G/91338njjz+uonGM5zN27Fh11TF37lx1g3nz5qmxf7Zu3aoeI0o899xzZc2aNdKvXz/ZsmWLLFq0SDVzOYvd4Mnn83QaasSUv0MKt/8suuJ9ElKeJcFlB9USeTOtaQhLkIbwZGkITxQj7oc1LdXjxKbH8SrosTSrdAJ8toyMDPU5cTJtaTvtWGB7nEzxO9LSa9yFEzR6m2o/lVr+E4Ife3MR4aSNk7WWq6jdt962tZwrf+ipZ90ry58+I3muKzx6eyHhWWNITVXBjztd4D0eAGVnZ6sAxlbfvn3VDf744w+Vo4DBDq1t27ZNjQQ9ePBgSUlJcel9GQCRN588rLsvqxNHea40HlonJbtWSnDhTgkt3auCHXPvITv70QVJfWSaNESnS31Eiro1RKZKfUSqWjZEJKsmJXfhylqrXtegnFpziHVVu3bVb1v9jloBXHlrV/eoAUDNAtZrJ0st8RrHA/vBiRTbIZiwrQFoLfjQmncQtGAb61oHHHPtPm7YFq+zrpHgCZzIO0aCPrJihVw+a5a89tln0qWNI0F7NADyFAZA5G3w3xC1F7VVFRJWvEvCjmyWyKI/JKJ4m+hKs+y+xhgaJ3VxfaU2pofURWdIfXSGeRmVJqHhkWqA0H379rlcFjQnIEjQAhctzwCBApoutHwFe80h9tYDawWIyNvO316fA0Tkb7RB+pDLUFdTJaGF26Rux1JJ2rdMwo5sFX1j8xwS9Oapi+kltfH9pTaun9Qi6Invp5qqunXvLvmHDh3zHshjQBCCmlTUZqBmRRtbB++PHw5tMDrtGghNNFqSoj3ILdFoNVSgLVtab90JwXo9EZGnMAAi6gRaswqSW8vyDkhU9i8SdGi5ROStkaD6ymb/EY2hsVKdOExqk4dLwvDpImmjJTev2DJQoOoBU1urggo07/Tp00ddFeFW27ReCzK0oAZsZ09GgKT1ZiEiCjQMgIg6kNZ0lL1zg0QdXCpRWcskqWBDs/wd9KSqShkrVanjpCpljGrKQu+Grl27iq4paMnIMPe00ZqUrPNf0CSFvBz0bvHHxFoioo7AAIionWgJuJbE2ooSqdvymUTu+Z/0Ovxbs4EBa+L6SWW3k6UifZLUxg+021Vcq7mxbVpy1Ixkuw0RETnGAIionYKfvXv3qhofjLUTt+t9id3zqQTVH52/qjpxqJT3OE0qup0sDVHpx4y/Ami+wj60QdqIiKhjMAAiagNtBmsM1RCav0nid74jUVk/WWp70AW9rNcMKe91ptTF9Gg2qrmWF4SmK+TjEBFR5+GvLpGbEMAcPHhQdLmbpMvGZyQyd7XlucqUsVIycI5Upp0g3TN6SHxoqEpQRrCEHlja0PPWzVxERNR5GAARuQHJxkW7f5fEVf+S6Mzv1TrMRVXW8wwpHjBH6uL7qVHNU+PjLcEOemxpA/QREZFnMQAiclF9ZbFUfH6nJO96TzV1Yb6s8p6ny5Hhf1W5PQhyeqWmWnpsERGR92EAROSK3d+L7tPrJL7SPB9NRdoJcmTEdarGR4MRmJnATETk3RgAEbUCIyeXFuZJxC+LJWzzG+o/TV1kmuSPvUOq0iY2G33Z0QSZRETkXRgAEbUQ+KB3V+nBzZK24jYJK9mt1teN+osc7HeFmAxhli7s6MnFwIeIyHcwACKyA7OQZ2dnS3jeWunxywIJqi2VhrAEyR3/d4kccbZ0CwuTvLw8SUlJYWIzEZEPYgBEZANd1RH8RGX+KKm/3i36xnqpSRgkOSc+Kg2RqZIYFqaCnp49e/LYERH5KAZARDZQsxOz73+SsvpBNWdXefepkjvxPjEFhaou7ZxAlIjI9zEAIrJSXl4uwbu/lpRVD4hOTFLaZ5bkjV0oekOwpKakqCRnTjRKROT7GAARWQU/JRu/kPRf71bBT0mfcyR/3J1qZvbevXszyZmIyI+wvy5Rk4I96yXt59tVzk9591Mkf+wCFfyo/yjs2k5E5FcYABGJSGnREem68i4JqiuT6sQhkjvxARG9eQqLxMREHiMiIj/DAIgCXlVVlRi/v1/Cj2wRY3CUHD7hHyrhWQt+GAAREfkf5gCRBPpgh/lbl0mP7W+qx3nH3yMNUWkSEREh3bp183TxiIiog7AGiAJaZmamJK1/wtLdvSJjilrP4IeIyL8xAKKAbvoKPrhCInNXiUlvkCMjr/d0kYiIqJMwAKKAdTgnW5I2PKHuF/e/QOqjzU1evXr18nDJiIioozEAooCd6ys4d4OElu4VoyFSiob8xRL8BAcHe7p4RETUwRgAUUDCXF/Rmd+r+5XdTpbG0FhJSEhg8ENEFCAYAFFAiowIl+isH9X98h6nqmVcXJyHS0VERJ2FARAFpLCCTWKoLhBjcKRUpR4vMTExYjBwVAgiokDBAIgCTm1trei3f67uV3SbLKagEElKSvJ0sYiIqBMxAKKAk5+XK9FZP6j7FRlTJSQkRIKCzNNeEBFRYGAARAEnumSbGKqPqGkv0PwVFRXl6SIREVEnY9IDBZzi0G5SPfEBCaotVc1f5eXl0qVLF08Xi4iIOhEDIAoojY2NUq8Llfqep1vW1dfXe7RMRETU+dgERgGlurra00UgIiIvwACIAkp4ePgx69j9nYgo8DAAooCi1+ubJT0j+Ondu7dHy0RERJ2PARAFlNzcXKmoqLA8joiI8Gh5iIjIMxgAUUApKytr8TEREQUGBkAU0DlA9nKCiIjI/zEAooCSnp7e4mMiIgoMHAeIAi4Jum/fvqo7PGp/8JiIiAIPAyAKOAh6IiMjPV0MIiLyIF7+EhERUcBhAEQB6fM9n8tlX10me4v3erooRETkAQyAKOCYTCb5bMdnsr5gvby29jUpKirydJGIiKiTMQCigIPJT09OPFndX1GwQvIK8qS4uNjTxSIiok7EJGgKOMHBwTImfoxEG6KlqL5INpdsliBdkMTHx3u6aERE1ElYA0QBR6fTSXhIuJzY5UT1+KeCnzxdJCIi6mQMgCggYQDEU5JOUfd/L/pdKhsqpaSkxNPFIiKiTsIAiAJSaGio9IrsJRnhGVJvqpflBcslPz/f08UiIqJOwgCIAropbHrqdHX/w+wPpdpYLVVVVZ4uFhERdQIGQBSwevbsKVOTp0rXsK5SWl8qn2Z/KocOHfJ0sYiIqBMwAKKAFRISIsH6YLkk4xL1+PPDn0thbaHs27fP00UjIqIOxgCIAlpycrKMSxgnA6MHSl1jnbxy4BU1TlBNTY2ni0ZERB2IARAFtLi4OJULNK/XPDHoDLK6aLXqFp+ZmenpohERUQdiAEQBr3///qpH2IXdL1TH4pX9r0huTa6Ul5cH/LEhIvJXDICImkaHnpU2SwZFD5Kaxhp5bOdjcjDnII8NEZGfYgBEJCK9evVS02Hc2O9GiTHEyP6q/bJk1xLZsXOH7N69m8eIiMjPMAAismoKG95zuCwYtMCSD/TfzP9KY2Oj7Nq1i8eJiMiPeHwy1L1798qrr74qeXl5MmzYMLnqqqskPDy8xdcsW7ZMvvrqKzWDd0ZGhlx66aXSo0ePTisz+a/o6Gg5a/RZcrj6sDy15yn5LOcziQiKkPO7nS8HDx7k94yIyE94tAZo8+bNMmrUKDXuCoIfBEInn3yy1NXVOXzNo48+KjNmzFA5G+PGjZNNmzbJ4MGDZePGjZ1advJvpySfIpf1uEzdfyfrHTVIYm1trWRlZXm6aERE1A50JpPJJB6CQMZoNMq3336rHmMuJtTkPPnkk3LllVfafU2/fv3k3HPPVYEQoPgDBgyQc845x7KuNWVlZRIbGyulpaUSExPTjp+I/AmavT449IG8m/Wuenxe+nlycfeL1feNiIg6X3uevz1WA4Ranu+//14uuOCCZoPSTZkyRb744osWpy+wnq6goqJCzeLdu3fvDi8zBV5O0Nw+c2Vuxlz1+OPsj+XFgy9KvbHe00UjIqI28lgAhIHmMOKube4OHrc0FcHrr7+ugp6xY8fK+eefLyNHjpT58+c7rDECNF0garS+ETkD38eL+14sV/e+WnSik6WHl8pV310lJTUlPIBERD7MYwFQdXW1WkZFRR2ThKo9Z8/y5cvlt99+UzVF06ZNUzlEb731lkpQdWTx4sWqyky7de/evR0/Cfk7fF+uO/E6eXrq0xIZHClr89bKhV9cKBvzmXdGROSrPBYAIRAB9OSyVlRUZHnOFuZnQi+xhQsXyiOPPKLuf/jhh6rpbMGCBQ7fC9ujvVC7MZGV3HFSt5Pkv2f8V7pHd5ecyhy5/JvL5flNz4ux0cgDSkTkY/SevKrGPExbt25ttn7Lli2qR5g9R44cUc1fQ4YMabYej/fv3+/wvUJDQ1WylPWNyB194/vK+zPfl5m9Z4rRZJRnNj4j85bOk9zKXB5QIiIf4rEACBNQXnTRRfLKK69Y5lz69ddf5ffff5eLL77Ysh2eRw0OpKenq9qejz/+2PI8Xrt06VLVFEbUGaJComTxiYvlH5P+IRGGCNUkdu5n58qzvz4rFZUV/CMQEfkAj3aDR/MX8njQ/R21OD///LNq1nr88cct28ybN09WrVplqSn65ptvZO7cudKtWzfV8wv5QGlpaWp9UlKSU+/LbvDUXjLLMuX25bfLH0V/qMf9ovrJogmLZGTaSB5kIqJ21p7nb48GQIBxgFauXGkZCXrgwIHNnkfwg6avmTNnNqv1WbdunRQWFqpeOmPGjFE1Ss5iAETtae/+vfJF1hfydubbUmWsEr3o5dxe58rMxJkSGxKrAvTIyEgedCKiNvKrAMgTGABRe0KvRSTWF9cVy38O/EdWFq5U6zGFBmaYn9l1pqQlpan8tZSUlFaneiEiIvsYALURAyDqiCAItZgIcL7Y8oW8efBNNaM8xAXHyexus2Vq8lQJ1gerDgAMgoiIXMcAqI0YAFFHwsjkuXm5qiboncx3JK82T61PCE6Qs9LOkhndZsjgvoP5RyAichEDoDZiAESdEQQhub/B1CAry1fKW7vfksK6QvVcTEiMzBk4Ry4aeJF0Ce/CPwYRkZMYALURAyDqbGUVZfLelvfk08OfSmZ5plpn0BvktB6nyZ96/UmSG5IlNTWVTWNERC1gANRGDIDIUzBq9A+ZP8ib296UjQVHp9LoFdFLpqZMlQuGXyBd47ryD0REZAcDoDZiAETeYHvhdnlp7UuyPG+51Jnq1DqDzqCm3Dgl+RSZ3m+6hIeyxxgRkYYBUBsxACJv6j22bd82WX5kuSwrWCb7K49O6RJjiJEZfWbIzD4zpVtQNyk8UqgG+4yPj/domYmIPIUBkBcdQKL27EK/5fAW+WzPZ7LiyAopqS+xbIMeZOMSxsn4xPEyOGawDBowiAeeiAJOGQdC9J4DSNSeGhoaZN++fWqi1U0lm2Rd9TpZfmi5VBurLdtEGaJkXPw4OXvo2TK+63iJDOYo00QUGMoYAHnPASTqiCAI3ejj4uLEYDBI3pE8+XHvj7K6aLWsKVojZQ1llm2RMzQqZZRMTJsok9InyYD4AS5NC0NE5EsYAHnRASTqDLt27VJL1AxtL9uugqGtlVstXeo1GFdoQtcJMjZ1rLqlR6UzICIiv1HGGiDvOYBEnR0EQf/+/S2z0a/MWSkrs1fK77m/S3XD0aYy6BrZVY5LOU4FQ1h2i+7GgIiIfBYDIC86gETeos5YJ+vz18vvh3+XNblrZOuRrWokamsJYQkyvMtwGZ5kvg3tMtSSQ1RTU6NGr05OTpawsDAPfQoiIscYALURAyAKBFX1VbKpYJMKhtbmrZUtR7ZIQ2PzgEiv00ufuD4yJH6IpOnSpE9kH0kPT5c+PfswCCIir8MAyIsOIJGvqDXWyo6iHbK5YLPlllOZc8x2SKzuEdlDhqcOl4EJA2VQ4iDpH9+fvc2IyOMYAHnRASTyZQVVBbL5yGZZf3i9rMtZpwZirDJWHbOdTnSSEZOhAqHesb2lb1xf6R3XW3rG9JSQoBCPlJ2IAk8Zk6C95wAS+QvkAGFAxvrIejlQeUC2F21XNUa45Vfl231NkC5Iukd3V81oCIywRHDUM7anhAaFdvpnICL/VsYAyHsOIFEgKKwulJ1FO2VPyR7ZV7rPvCzZJ+X15Xa3R41RamSqZERnqJqjHjE9VKCEJXqiMTgiIncwAGojBkBEbWcymVTN0N7SvSoYsg6OyuvsB0bNgqOYDBUgYayitKg08y0yTRLDE1VyNhGRLQZAbcQAiKhjA6OimiI1SCPGKTpYdlCyyrPUEusq6ytbfH2IPkS6RnVVwZAWGGE8Iy1QSgpPkiB9EP+ERAGojE1g3nMAicj14Mg6IDpccViyK7LlcOVhyavKk0ZTY4v7QO1Ql7AukhyRbLmlRKYcfRxuXkaFRPFPQ+Rnytrx/G1ot1IREbUC85ShiQu3kckjj3m+vrFeNavlVORYblpwhGVeZZ4a3DG/Ol/dpNDxe0UYIszBUYQ5OEqKSJLEMPN7q1vT/bjQODa5EQUgBkBE5DWC9cGqqQs3e4yNRimsKVRBkvUNNUfWjyvqK6SqoUoOlB1Qt5agJ1t8WPzR4MjOEs/jFhsaK+GG8A769ETUmRgAEZHPQO6P1tTV2ijYtsFRQXWB6s2GAEpbltaWqglmj1QfUTcpbr0MYUFhEhcWp2qOmt2s1sWHxktsWKxa4jGCJtR+EZH3YABERH4nIjhCjUWEW0vQ5FZcU3xMYGS7LKkpkeLaYjWVSI2xRnIrc9XNWUjsjgmNkeiQaIkJiVE3y/1Q8+Nm60OP3o8KjmLwRNQBGAARUUA3uTlTo6QlcKNZDQETao4QEFnfV8uaYimpLTHfmoImBFl1jXVHa5lchKRvBELRwebASAuKMImtZRkSpe4j8LN+Tt0PMd/niN1EzTEAIiJyApqwEFjghsEcnYGgqbqhWgVEZXVlanykstoydd9yqy1TA0pq69U2TesROKFXHIIr3KSibcGedcDULIBqWiKAQvJ4eHC4eWkIP7rO5j4Gs2SzHvkyBkBERB0EAYIKGoIjJE3S3JrA1jYwwhJjKSHRu6KuwnIfS+2mHteZl6i1sjT3odaq1olEJydrpuwFRs2CJ4P5s2v38RxyqPA4zBCmgigtmMJj6/sI2Ig6EgMgIiIvhWAA3fdxcxd6ziEIUoFRXYUlWLIsm4Io1EKhtgoJ5Nge96vrqy33sR5L5EABaqZUEFZfIVIt7Q698xAIIWDSlqGGUEsAZS9osmxrdR/P4YYmQNv71usQcLFGK7AwACIi8vOecyqHKCRaJLLt+0NApYKjhubBkW2ghMfW97XnahpqVM2WFkzVNtSqJdZjqQ2Eid55Wo1WZ0GyuqMASbsfHBTcYiCFfdiuxxIB1jFLfYjan0FvaLaOI513DgZARETkNJycVdJ1B4y0jZwpNNVZAqKmoMj2viWAchBM4THWa69DLhUe1xnNS+v71rAdblLv2S8EmhetAyTctw6cmt2383yLz1nvM+jo8wjCtKVBZzAHZjqD+XHT7Zjt9AafHkSUARAREXkFNEHhRI0bhgHoaAi4MLSBbVBkfV8FRdp9e89bLVsKtBDY1RvrLUtsq3oIGs1La6gF017v6WDM2WDNEig1BU3W6xzdt2xrE2zZC7S07eur2++AMAAiIqKADbhULUhQsESJ5+aO0wIxFRxZBUXastn9piBKBVB27jcLsOwEWngf6/3XNdapdbY3bVt1Mx19bKtZsNYJjNVGzwZAL7/8ssybN6/dCkFERBSorAMxb2ZCoGZqOVhS95u2QQBmu/0x29red7C9tqwsr5Ttsr1dPo/OhE/kopCQEKmurpagoCDxRZwNnoiIKLDP325lLw0aNEg2bNjQpjcmIiIicpbJaJTadetkRnS0WuJxp9cAPf300/LEE0/IvffeK4MHD1Y1QtaGDh0q3ow1QERERL6jbOlSyfvHYmnIPToHnyE1VVLuXCgx06Z1XgDU2mBRbuyyUzEAIiIi8p3gJ/vGmxBcNH+iKRZJf2KJW0GQW0nQhw8fdudlRERERE5DMxdqfo4JftSTJhUE4fnoqVNF52JeslsBUGpqqjsvIyIiInJa1dp1zZq9joGeabm5arvI48d1fBI0FBUVyeuvv67ygDRr164VYxuTkoiIiIigoaBA2nO7NgdAmzdvVj3BHnroIbn//vst61944QV588033dklERERUTOGpKR23a7NAdAtt9wi8+fPl127djVbf91118m///1vd3ZJRERE1EzEcWNUby8t4fkYOp16Htt1SgC0Zs0aueGGG5re+2ih+vXrJzt27HBnl0RERETNILEZXd3ND2yCoKbHeN7VBGi3AyC9Xi+VlZXHrEeNUHx8vDu7JCIiIjoGurijq7shJaXZejx2twu82+MA/fnPf1ZDUD/zzDMSHBysEp+zsrJk9uzZahBEzBXmzTgOEBERke91iT+yYoVcPmuWvPbZZ9LlpJPcqvlpUwCUm5srU6ZMkZKSEjUm0MiRI2Xbtm2qCWzZsmXSpUsX8WYMgIiIiHxPe56/3QqAoLa2Vj7++GPV9b2xsVFGjx4tF1xwgYSGhrapQJ2BARAREZHv8XgAhMDnrLPOUs1fvogBEBERke/x+Gzwc+fOlfT0dNUdfuvWrW0qABEREVFncysAQg7QAw88ICtXrpRhw4bJ8ccfrwZBRGRGRERE5JcBEKqd/vrXv8rq1atVDdCkSZNk0aJFao6wSy65RCVCExEREXkrt+cC0wwZMkRuvPFGueqqq1R3+E8++UROPfVUGTVqlGzcuLF9SklERETkDQEQeoG9++67Mm3aNOnVq5d89913alwgNI9lZmaqZrGLLrqoPctKRERE1C7c6gV2/fXXy9tvv62mwUBC9JVXXqkGQLRWX1+vusSji7y3YS8wosCC36G6ujpPF4OIWoHe5UEtDG7YnudvgzsvwqCHTz/9tPzpT39yOO4PPsSPP/7YpsIREbUVAp/9+/d75cUYER0rLi5O5RRbzzXaEdwKgJwNbCZPnuzO7omI2gUquDFaPa4ou3fvruYxJCLvhP+vVVVVkp+frx537drV+wIgIiJf0NDQoH5Q09LSJCIiwtPFIaJWhIeHqyWCoOTk5Babw9pK724CNMYBGj58uKqqioqKanYjIvIG6JkKISEhni4KETlJu1hBLrHX1QDde++98r///U9uu+02ueKKK+Sdd96R33//XZ577jk1OrQr8vLyVEI1lhhU8cILLxSDofVirVixQjXF4UCht1lGRoY7H4WIAkBH5xIQke/9f3WrBgjd39966y25/PLL1WMELf/617/k1VdflZ9//tnp/ezevVsFPd98841KmkZgdfrpp1uu2uxBIiMGWzz//POlurpa3c4++2zZvn27Ox+FiMiv/Pbbb/L99997/T6d2S8udL19YF1fKCO1Yw1QVlaWClwgMjJSdUdDUxgmSP3LX/7i9H7uuOMOGThwoHz99dcqORHd6fv27atqhBDk2PPUU0+pwRY3bdokffr0UetuvfVW1c5PRBTocHF66NAhNSCtN+/Tmf3iohp5XN7cocYXykjtWAOEWhgtMQlBiNYrbMOGDRIdHe3UPtC299VXX8nFF19s6ZmBZix8iT799FOHr3v22Wflz3/+syX4AeQdIVmKiCjQTZw4UU477TSv3yeRT9YAodZHg2kwMBgiEqK3bNmiHjsDo0Ujmdo6kAE8xiSrjgZA2rVrl9x1113y4Ycfyrp161TvDoxHhKUjeB/crPdDROTNzSq40ERNO/Iry8vLVS1JQkLCMdvgtxdNMEgdmD17thqZ3/qCUNtu5MiRav7GiooKOfHEE+1eNOJ5pCb0799fxo0bZ1nvaJ8tlQ9TIa1du1bdx8B1eP9+/fq5dTwKCwtdPg7OvH97HBtNSUlJq/sgPwiA8AfWoMkLQQvachcsWCDnnHOOU/vQmqxsa4wwsqOj5iwtcPnnP/+paotOOOEE1X585513qqk4xo8fb/d1ixcvlvvuu8/pz0dE5OlmFZy88VuLeRVxwXjttdfKDz/8ICNGjLBsg4tA5EHiBI4TM078ts1K2nYYEBIBS05OjsybN0+WL1+uggYoKipSv924wMTJG6/v1q2bfPDBB+p5e/tsrXzZ2dmyatUqy/5xrkAnGVd/ixHIjBkzxuXj4Mz7t8exAaRkYPonR/sg79Qu4wCdfPLJ6uYKLfBB1GytuLjYYTOath6R9ZdffmlZf+aZZ6paIfynsGfhwoXNeqchkMKgaEQUeAOtVdc77mTRkcKDg1zq3YIR91EbPmHCBFVu9HadP3++qrXQ4KSMAGHQoEEt7uvAgQOyefNmVZMD6Gzy+OOPy+uvv64e33DDDeq3F51J4uPj1brWkp5bKx9+l3Gz3h5BDFIYEKR09HFw9v3b49i0tg/y8QBIi6Sd4agmxhpqcJC7s2PHDvVl0eDx4MGD7b4G1Zjp6enqasAaHr/55psO3wvTdTiasoOIAgeCn8GLvvXIe2+7f7pEhDh/zYlmFpz0AYET0gtQ611QUCBJSUlqPWokWgt+ABeo2slZy+n59lvzcUDtB1IKXnjhBcsJHlpLeHamfLiPpisMaoemKVzEIlfUlQCoLcfBmfdvj2PT0j7Iezn9v1H7AjrDmflVkfiM3J3XXntNrr76agkLC1MRNCL9jz/+2LLde++9p6Jr9BiDOXPmyE8//aS+zEjERvstkrC16lAiIn9gW0vdo0cPSy9c7cSP+ZKcgV661jAwpJYXiSDBXj5mW8v33//+VzVXodYFF7y4CEVvqSNHjrTr+zg6Ds6+f3scm5b2QX4QACH5rL09/PDDKnIeO3as+pKiVxgSqmfNmmXZBrk9qH3SAqB77rlHVX1ie9Q0rVmzRnXDf+ONN9q9fETkX9AMhZoYT723q4m/1rQTt3bSby84eeOCVJt/qb3Kh+FJkK/517/+1bINhjBx5gLZlfdxpD3e391jQ34WAHXEFBeI2tFui3GAMBL0VVddJZMmTWq2Ddp7rcdXQJI0aokQGB08eFAlp02dOpVNXETUKjShuNIM5Um//vqrSqjVeriiNhw1EUjAbU/o1YsmpFdeeUXOPfdcS56SluzrTvlQQ4/8TusR+tEkhITizjgO7fX+7h4b8g1u/xIg+MCYPNoIzMjbQXWjq1NSYOKz8847z+Hz9tqhMVXGGWec4UapiYh8A2ofpkyZonovIQ3gxRdfVD2POmKagGeeeUZOOeUUdTE5c+ZM1byELt0IPtwpH9IT8Lt+3XXXyfXXX6+akl5++WW3LqTdOQ7t+f7uHBvy4wAITVWIhpF0huYrwHQWS5YsUYMYWic1ExGR63Dxh4tK/LYifwVN/0iu1SB9ADmQtrANei21tB1yJpEPoxkyZIjqJYVUgn379qkR+h988EGH+3SmfOgB9Z///EeND5eYmKimSUJ3erxXS/u1hrJrCc6uHgdn3r89jo0z+yDvpDO52iArIgMGDFBTVdx9993N1uNLgS+Yt8/LhW7w6FGG3CE0qRGRf6qpqZH9+/erHjroaOErMM8iTqBI5PVG3l4+8t//t2XteP52ayoMtH+iWtEW1mGgKiIiIiK/awJDdeTWrVuPSVhGVaOjMXyIiMg5jpp1vIW3l4+owwKgSy+9VA01jhGWkQOEVjQMi44pJzAtBYIjzdChQ915CyKigHXFFVeIN/P28hF1WA6QK70Q3Nh9h2MOEFFg8NUcIKJAVtNJOUBu1QAdPny4TW9KRERE5EluBUDODr9ORERE5I3c6gVGRERE5MsYABEREVHAYQBERETtBkmqLc34jpGfWxr92Rv4Qhk9oaSk5JjJaV39+/t8AIQhxjEXGBERkbV//OMfMnfuXIcH5eabb5b58+d79UHzhTJ6wt133y3/93//16a/v88nQd97770qAOrZs6eaqV279ejRo/1LSERERB4XHx+vuqj7C7dqgDAjL/roL1q0SI0GioAIwRD67HOALCKi9oGxThxNqonfXjQ1tDTWWmvb1NXVqZnS7Y3qbN0MVF9fLxUVFQ7fB89VV1c78YmOfX98xpbeu7KyUvLy8tT98vJyNRUTbrhvjyvlduYYtrYPR9BUZPvZ8Ni6eci6rM4cC0fbOPN5HB1TV757t956qzzyyCNu/f2dOdY+kwOEgAfBzosvvqhmycXkeFlZWfLaa6+1bwmJiALMl19+qX5jMzIypEuXLmr0feRfAE4gDz30kFrfv39/NRjcDTfcILW1tZbXYxs0RSQlJUnv3r0lOTlZnn/+ecvzOJFiJncMKNenTx+13ZNPPnlMM9BFF10k55xzjhr6JCEhQaZMmSJFRUWWbVAb8Oc//1ni4uKka9eucsIJJ6iL49bk5+fLjBkzJCUlRe33jDPOsHw+6/c+88wzJS0tTc4//3y1HrO7jx8/Xt3wfv369ZOlS5e6XO7Wjg8gMGxpH6257LLLVOWAtQceeKBZ8xDKeuGFF7Z6LFrbxpnvhKNj6sp3z7YJzJm/vzNl86kA6JdfflEzv0+dOlVViSEQ0uv16suJIIiIyCvh6rOu0jM3J698ccK45JJL1NU2rsIRLOCEt3nzZvX8Y489pmZhX7VqlToh79q1S37++We5//77LfvAtESPP/64fPDBByopFdtY520+/PDD8vnnn8u6devU87hwxft99913zcqCxxdccIGqzcAAuDk5Oc1qAHBi+/XXX2Xnzp2qduHqq6+W999/v9XPiP0ioMB+s7Oz1X7x/tYQ2Jx33nnq5IvPBzhxWtcA/e1vf7OUz5Vyt3Z8nNlHe3HmWLS2jTPfCUfH1JXvni1n/v7Ols0jTG7Ay7p06WJavHixKSsry+RrSktL1WfAkoj8V3V1tWnbtm1qqdRWmEz3xnjmhvd2Qk1NjSkoKMi0dOnSY55rbGw0JScnm5555hnT4cOHTTk5Oabs7GzTkiVLTH379rVsg9/nhx9+2OF74Hm8xtrs2bNNM2fOtDy+7LLLTCeddFKzbe68807TKaecYnmcmJhoeu6555ptM2nSJNP06dMdvjf2i7KinJpPP/1Ufeby8nLLNmPGjHG4j7q6OvXZcf5JSUkxff75506X25nj48xnb82ZZ55puvHGG5utu/XWW5sdG2ePRUvbOPOdcOaYtvbdg+uuu840a9Ysp//+zpat1f+3HXT+djsJ+qeffpK///3v8uqrr8opp5xiSYRGNRgREbknNDRU7rrrLjn77LNl2rRp6vf13HPPVZ1McEWO23333aeacKyFhISoJXI7kGsxbtw4u/vHVTieHzlyZLP1o0ePVrX41rp3797scXR0tKox0faDGolhw4Y122bEiBGyZ8+eFj8jJsm2nlMSrzEajar5RNtf3759j3kdJtq+5pprZPXq1ar5DscKZUCNkLPlbu34OLOP9uTMsWhpGzTftfad0Ng7ps5+92w58/d35vvqSW4FQAh8cEP732+//SbLli1T7adoK8QB3r59e/uXlIiorYIjRO7M8dx7OwknjCuvvFI1fXz99ddy5513yrvvvisTJ05Uz7/yyisyc+ZMu681GMw/645yLHCS0/KArGF77TlnONqP7WN7HL3G+v21z2Ht4osvVscAxyQqKsoSqCAYcFZrx6e92Js03F45nTkWLW0TFBTU6neipWPq7HcPQZGrf39XyuZzAyEiSQyRN/J+MjMzVca4o8x8IiKPw0kpJNIzNzsnRHu0HlndunVT+ZXIqZg1a5bKo0AiKS4yP/30U4ev07axTQ7Wno+MjFSJzytWrGj2/PLly9XVu7OwHyQQIydUgwwJ68eOrF27tlkAgpwQ1LAg+dYRBA9//PGHSuTVgh/UNCAnxhWtHR9nofw4/6GXmD2JiYmq9sPali1b3DoWLW3jzHfCWY0tfPfc+fu3Z9m8pgZo3rx5qtZn7969kp6eLieffLKKEtEEhqx8IiJyD07oqOlArx00L+Aki0RTNP3Ao48+qpJz0SMIvYNQE//DDz+o3+OXX37ZkpyKGnlsc9ZZZ6mL1CVLlqgrekANPhJWEQihKeidd96RlStXyoYNG1wq68KFC+WWW25R+0HwhJYAJMSiB1FL0ASFE+yCBQvUsCo4f2A/LTWLoDZh1KhR8u9//1s1++AC/KabbhJ3tHZ8nIHWDzQRbdy40W7giCYk1KTg5D9gwAAVTCB15LTTTnP5WLS2jTPfifb47rnz92+vsnlNAIQPcMcddzDgISJqZ2jSQS8tnOhRY4Cettdff72l1w9yMr7//nvVi+m9995TV9k4qaK3jQYnHHQ3/te//iUvvfSSDBw4sFmvG3TFxhU4TlhYj+7JOCkNHjzYsg26W9uOA4N94kRmfTGMMWDQqyo4OFidE3ByxknaEez3r3/9q9oPXo9WAwRj99xzT4vvDWiKue2221RzDGpYsB+s02qEnC13a8fHmX1s27ZNBTbWx8zanDlzVMsImpTQS3r69OkqYLDtbTZ79my1H0fHwpltnPlOODqmrnz3bAdCdObv70zZPEWHTGgJMEhkQwIduvnhS01E/gk/1kgUxSCtYWFhni4O+RGc/HFyx7g67sL4eQhK7DUxubJNIP2/LWvH87dbNUDW7ZJIeEYMhSj4uOOOa1NhiIiIfIGnm2+o7dwKgND2ikS0H3/80VL1iGowDNSE6kiMrklERESOOdMs5cw21Im9wG688UY17wfaCNEeiRvuV1VVqed8RWtjVRAREXUU5CDZTkHizjbUiTVAmCtk/fr1KvNbg4Ga0EY5ZswY8SUYlhsJgERERBQ43KoBwrgH1ln31uMCODMIFhEREZHPBUAnnXSS6vtvPeghMrMxJgOe8xVV9Y2WWiAiIiIKHG41gT3xxBNqhti0tDQZNGiQWofeYEh+dmUgKU97ZHmuPHJ2tBj0OpXEba9Wi4iIiPyPWzVAGJAJAc9zzz0nU6dOlVNPPVXdxzo85ys2Ha6WJ1bmq278OTkemh+IiIiIfKMGCEOH/+9//1OjifoyvU7k291l0j0uRC4YFs+EaCIiogDhVg0Q5jNBl3df95fjEtXylTVH5PesSnWf+UBERO7DnFqYqsGRu+++W00J4c3ao4z/+Mc/fGpYmLZ8jtb+5n4VAGEej48++kh83ZkDYmXGgBjBXCAPL8+V7DJzDzYGQURE7snNzW1xLjBMsInJR71Ze5QRaRW28375ohwnPkdrf3O/agJD8jNmpv3ss8/UFBi2M/gievYFOp1Orh2fJPuL6mR7QY088ONheXJmdwkx6NkcRkREAe+uu+5SQ9/4I7dqgNatW6fm/UKUvHTpUvniiy+a3XxJSJBe7pnSVWLDgmRfUZ08//sRTxeJiAIcZhFHk8KECRNk5syZ8vbbbzd7ftWqVXLhhReq32FMyInBaW2tXr1azUiObS6++GLVScUaLmBnzJihBq/F1EYbN2485kJ2wYIFasZ49Po98cQT5dFHHxWj0dhsuzfeeENOPvlkNRXSAw884NTJEh1PMLoxZkifOHGi6lls+9533HGHPPXUU2poFW3C0RdffFENuovbCSecIPPnz5e8vDy3yt3a8UEZW9uHq1o65nj/4cOHW4aXwZh6o0aNUsPLaD755BNVHme/B46Ooyvft//85z9qJndX/+bOfEc9zhSASktL0eqlljt37lS3//6w3tTjji/U7dWl6yzrich3VVdXm7Zt26aW0NjYaKqsq/TIDe/trKFDh5ouuugi08qVK03ffvut6dJLLzV99dVX6jk8jo+PNz355JOm1atXm1577TVTQkKC6d1337W8HtuGhoaabrvtNtMvv/yinjv55JMtz3/00UemkJAQ0+OPP66ev/baa03h4eGmPXv2WLa57LLLTMHBwWr5888/m9577z1TbGys6ZlnnrFs884775jCwsJMTz/9tNrmkksuUa+ZPn26w8+G/RkMBtPMmTNNy5YtM73++uumuLg40z//+c9j3nvOnDlqv7t27VLr8/PzTVu2bFG35cuXm2bPnm0aOHCgqb6+3qVyt3Z8nNlHa6677jrTrFmznD7m+AxRUVGWvzM+H55PSUmx7OOKK65Qx9jZ74Gj4+jK9+06m8/hzN/cmbK58v/W0fm7rXT4RwIMBm2MjY2V0tJSCQ0NtbRvvrTmiHywpVjVBr1wToYkRBgkIiJCunXr5ukiE5EbampqZP/+/dKrVy8JCwuTqvoqOf7t4z1yLFdfvFoigiOcKnN4eLiqaR89erRlPa6yg4ODVS0BUhBuvvnmZkmor7/+umzYsEE9RmoCrtAxPInt67XnURvwz3/+0/I8amIGDhwor776qnp8+eWXq1qSbdu2qXQBuOGGG2Tv3r2Wq3mMA3f++eerWgBobGxUQ6FgmqRvvvnG7ufDftGLGDk2+H2FZ599Vu655x6VS4IyYptly5ap+RoNBseZGpgkNDk5WT744AM1JIuz5W7t+Dizj9Zcf/31qpXk008/dfqYn3766ervi9qm+++/X313P//8c/n555/V63v37q1qdf7yl7849T1w5jjWtPJ9s/0czvzNnSmbK/9vHZ2/Y2JipNObwPwJAqAePXqo+5eNTpDeCSFSWmOUf6/MU1Wg6O3G6T2IqLPgB3/y5Mly2WWXqRP0jh071HqcjEpKStTE088884yMHDlSRowYoU42OLlonTeKi4tVcwqGK7GmndwxkTX2ifHbbDu32J6csH8tANDyP/Pz89V9/DZiP6eccorleb1erwKL1hx//PGW4AfQlFJUVNQs2RYnY9uTNpqHHnroIVVWlA3HoLKyUp0snS13a8fHmX24ytljjr87AhbAEscFzW+4j4ARnxPbOPM9aOk4Ovt9s+XM39yVsvlkErQ/BkGYEBV/nAUnp8p1n2XJ6qwq+WFvuZzaN0Zlt3PCVCLfF24IVzUxnnpvZ+FK+q233pJvv/1WFi1aJOnp6fL+++9LdHS0eh5dtBFEWNNO1rh6BusAw/Ykhos7XPVbw/YIJqzZO3FqjQY4qavPZWc/rXH0Guv3t7efSy+9VPVKQo5PRkaG+u1GrYn2mZ0pd2vHx5l9uMrZY45ABDU8BQUFKocGNSaFhYVq6BnMVNC9e3dVC3T48OFWvwfW7+Hu962/zUThzvzNtW2cKZunMQCyoma337tX5o5KkP+sK5TnVhfImPQIiQ83qC8pJnslIt+FH2BnmqE8DSd2NHPgVltbK9OmTZMHH3xQJaSi+h8nQCQC25OSkiJxcXGqZgEnVFuJiYnq+T/++KPZ3I1bt26Vvn37Ol1G7AdlQTMRkmc12K+92gNreI01vAZ/GzR5OIIE5K+++kpNt4SaEa1GyNVamdaOT0dw9pgjYRjBBZrJUOOEgAdlRK0XAiCtvGj2a+170B7ftzfeeMPlv3l7l60jtWsTmG0U7muCgoLUcvaweOmTECrltY3y3KoCtS47O9vDpSOiQIATB04+1pNNI9cFJ0D8RiEX5bHHHlN5IRqczNHEoDVJXHPNNSqPROtlhJPaww8/bNkePX6wD22sm19++UVd8bs6mN28efPUyRq5O4DcHtRWtAbNKC+99JIlp+Pvf/+76jHUUk4HPntCQoIqq5ajggH6XO2i7czxccaaNWvUCX7nzp1Obe/MMUetE3q3ISdKa2ZCExLybJDnpAVAznwP2uP75s7fvD3L5lM1QIhckdSFDzl27FjxRajKQ3XlLZOSZf7/smTZ/go5Y0CVjEqL4NhARNThcJWNEzKaeHDCP3LkiKoZuO+++9Tz9957r6oNQXdqNIlhWzSLWHdVRgItmiJwlY5JqjHZM5qNNEg4Rr4Nah9QI4L3uPPOO+Xss892qawoC2oxUFbsBwEMcmtQppYgZwSJv3g9cnJwkv/3v//d6vshRwWJvS+//LJKgkWQgPd2VWvHxxnIx0Ewg9c7w9ljjiAHTVFasIOaMeQBoQu9dY2VM9+D9vi+ufM3b6+ydbR27QWGMRPwpUAV5ebNm8VbtZRFjj8aMv3hmd/y5bPtpZIRFyLPzcqQ4CCd6hHmTJsqEXleS71JvB2u+nHCjI+PV80nttA5A+O3dOnSxe7zgIs55Mygo4e9ZikEH8g3QVOLbV4Har1xerDuBYuTI343VbqAzbbYP5o/MC4PjrvWucSW9X6R+IyaB9tt7b23BidTBB44WeO2e/dudRLHfVfL7ej4OLMP9HJCz6zbbrvNYc0KaqdsA7SWjrl2fsLfFe+jPY9jivcfMmSIS9+Dlo6js983R5/Dmb+5M99RT/YCC/hu8PYOoBYEVdQa5YqPDqpeYVeO7aKaxoAJ0US+wZcDIPJu+/btU0FMa/lO5Dqv7waPKBbVYLjhvj9BGyaCnKjQIJnXNGHq25uKpKzGPApoa9W7RETk39Ckw+DHt7kUAKHaDjPDok8/qhyHDRumbriPNlwkkaGazp++4OgGj7GBKusa5a2NRWq9P0xwR0REFMicDoAeeeQRy0iPc+fOlR9++EF1fcMN9zGXCkbIxDbIrvcHyMgP0uvkqrHmJLf/7SiRnKYZ4zGyJhEREfkmp3uBrV+/Xn7//Xc1bLctJIIhGx+TrqF7IzLA/QUy8EenR8hx6RGyNrtKXl9fKAsnd1UJY0REROTnNUDvvfee3eDHFrbBtv4CSW7wf8d1Uctl+yrkYLE5B8jbhvUmIiIi5wT8XGCtQQY6xjrokxgqk3pECsYM+G9TLhARERH5JrcGQrzppptaHFIbycPnnnuuGh/AH6DLHcY5mDsqUX45WCkr9lfIxSNrpVd8qOoyr40gTURERH4cAGEm3aVLl6oRMDEwE/JkMPsreoBhnpO3335b5QNhGGz0EvMHauyfXbvkxJ5R8vOBCnl7Y5HcdUpXNV4QEr8ZBBEREfl5ExiG8r722mvl0KFDag6QH3/8Ud3HnCYIeDB7+pw5c+TWW28VfzN3pHm0UQRBh8vMc9BwnjAi8kXI13znnXfEW3366afy2muvOf24LZ/Hdl/k/9wKgDAnCeZSCQkJadb09cADD6jnUBuCeU/WrVsn/qRr167SKyFU9QhrNIl89EexX0wCS0TeBcON/O1vf5Pvv/++2XoMOov1uOBsD5i2CMOXeCt8fgQmzj5uy+ex3Rf5P7eawPCfEDkxGADRGmaH1UaFxgiZ9uY58WWY1A3zomBKDHSJ/3ZXmVwyKlFiw5gDRETtBzOFY+JIzACO3qa4wAQM/4/1F110kVPzO/k65JJiolJ3n2/P9yL/41YANGvWLLngggvkn//8p5o1FpOtobYHVybazLaffPKJ2s7fIOgbaTJJ38RQ2VNYK//bXqKSo3FFFgg/SESByGQ0StXaddJQUCCGpCSJOG6M6Dq480PPnj3VjOVPP/20w3QCDEKLWg+ts8bo0aPlzDPPbLYNxiz7/PPPZdOmTer3C7/RthNbYvw2zECOAOCMM85Q+2lJZWWlvP/++yoHEkOF2Ov0grmc3n33XdUigNnfCwsL1cSj8+bNU89jNnhMkmk9G/oXX3yhLqS1bTBRaklJicNyOHoeOamo0cHz5513ngwdOrRZMxmOCdI1cFxQPuSs2u7LmWNLAdgEhlnfEficddZZ6kuPbuK4P3bsWPUcpKenq9Gj/Q1+QJD0rU2Mitni64yNalbh/Px8TxePiNpZ2dKlsmfqqZJ52WWS87e/qSUeY31HioyMlEWLFqnphxwFAdgmNTVV3RAsXX/99WpUfmvIx7z99ttVj1VM4Dlz5sxm6QnorDJ79mw11RECmvHjx6vcTkcwFRACig8//FClQSxbtkx1htm8ebNlm40bN6oA47ffflOTV15++eWqbHiN5uOPP1b5o9awL+ttWmuWsvf8ihUr1MU3fo8R2CFw+e677yzPI6hBwIPPjN9tBGH29uXMsaUArAHCDKxIFvvXv/6lqmcREPTr108SEswJwuDvkfJJPaPkpQiDHKlqkJUHKuWUPtHqR8pfuv4TkTn4yb7xJhETRgA7qiEvz7z+iSUSM21ahx2qq666SpYsWSKLFy+2e0GJYAU3zY033ig9evSQDRs2yKhRo1R+IgKKVatWqQtUrfbGOqDCyR3BC2o5AEHBc889p0b3t+e6665TtUTPPvusZd0tt9wit912m6pFAgRcCLRQAwQ333yzGh6lMyBNYefOnZb3w28y3h+1QjhXAT4/gkD0ZHaktWNLARoAaRDwWH9B3IFqR0TdyCnCFcP06dOdfi3mIUNT2/HHHy+nnXaadBZ0e8eV0owBMfLGhiI1RxgCICLyr2avvH8sPib4MT9pwjw56vnoqVM7rDkM8xE+9NBDcumll8r8+fPtbrN27VpZvny5qvFALQ9yL7du3apO0hjINS0tTV544QVV09GrVy9Vs4Gb5oQTTrAEP4DaHTRF2YNgCUHOOeecIwsWLFDpD7jh9xDlgIaGBlWDhN9m65pzXBQXFXX8ILL4PNbBFo7dE088oQIjHAuYNGlSi8GPM8eWAngkaHzpUZ2KKktUHVrfnIW8GQQ9Tz31lPoPdMUVV6hqSey7NbiKwbaYeLWzezFoY/6cMSBW9DqRrXk1sr/IPD1Gfb25azwR+TaV85Ob63gDk0k9j+06En7n8DuJ5jBb6HmLiz/UxKNmHs01CJqQLK1BwIJmKDQFIa8IgQt+PzXWwRDg9Qhi7EEAg+dQq4KACkEE7p944oly1113qW2Q64NtbAMMpEp0BkfviwBIY91a4Ygzx5YCsAYI4/ycf/75Dru5OxPAANph8WVduXKl6jWGEabRlvzRRx+p/bcE4xDhisK6bbczxcXFoSJVJvaIkl8OVMj/dpTKDROTVeKfGjSRiHwaEp7bc7u2wIXe1KlTVUKvNfQIe/nlly2/l/jtxRAltpNVI2EZib9oCrvkkkvUfezTVajJwW81gqn/+7//s7sNftORG4SEZ2u2XfexH9sLRgRqbeXofV3tpOLMsaUArAFCoIIrEq3LO6pFUU04aNAgSxJ0a1CdiKYvVE/iPwIMGDBAXUlYJ8HZ89Zbb6k2a1QNe4qW63PWQHPV8Q97yqSqnjPEE/kL9PZqz+3aYvLkySo94M4777SsQxCDAML6gvOVV15RaQUa5LqsWbNG3dfr9TJx4kQZM2aM24O3okkNvbYee+yxZjUhdXV1KvlYex/kCL300kuqjJCVlSVfffVVs32hmcr6IhrBj9brqi0Q5FknZGuddlypgXLm2FKA1gBhjAoklJlrQcxVppgC47///a9ceOGF8te//rXVfWRmZqpkO9vaEjxevXq1w9ft2bNHJdyhjdl6IMaW1NbWqlt7XmVoRnYNl24xwXKorF5W7C+X0/vHqmpiZ6pYich7oau7ITVVJTzbzQPS6cSQkqK26wwPP/xws9wTBBromXTllVeqmnD04sJvp/VvD5J+kTuE30pctGqj92vJyu5A8jNq31GzhKAMidYIspAcjfMAIGEbeTYIuPC+KJ9tEvQ111yjusIj2Rq/+7iI1s4pbc3RRK9k1JihxxqOCaZucoUzx5YCNABCGy9GRdaqRJHAjG7vqMFBYOMMbcAp6+Q7wH8AR4NR4SoDARbawvGfz1noQXHfffdJe8N/WrQPn9YvRv6zrlCW7i5TARDmRON/FCLfhsTmlDsXmnt7ofeQdRDU1JsIz3dEAjRqUDDlkLXhw4fLm2++qZp4MPaOFmjMmDFDXZDitxi9c9G9XAuU8PuKGhHtohU17NgmPt48jAcGVNRqaTRTpkxpsbkItd8IBpD/uW3bNpULhDHhcA7Q4FyAOSMxMwBq+JHugOYkdI/X4PPh9QhOEHCgdgvpFfj9dDQ4YWuP8XkwRh2OFWqkUGPz+uuvN/s89j6zvX21dmzJ9+lMzibsWL9Ip7NUDeIKABE+BkHEFxy1QBh7oTVIoEakjiuRaVbdSDGfGMaOwKBdtnC1gNofvJfmmWeeUT0b8EVFEp7WzbG1GiD8gKAKF8ltbbF7927Jr6iTue8dEByR18/vKV1jgiUiIoIDIxJ5GGonkJeH3wg037jbFR69vawTolEzhOCnI7vA+xskXyMAwjQfRO7+v8X5G4F9e5y/3aoB+vOf/2y5j0G6EHwgYSwqKsrpiegwEim6FKJJyzoAQkCBqwd7kCCNaknrubcQiCGfCOtw314AhGHktaHk2xvGPzLt2iWj0iJkfU6VfLenTC4dnaia94jI9yHIQVf3zh4Jmog6lsHdtmgNEurQroxu7KhmbGnY8mZvbDCodlpU6WKwLzzGPlBtiXUadHFHwh62wXg/uFnDeBUTJkyQBx98UDzptH7RKgD6fk+ZzB2VIHo7gRgR+SYEO5HHj/N0MXwa8oa0wRiJfDYAQvORdcsZ2ngHDhxomTDU2VY1tLFi0CokweE/Bnp/nX766aoNV4PBtNCGjQDIm53QI0oiggskt6JBjQs0PDVc5QexSzwRkaj8IyK/GAjRHjT7uDIDPAblwqiaGJcCSXlPPvmkSppDQpwGw6m31KsMWfrWTWiegCAnzKCXE3tGWbrEExERkZ/UAN1999127wOy6tevXy8jR450qQAIfFqq3cGQ6y1B10tvMaVPtHy7u0xWHqxQgyIGYZhoIiIi8u0ACF0p7d3XmsFQo4MJ8QIRaoGMjTslNixISmuMsvFwlYxJj1T5S9bdQ4mo87nR2ZWIPMTeMAUeD4Aw7gNgaPDWRmsORKjxmdQjUr7cWSYr9leoAMh6zh0i6ly4MEPPUAxkhyka7PUSJSLvuVDBeH/4/4pUGGcHO+7UJGh7wQ8mv0NPrkB3Uq9oFQD9crBC5k9MFgObwYg8BhMXo3cqeqpikD0i8n4RERFqqBzrfOCO4FLEglEy33777WY5Oxhl89Zbb1UjbqKbIx6jJ1ggwqBNxsZ9EhcWJCVoBsupkuO6RaqRW9PS0jxdPKKAhPHJMF6X7cSbROSdFy2oTOmM2lqXAqCnn3662VDhGM0ZvbAwhDjG4nnqqafUwIiYeiJQq9tVM1jPKPliR6ks31+hAiBHU3sQUef9qOJGRKRxqX4JtT/Wo0BjXhSMCYTRnzFDvDZXSqA7uZe5O/yvmRVibGTyJRERkU8HQJi2As08mpUrV6q5wLR2Om1U6ECGfIOhKeESHaqX8tpG+SPfPG0Hq9+JiIh8NADCrL87d+5U9zH/FgIgNH1piouLLbMMB3LyFprBju8WqR6vyjQ3f2FiNyIiIvLBAAhJzsj5QTPXDTfcoHJbMHWFZt26dcfM1RWoxmeYA6BfMys5BgkREZEvB0APPPCAREZGyp/+9Cd59dVXVdIzxtbQYCoLzNYe6JAMjeTnYL1OcsrqJauUvU+IiIi8icHVJrCffvpJSktLVVMPTvTW3nvvPUlMTJRAhzwpTIQ6omu4rM2uUs1gGXEJUlZWJjExMZ4uHhERUcBzugYIIzNqYmNjjwl+QAt+rLcNZBOamsF+yzSPBp2bm+vhEhEREZFLAdDQoUPlnnvukczMTIfbINH3rrvukiFDhgT80UUtkJYHtC2/RkqqGwL+mBAREflcE9jq1avljjvukL59+6pgCF3eU1JSVIIvajbWrFkj27dvl/POO09+//13CXSoIUuKDJa+iaGyp7BWNYWd2jdGDROArvJERETkAwEQZnpHjg/m03n//fdVF3j0+sJw1TihX3LJJXLBBRdIjx49OrbEPua49IhmAVBVVZWni0RERBTwXJ69FIHQ7bffHvAHzlnoDfbu5mJZl10ljSaT6DkbNRERkW91g8c09QsXLlQ5PoMHD1b3sY7sQxPh4OQwiQjWS2mNUdUEERERkY8FQPfff78a+2f8+PGWyU8xNhDZh95yBr1ORqWFq8drD1VZRswmIiIiHwmAMOnpJ598Iq+88oq6ffjhh2odtey4dHNvsLXZ5u7wHCaAiIjIhwKgrKwsmTx5suXxlClTWuwWT+axkY7rFmHpDl9Ra+RhISIi8qUACDOaWw+AGBISwlnOnQiAUqKCJSMuRBpNIhsOm5vBODs8ERGRD/UCmzlzZqvrvvjii7aVyk+7w2eW1Kk8oBN7RqtBI/v37+/pYhEREQUklwIgTILqzDpqDjVlo9Mi5OM/SmRDDscBIiIi8qkACEnP5DqMnVRaWSNBOpHcigY5XFYvXWOOnUuNiIiIvDAHiNwXHqyXQclh6r6WB1RTU8NDSkRE5AEMgDrRyK7m3mBaMxh70BEREXkGA6DOOtB6vcoDgo2Hq9W0GEREROQZDIA6Sd++fWVAUpiEGXRqWoz9ReYpREwMhIiIiDodA6BOFBykk2Gp4c2awXJzczuzCERERMQAqPONamoGW98UAJWXl/OLSERE1MlYA9SJevfuLaOaEqG35FVLA4aGJiIiok7HAKgTGQwG6ZUQIjGheqltMMnOAnaDJyIi8gQGQJ19wHU6Gd6UB7TpcLVaYloMIiIi6jwMgDpZZGSkjGhqBtvEiVGJiIg8ggFQJ0tNTZURXc01QNvya6TO2NjZRSAiIgp4DIA6WVBQkPSIC5G4sCCpNSIPqDbgv4RERESdjQGQB+h0OkstkNYMtmvXLk8UhYiIKCAxAPKQowGQORGaiIiIOg8DIA9ISEiwJEJvK6iRugbmAREREXUmBkAe0KVLF+kWEywJ4UFSbzSpIIiIiIg6DwMgL8gD2tzUDLZv3z5PFYeIiCigMADyoOGp5mawzbnmAKihocGTxSEiIgoYDIA8JCIiQkY21QBtz6+RWuYBERERdRoGQB7SrVs3SYsJlsSIIKlvNMl25gERERF1GgZAHs4DsjSDsTs8ERFRp2EA5C3jATXlAXFARCIioo7HAMiDMjIyZETTzPA7mAdERETUaRgAeVBYWJjKA+oSYVB5QJgcFSoqKjxZLCIiIr/HAMgb8oBspsXIycnxcKmIiIj8GwMgL6A1g23ONU+MSkRERB2LAZAXGNk0L9iOghqprue8YERERB2NAZCHxcfHS2q0QZIjDYKxEP/I5+zwREREHY0BkIclJSWpPKCRaU15QDnmAKi2ttbDJSMiIvJfDIC8xIimARE3HjbnAR08eNDDJSIiIvJfDIC8QP/+/S0DIu4urJXKOqOni0REROTXGAB5ieSoYDUmUKPp6OzwRiMDISIioo7AAMiLjLQZD6i8vNzDJSIiIvJPDIC8yIiuzfOA8vPzPVwiIiIi/8QAyEtERERYaoD2FdVJaQ2bv4iIiDqKQTysrq5OfvjhB8nLy5Nhw4bJmDFjWn1NZmamrF69WgwGg4wbN07S09PF13Xr1k2qqnZJr/gQ2V9cJxtyqmRy72gpKSmRuLg4TxePiIjIr3i0BqigoEAFPDfddJN8+eWXcuqpp8rVV1/tcHuTySRz5syRyZMnywcffCCvvPKK9OvXT5YsWSL+YnSauRlsfQ6bwYiIiPyyBmjhwoVquWHDBtUEtG7dOhk7dqycddZZcuaZZ9oNgGbNmiVvvfWW6PXm2O3NN9+Uyy+/XL2mT58+4uvGpEfIR3+UyLrsKvV5MUgiERER+UkNUGNjo7z//vtyxRVXqOAHUBs0ceJEeffdd+2+BkHPRRddZAl+YPr06WpfO3fuFF+XmJgoQ1PDJVivk4LKBjlUVu/pIhEREfkljwVAWVlZqpv34MGDm63H4z/++MPp/XzxxRcSFBQkw4cPd7gNppUoKytrdvPWACjMoJchKWHqMWqBAAEeERER+UEApAUhtgm+mBzU2QBl+/btcsstt6gbkogdWbx4scTGxlpu3bt3F29vBoP1TQHQnj17PFwiIiIi/+KxACg8PNzuYH8IfrQmsZbs27dPpk2bJjNmzJCHH3641Vyj0tJSyw21T94KtUBaIvSmw1XSgKGhiYiIyD+SoHv06CEhISGyf//+ZuvxuG/fvi2+FtugJxjyhZAEbZ0TZE9oaKi6+QIEQH0Sj0hsWJAaC2h7fo0MSzUHi0REROTjNUDBwcFy+umnq4Rn9HaCnJwc+emnn+Tss8+2bLd8+XKVLK05cOCACn4mTJigeoMh/8ff6HU6GdU0KKKWB7Rr1y4Pl4qIiMh/6Exa9OEBO3bsULU4kyZNkvHjx8sbb7whycnJ8uOPP6pBDmHevHmyatUq2bp1q9TU1MigQYOkqqpKFi1a1Cz4QVA0cOBAp94XzWzIBUJzWExMjHgbBDtLd5fJYz/nSb/EUHlmVoZl1ngiIqJAVdaO52+PjgOEgGXz5s0q8MFI0H/729/k0ksvtQQ/WmCD5jJtdnR0e4ctW7Y02xdGkfYXvXr1krHVu9X93YW1UljVIIkRHh+0m4iIyG94tAbIU7y9BkirBZr/eabsPFIrN09KljP6x0pSUpLqJUdERBSIytrx/M3JUL3Y8RmRark6s9IydQgRERG1HQMgLza+e6RlXrC6Bg6GSERE1F4YAHmxPgmhkhgRJDUNJtmcW63WBWCLJRERUbtjAOSl0OMLE6Ee31QLtDqr0u7AkUREROQ6BkBeTguAVmVVqtqf3NxcTxeJiIjI5zEA8mLp6ekyKi1CQoJ0klfRIJkldZ4uEhERkV9gAOTFIiMj1ezwI5tGhf7loLkZjIiIiNqGAZAPOLFnlFr+vN+c/1NZyUCIiIioLRgAeTkMfDihR5QE6UT2FdepZrDs7GxpaGjwdNGIiIh8FgMgH5gdPiY0SEanR6jHKw6Ya4E4KCIREZH7GAB5Ob3e/Cc6uVe0Wq7YX6GW7A5PRETkPgZAPgDznUzIiBSDXuRAUzMYERERuY8BkA9ITU2VaDSDpTU1gzUlQ2NSOCIiInIdAyAfERcXJyc1NYMtb2oGy8vL83CpiIiIfBMDIB+RlJQkE5uawQ6W1Mn+4lpLfhARERG5hmdQH4F5waJCg2RsN/PUGN/tLhOj0SiNjZwlnoiIyFUMgHysS/zp/WPU/e/2lEu90SR79uzxdLGIiIh8DgMgHwuAxnWLlITwICmtMcpvmeZcICIiInINAyAfE6TXyfR+5lqgb3aZe4GhKYyIiIicxwDIx4SEhMj0pmawddlVklteL3v37vV0sYiIiHwKAyAfEx4eLmkxIWqGeJOILN1trgXatWuXp4tGRETkMxgA+ZiEhAS1PKN/rFp+g95gjQiFiIiIyFkMgHxMcHCwGhn6hB6REh2qlyOVDbI2u0o9V11d7eniERER+QQGQD4oOjpaQgx6ObWvORfoo63FapmVleXhkhEREfkGBkA+OigiRoY+b0icBOlENh6ulh0FNeq5yspKTxePiIjI6zEA8lHx8fGSEhUsp/Qxzw/2/uYitczOzvZwyYiIiLwfAyAfhlygC4bFq/srD1ZKZkmdus/pMYiIiFrGAMiHRUVFSc/4UJmQEam6xH+wxZwLVFBQ4OmiEREReTUGQD4Ms8EjCLpouLkW6Ps9ZZJfUS+lpaUcHZqIiKgFDIB8XGxsrAxKDpcRqeFiNIl89EeJWp+Tk+PpohEREXktBkB+MDI0XNhUC/TVjlJVC4Qxgerr6z1cOiIiIu/EAMgPmsEMBoOMSY+QoSlhUms0yctrjqjn9u/f7+niEREReSUGQH7SGwxjA107Pkl0IrJsf4VsyTWPCs2EaCIiomMxAPIDERERanTovolhcsYA8+jQz64qUHOEFRebe4YRERHRUQyA/ERKSopaXj46USJD9LK3qFa+2WWeKT43N9fDpSMiIvIuDID8KBcoIyND4sINcumoRLXutfWFUl5rlLKyMjGZOGM8ERGRhgGQHwkLC5Pk5GQ5a1Cs9IgLkdIao7yxoVA9d+DAAY4NRERE1IQBkJ+Ji4sTg14n1xyfpB5/tq1U1hyqVF3i9+7dyyCIiIiIAZB/Qo+w0ekRcvagWPX40RV5UljVoO4fOWLuIk9ERBTIWAPkh3r06KGWV43tIn0SQlVT2OJluapXGKbJYD4QEREFOgZAfigkJESSkpIkxKCXu05JlTCDTjbnVstbG4vU81lZWZ4uIhERkUcxAPJT8fHxkpaWJt1iQ+TGE5LVOgRAGw9XSU1NjeoZRkREFKgYAPkxzBSP29Q+MTK9X4ygI/zDy3Ilt7xejQ3EIIiIiAIVAyA/h27xgGky0DW+qNoot399SAoqzUEQ84GIiCgQMQDyc5gotWfPnhIerJfF09MlLTpYcisa5Pavs1XPsN27d6sbmsWIiIgCBQOgAEmK7tatm3SJNMijZ6RLSpRBssvqZcE32VJS3aBqgTIzMxkEERFRwGAAFEATpsbGxkpyVLA8cnq6dIkwyMGSOlnwbbaU1RrVNtnZ2WwSIyKigMAAKMAmTA0NDZW0mBB55Ix0iQ8Pkn1FdSon6HB5vRolGs1hWBIREfkzBkABBk1h0D02RNUExYaZg6DrPsuUVZkV6jlMmYERoxkIERGRv2IAFGCCgoIsI0X3jA+VZ87uLgOTwqSirlEWfX9YXl17RI0YXVRUpAKh6upqNosREZHfYQAUgNAM1rt3b4mMjFQ5QY/P6CazBpvnDXt3c7HKCyqubrCMGo1msYYG82MiIiJ/wAAogLvHp6enS/fu3SU4SCfXjU+WhZPN02ZsOlwt13yaKT/uLZNGE4ZPFNm3b5/U1dV5uthERETtQmcKwJHwMAIyekRhYtCYmBgJdMj1QXMXZJbUyQM/HlY9xGBAl1C5alySDEsNt9QeYZ6x8PBwNes8ERGRL56/GQAxAFIQB6MbfFVVldQ2NMrHf5TIu5uKpLrBHB+f0CNS5h3XRdJjQyxfHjShoWcZapOIiIg6GgMgLzqA/hYEId9HgzygNzcUyVc7S6XRJBKkE5k5KFbOGRwn6TFHA6Hg4GA15QbGGmKtEBERdRQGQF50AP0xCEIX+OLiYsu6g8W18tKaI/L7oSrLuhFdw+WM/jEyqUeUhBiOppLp9XrJyMiwBEYMiIiIqL0wAPKiA+ivGhsb1WSpFRXmsYFgQ06VfLi1WNYeqlIzy0N0iF6m9I2WM/rHSu+E0GP2g9nocazR/R7BEKblYFBERETuYADURgyAnFdZWalyg6zlV9TL0t1l8s2uMsmvPNo9vnd8iIxOj5DRaREyNDVcwqxqhjQIhNBchslX0WTGwIiIiJzFAKiNGAC5Bt3f8/Ly1KCI1jBg4obDVfLNzjL5NbNCGhqPPhes18nglDAVDI1Ki5B+iaESpG+511haWppaIjBCUxoREZHfBkB4+7Vr16oT7NChQ6Vnz54d8hprDIDchyaxnJycY9aX1hhlXXalbMiplnU5VXLEqmYIIkP00jchVHomhEjPuFDphWV8qEQE2w90EhMTVTNcdHS0lJSUqCAsLCxM1RjV19dLQkJCm/OM8D3SxjbCfvHZ8H64T0RE3sVkNMqRFSvk8lmz5LXPPpMuJ50kujb8Xns0AEIgMmPGDDUGzcCBA+X333+Xm2++WR588MF2fY29fTAHqG0QOBw4cMBxl/qyelmfU6XyhjYerpbKOqvqISspUQbpFR8qPeNDpFtsiCRFGqQLbhEGCXcQHNmrOcJ7ojs+ao5ayzPSAp9Dhw7Zne8MgRaa6DQY8wj7RmCEEbG7dOmi1uMxtsP2CMpQQ4ZhBBC8YTu8BuMmoSx4T2yDgE07fnjv2tpa9XqUGa/HPvEZsB22B9zX9oelFvRZ79PTeVWOyoIgFp8Ln6+8vNxSw4cke3xuvA5LvEb7bNoxIyLSlC1dKnn/WCwNubmWdYbUVEm5c6HETJsmPhcA3XDDDfL111/LmjVrJC4uTpYvXy6TJ0+WH374QaZMmdJur7HFAKh94KuDEz5qaLB09FVCU9m+olrZX1wnB4rNy/1FtVJU3fKs80iwRjBkCYoiDZIYYZDokCCJDtVLdGiQRIWYlxjB2vqkieRrBBIIMlAuBCp4Huu0wKIzaO/Z3hPL4vNpCerYP4JABBn4W+CzYh0CCVQRI9hCEKfldOF4YFvctGPRluR07C8zM1MFc3hPjC6O+3gvzCnnKgR6KLcWdCJgQnCE97FOpMcxRVCF99SCKK083hIYElH7BD/ZN96E/9zNn2j6/53+xBK3giCPBUB4W1wp33777bJgwQLL+nHjxqlmrVdffbVdXmMPA6COgxMPeo/Z5gvZ/TvUGC0BEZa5FQ1SUNkgBRX1lgEYnYV866iQIIlCYNS0DDfoJdSgk1CDXgVIWIYGWT/WqURtLEOC9GofBr3OfAvSiUGHpdU6y80c2JD/QKClBakInBB8aYEWAjCthhHw3UZwh8cIRBHsIUDDtgg+0YyKG7ZhkypR25u99kw9tVnNTzP4nU5Jkb4/fO9yc5jHhvBF8wOqwYcPH95sPR5v3Lix3V4D+IHCzToAoo6BkwdqAND0gRMATgg43vZqQGLCgmR41wh1s1VZZzQHQ5UNKp9Iu19U3SAVtY1SXmeU8tpGqag1itEkKgG7pMaobiIdX8ODQSH1ep0grzsItTx4rG7afat1VtshbkLDnq7pPsKoo0udzWM76/Dm6r45ANPWa7S4THvN0Ue266xeY/vYZsUxL7HaoKUwsMXnPBQ/euJto6KjRKdjUn8gePi8YRIZypHx21PV2nWOgx8wmdTz2C7y+HEu7dtjfylkcEN8fHyz9ajhQTV+e70GFi9eLPfdd187lJqchSYY7UoYc4dZ54IUFhaq5htcPSNAQhOGlh+iiQwJUjckSrdENW81mKS8tikg0gKjOqPUNpjUtB54vtZovo91NU1L9dhoflzXYJKGRpOg4qnBaFLNdvWNWIpa2kLQZcQ/5lLwi0EtODqWFvm3B2cN9XQR/E5DQUG7bucVARBOeoDcEWs4MaI9v71eAwsXLpRbbrnF8hg1EqiloM4NiDB3GKSmph7zPOYUQ4CLv62Wz4HgCE0L1gnJtrBdeDBuekmO6piyI8gy1zKZVHCklo0ijU3rsUSM1NjYtERwpK3DsmlbpIGr+wiYmrYDPKeFUFiHRmmsUUvzpuZb03bWjdbafesQTNuu2fqm/Vi/xvZ19tbYNpA3e+hC3Ofsph0ZSnoq27FLl0QO6xAgQp3suEHOMyQltet2zV4jHoIABG3oSJ60hse9e/dut9dogZMWPJH3Bkio2bOt3bPXews31PhpuRqoXUITJ+5rwRJykfA3t276dBeCLIPOnAvkuf8x/kvr9ab9rbTBMbUE9s7AHCAi7xRx3BjV26shL8/+VUxTDhC286leYNOmTVM/fF9++aV6jKYRBDmPP/64XHPNNWrdunXrVE+S0047zenXtIZJ0ERERD7WCwysQxZf7QUG69evlxNPPFEuuOACmTBhgrz00kvqyn316tWWGpt58+bJqlWrZOvWrU6/pjUMgIiIiAJ7HCCPNliOHj1a1fCg2QPj+fzpT3+Sn3/+uVkgc9xxx6laH1deQ0RERP4jZto01dW9y3PPyt9ystUSj90NfrxiKgxPQLItBlHMysribPBEREQ+QuvEhDxQzOjQFgGZ0om8IWBPMCIiIt88jzMAcoM2kSZ6j7X1AAYyLRJnTRqPpTfh95LH0dvwO9m+LTgZGRmW83hbGAK12y0g+MGcQ9Q2OIY8ju2Dx7L98FjyOHobfifb/zzepn20S0mIiIiIfAgDICIiIgo4ARkAocv8vffey67zPI5eg99JHktvw+8kj6W/fy8Dshs8ERERBbaArAEiIiKiwMYAiIiIiAIOAyAiIiIKOPpAHD1yzZo1kms1oRq5DhPQYoLa/fv3S2NjIw9hO9i+fbv88ssvUltby+PZBnv37pU//viD38s2aGhokN27d8uGDRukuLiY30cXFBQUqP/HRUVFDrfJyclR5yEe25Zt27ZNfv31V4fPV1VVycaNGyU7O1vcYgogixYtMoWGhpoGDx6slv/3f/9nMhqNni6WT6murjbdfvvtpoSEBNPQoUNNaWlppv79+5tWrlzp6aL5tE2bNpkiIiLQIcG0f/9+TxfHJ23YsME0bNgwU3JysmnMmDGmIUOGmDZu3OjpYvmcn376yZSRkWHq3r27adSoUabw8HDTlVdeyd/KVmzZssU0Z84cU0pKivp//MknnxyzTX19vemSSy4xhYWFWc5DDz30UEf9KX3WW2+9ZRo7dqwpPj5eHSNbubm5piuuuMIUGxtrGjlypDofTZgwwbR3716X3idgaoA+++wzWbx4sfz444/q6nDTpk3y4YcfytNPP+3povncMOSJiYly8OBB2bJli5pOZPLkyTJr1izWXLgJVzFz5syR66+/vn3/WAEkLy9PTj31VJk0aZK6ul67dq36P3/48GFPF83nXHbZZTJlyhT1f3z9+vWyatUqefXVV+X999/3dNG8Gs4rZ555plo68vjjj8vXX3+tajaw3VdffSX33HOPLF26tFPL6u127NghTz31lDz66KN2n8f0SyeddJIcOXJE1VLiPBQeHi5z58517Y1MAeLss882nX766c3WzZs3zzRixAiPlclfrF27Vl3xoBaDXIcrmeuvv15debMGyD0LFy5UNT81NTX8CrZBY2Ojqol8/vnnm62Li4szPfnkkzy2TigvL3dYA4Ta8ptuuqnZukmTJpkuvPBCHls7XnrpJbs1QPa89tprJr1er2rZnBUwNUCIEseMGdNs3bhx41QeC/JZyH1oyw4KCpKePXvyMLro3XffldWrVzu80iHn/PDDD3Laaaep+YHwf525ae7R6XTy0EMPqe/jW2+9pWom5s2bJz169HD96pqaqayslF27dtk9D+E7S20/D+F7ajA4P8VpwEyGioQ0NN1Yw2Oj0ahm6rV9jpxPOL3rrrvkxhtv5ISobhy7+fPny/fff6+qb8l9aPZKT0+XoUOHqmOJTg74P/3222/LiBEjeGhdcPbZZ8vnn38ut99+uyQlJcmhQ4fk4Ycflvj4eB7HNtASnu2dh1pKmKbWLVu2TF544QV58cUXxRUBEwAFBwdLTU1Ns3XV1dVqGRIS4qFS+f5JZ/r06TJx4kT1A0muufLKK9XxKy8vV71GkFMFyF9Bz7revXvzkLrw//vLL7+UlStXynHHHSd1dXVy4YUXykUXXaR615Fz8BuJnL6ZM2eqwBw1aqglHz9+vLqyvvzyy3ko2/Ad1Y6x7XmI5yD3rVu3Ts455xx1EX7FFVe49NqAaQJD1ZhtVzk8jouLk+joaI+Vy5eDn1NOOUUGDBggH330keU/NzkvOTlZDhw4IAsWLFA37erlkUceUQm85Dw0vyLwwQ1wQvnLX/6ikimRKEnOQecQJJhec801KvgB1KqdfPLJqlaI3IfatIiICLvnoYyMDB5aNyBJH03fCHwee+wxl18fMAEQDhIy7tHkpcFJBuvJNehZg+CnT58+8vHHH/PqpQ35P6j50W7o9QAffPCB3HzzzfxaugA1afheWo9JhaYbBEIxMTE8li6cpLVjZw2PtefIPQgo0bvOOpBETSV6hfE85DqM/4Pjdskll8i///1vt/4mAdMEdsstt8gbb7yhqsQvvfRSVV2OA4h2Q3KtG/zUqVNVIHnrrbeqxDMNrhRRo0bU2a699lp56aWX1P9tJOuiWyy6FyOQZPOC89Dsiq7cqAG67777JCUlRXV/RzPif/7znw78C/o+5PGge7uWWoFj1qVLF5Wb1qtXL7UOx/SEE05QzTUYtuHll19WgdENN9zg4dJ7l507d6oBJffs2YOe6uoCEZDPhxYbJJPj+OGcM3v2bMvzWlK5s//nA2o2ePQMQe8GHFxUOeLHkQmSrsEX0lEeAMa4OP7449vlbxWI0BMESdEYnyo1NdXTxfE5+fn56v83Lmxw4sHYVLjgQc8mch5GIkdz7PLly1V+Gmp6r7vuOhkyZAgPYwt+/vlnWbhw4THrL7jggmYBDnJWnnjiCdX0NXDgQLnjjjvYBGbj73//u8pBs4Xv5eDBg1XvxPvvv1/s+eSTT5yurQyoAIiIiIgooHKAiIiIiDQMgIiIiCjgMAAiIiKigMMAiIiIiAIOAyAiIiIKOAyAiIiIKOAwACIiIqKAwwCIiPzC7t275fnnn1cDIRIRtYYBEBH5hb1798qrr74qY8eOVSOWExG1hAEQEfmF008/XZYtWybBwcFqWgIiopYwACIivxEREaHmV9q0aZOni0JEXi5gZoMnIv+3detWdYuLi/N0UYjIy3EyVCLyC0ajUSZOnCgHDhxQ948cOeLpIhGRF2MTGBH5hSVLlkhubq688MILUlhYKDk5OZ4uEhF5MTaBEZFf9ABbtGiRfPLJJzJ69Gi1bvPmzZKWlubpohGRl2INEBH5NJPJJFdddZXMmTNHpk2bJl26dJH09HQmQhNRi1gDREQ+7aWXXpKdO3fKxx9/bFk3YsQIVQNEROQIa4CIyGchz+f2229XeT+xsbGW9QyAiKg17AVGRD4rPz9fJT4PHz682fqCggLJzs6WkSNHeqxsROTdGAARERFRwGETGBEREQUcBkBEREQUcBgAERERUcBhAEREREQBhwEQERERBRwGQERERBRwGAARERFRwGEARERERAGHARAREREFHAZAREREFHAYABEREVHAYQBEREREEmj+H4eWBQ1zI5WmAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.scatter(on_locus[:, 0], on_locus[:, 1], s=2, color=\"0.85\")\n",
+    "ax.plot(principal[:, 0], principal[:, 1], color=\"C0\", label=\"principal branch\")\n",
+    "ax.plot(branch_upper[:, 0], branch_upper[:, 1], color=\"C1\", label=\"second branch, upper side\")\n",
+    "ax.plot(branch_lower[:, 0], branch_lower[:, 1], color=\"C2\", label=\"second branch, lower side\")\n",
+    "ax.scatter([12, 12, 12], [0, 2 / 3, 1], marker=\"o\", color=\"C3\", zorder=5,\n",
+    "           clip_on=False, label=\"Nash equilibria\")\n",
+    "ax.set_xlabel(r\"$\\lambda$\")\n",
+    "ax.set_ylabel(\"P(Stag), row player\")\n",
+    "ax.set_xlim(0, 12)\n",
+    "ax.set_ylim(-0.02, 1.02)\n",
+    "ax.legend(loc=\"center right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ed30af0",
+   "metadata": {},
+   "source": [
+    "## Remarks\n",
+    "\n",
+    "The upper side of the second branch converges to the payoff-dominant equilibrium (Stag, Stag), and the lower side to the mixed equilibrium — neither of which can be found by following the correspondence from the centroid.\n",
+    "The two sides stop just short of each other at the fold, which fixed-$\\lambda$ continuation cannot go around.\n",
+    "\n",
+    "Some natural directions from here:\n",
+    "\n",
+    "- Gambit's internal path-follower could trace the whole branch (including around the fold) starting from any polished point; the C++ implementation accepts arbitrary starting points, although this is not currently exposed in the Python API.\n",
+    "- The sampling method needs only expected payoffs, which Gambit computes for any finite game, so the same code applies well beyond $2\\times 2$ examples; [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) discusses performance in larger games.\n",
+    "- [Bla24](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) builds a Bayesian estimation procedure on top of this sampling approach, in which the penalty acts as an equilibrium constraint inside a posterior sampler; see also [BlaTur23](https://gambitproject.readthedocs.io/en/latest/biblio.html#articles-on-computation-of-equilibria) on maximum-likelihood estimation along the principal branch with `logit_estimate`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds an advanced tutorial notebook, `doc/tutorials/advanced_tutorials/quantal_response_branches.ipynb`, on the simulation method of Bland (2024, SSRN 4774850) for finding branches of the logit QRE correspondence that path-following from the centroid can't reach. I've added the reference to `doc/references.bib` and the notebook to the advanced-tutorials toctree in `doc/pygambit.rst`.

The notebook works through two examples. The first is a 2x2 stag hunt: the principal branch converges to the risk-dominant equilibrium, and sampling from Bland's penalty density turns up the second branch, whose two sides converge to the payoff-dominant and mixed equilibria. Draws get polished with Newton iteration, then the branch is traced by warm-started continuation in lambda up to the fold.

The second example is the three-player 2x2x2 game of McKelvey-McLennan (1997) (`doc/2x2x2.nfg`, the same game the starting-points tutorial uses; nine Nash equilibria, two of them totally mixed). This one is more interesting: `logit_solve_branch` stops at a bifurcation around lambda = 0.597, where max regret at the returned point is still 0.213. The notebook shows what's going on directly: the principal branch has a closed form past the stopping point, and a second branch crosses it there. Sampling plus seeding at a few values of lambda finds 22 distinct LQRE, and following their branches upward reaches all nine equilibria, including both totally mixed ones.

For the lambda-elimination and the penalty I followed the author's own implementation in the online appendix (https://github.com/JamesBlandEcon/ApproxQRE). The sampler is a plain random-walk Metropolis rather than HMC so the notebook stays self-contained; the Remarks section points to HMC for larger games.

All cell outputs are computed. The notebook executes in about 25 seconds and runs under `pytest tests/test_tutorials.py --run-tutorials`. One thing I noticed along the way: ruff doesn't currently lint the notebooks at all, because of a quoting typo in the `include` list at `pyproject.toml:68`. Happy to fix that in a separate PR if you'd like.
