### PR TITLE
Refactor Nash support iteration to a lazy algorithm.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@
   the run.  (#998)
 - Implemented bespoke XML parser that handles the subset in the de-facto legacy XML workbook .gbt format;
   removes dependency on tinyxml.  (#897)
+- Enumeration of candidate supports for a totally-mixed Nash equilibrium is now done by a
+  lazy generator algorithm rather than materialising all as a single list up front.
 
 ### Fixed
 - Converting a behavior profile to a strategy profile, and computing pure-strategy payoffs

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -583,11 +583,9 @@ cdef extern from "solvers/gnm/gnm.h":
     ) except +RuntimeError
 
 cdef extern from "solvers/nashsupport/nashsupport.h":
-    cdef cppclass c_PossibleNashStrategySupportsResult "PossibleNashStrategySupportsResult":
-        stdlist[c_StrategySupportProfile] m_supports
-    shared_ptr[c_PossibleNashStrategySupportsResult] PossibleNashStrategySupports(
-            c_Game
-    ) except +RuntimeError
+    cdef cppclass c_PossibleNashStrategySupports "PossibleNashStrategySupports":
+        c_PossibleNashStrategySupports(c_Game) except +
+        optional[c_StrategySupportProfile] Next() except +RuntimeError
 
 cdef extern from "solvers/enumpoly/enumpoly.h":
     stdlist[c_MixedStrategyProfile[double]] EnumPolyStrategySolve(

--- a/src/pygambit/nash.pxi
+++ b/src/pygambit/nash.pxi
@@ -160,13 +160,20 @@ def _gnm_strategy_solve(
         raise
 
 
-def _nashsupport_strategy_solve(game: Game) -> list[StrategySupportProfile]:
-    return [
-        StrategySupportProfile.wrap(support)
-        for support in make_list_of_pointer(
-            deref(PossibleNashStrategySupports(game.game)).m_supports
+def _nashsupport_strategy_solve(
+        game: Game
+) -> typing.Generator[StrategySupportProfile, None, None]:
+    generator: shared_ptr[c_PossibleNashStrategySupports] = (
+        shared_ptr[c_PossibleNashStrategySupports](
+            new c_PossibleNashStrategySupports(game.game)
         )
-    ]
+    )
+    result: optional[c_StrategySupportProfile]
+    while True:
+        result = deref(generator).Next()
+        if not result.has_value():
+            return
+        yield StrategySupportProfile.wrap(make_shared[c_StrategySupportProfile](result.value()))
 
 
 def _enumpoly_strategy_solve(

--- a/src/pygambit/nash.py
+++ b/src/pygambit/nash.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
+from collections.abc import Iterator
 
 import pygambit.gambit as libgbt
 
@@ -636,25 +637,25 @@ def gnm_solve(
         raise
 
 
-def possible_nash_supports(game: libgbt.Game) -> list[libgbt.StrategySupportProfile]:
-    """Compute the set of support profiles which could possibly form the support
+def possible_nash_supports(game: libgbt.Game) -> Iterator[libgbt.StrategySupportProfile]:
+    """Generate the support profiles which could possibly form the support
     of a totally-mixed Nash equilibrium.
 
-    Warnings
-    --------
-    This implementation is currently experimental.
+    .. versionchanged:: 17.0.0
+
+       Returns a generator instead of a list.
 
     Parameters
     ----------
     game : Game
         The game to compute the supports in.
 
-    Returns
-    -------
-    res : list of StrategySupportProfile
-        The list of computed support profiles
+    Yields
+    ------
+    StrategySupportProfile
+        The next computed support profile.
     """
-    return libgbt._nashsupport_strategy_solve(game)
+    yield from libgbt._nashsupport_strategy_solve(game)
 
 
 def enumpoly_solve(

--- a/src/solvers/enumpoly/efgpoly.cc
+++ b/src/solvers/enumpoly/efgpoly.cc
@@ -240,9 +240,9 @@ EnumPolyBehaviorSolve(const Game &p_game, int p_stopAfter, double p_maxregret,
   }
 
   std::list<MixedBehaviorProfile<double>> ret;
-  auto possible_supports = PossibleNashBehaviorSupports(p_game);
+  PossibleNashBehaviorSupports possible_supports(p_game);
 
-  for (auto support : possible_supports->m_supports) {
+  for (auto support : possible_supports) {
     p_onEvent(EnumPolyCandidateSupportEvent<BehaviorSupportProfile>{support});
     bool isSingular = false;
     for (const auto &solution :

--- a/src/solvers/enumpoly/nfgpoly.cc
+++ b/src/solvers/enumpoly/nfgpoly.cc
@@ -154,9 +154,9 @@ EnumPolyStrategySolve(const Game &p_game, int p_stopAfter, double p_maxregret,
   }
 
   std::list<MixedStrategyProfile<double>> ret;
-  auto possible_supports = PossibleNashStrategySupports(p_game);
+  PossibleNashStrategySupports possible_supports(p_game);
 
-  for (auto support : possible_supports->m_supports) {
+  for (auto support : possible_supports) {
     p_onEvent(EnumPolyCandidateSupportEvent<StrategySupportProfile>{support});
     bool is_singular;
     for (auto solution : EnumPolyStrategySupportSolve(

--- a/src/solvers/nashsupport/efgsupport.cc
+++ b/src/solvers/nashsupport/efgsupport.cc
@@ -22,7 +22,7 @@
 
 #include "nashsupport.h"
 
-namespace { // to keep the recursive function private
+namespace { // to keep this helper private
 
 using namespace Gambit;
 
@@ -38,54 +38,85 @@ bool AllActionsReachable(const BehaviorSupportProfile &p_support)
   return true;
 }
 
-void PossibleNashBehaviorSupports(const BehaviorSupportProfile &p_support,
-                                  const std::list<GameAction>::iterator &p_cursor,
-                                  const std::list<GameAction>::iterator &p_end,
-                                  std::list<BehaviorSupportProfile> &p_list)
-{
-  auto copy = std::next(p_cursor);
-  if (copy == p_end) {
-    if (AllActionsReachable(p_support)) {
-      p_list.push_back(p_support);
-    }
-
-    BehaviorSupportProfile copySupport(p_support);
-    copySupport.RemoveAction(*p_cursor);
-    if (AllActionsReachable(copySupport)) {
-      p_list.push_back(copySupport);
-    }
-  }
-  else {
-    PossibleNashBehaviorSupports(p_support, copy, p_end, p_list);
-
-    BehaviorSupportProfile copySupport(p_support);
-    copySupport.RemoveAction(*p_cursor);
-    PossibleNashBehaviorSupports(copySupport, copy, p_end, p_list);
-  }
-}
-
 } // namespace
 
-//
-// TODO: This is a naive implementation that does not take into account
-//       that removing actions from a support profile can (and often does) lead
-//       to information sets becoming unreachable.
-//
-std::shared_ptr<PossibleNashBehaviorSupportsResult>
-PossibleNashBehaviorSupports(const Game &p_game)
-{
-  const BehaviorSupportProfile support(p_game);
-  auto result = std::make_shared<PossibleNashBehaviorSupportsResult>();
-
-  std::list<GameAction> actions;
-  for (const auto &player : p_game->GetPlayers()) {
-    for (const auto &infoset : player->GetInfosets()) {
-      for (const auto &action : infoset->GetActions()) {
-        actions.push_back(action);
+// Candidates are the 2^n ways of choosing, for each action in the game (in player/infoset/
+// action order), whether to keep it or remove it from the full support.  This is walked as
+// a binary odometer over `m_removeFlags`, with the last action in the list as the
+// fastest-changing (rightmost) digit.
+class PossibleNashBehaviorSupports::Impl {
+public:
+  explicit Impl(const Game &p_game) : m_fullSupport(p_game)
+  {
+    for (const auto &player : p_game->GetPlayers()) {
+      for (const auto &infoset : player->GetInfosets()) {
+        for (const auto &action : infoset->GetActions()) {
+          m_actions.push_back(action);
+        }
       }
     }
+    m_removeFlags.assign(m_actions.size(), false);
   }
 
-  PossibleNashBehaviorSupports(support, actions.begin(), actions.end(), result->m_supports);
-  return result;
+  std::optional<BehaviorSupportProfile> Next()
+  {
+    while (Advance()) {
+      BehaviorSupportProfile candidate(m_fullSupport);
+      for (size_t i = 0; i < m_actions.size(); i++) {
+        if (m_removeFlags[i]) {
+          candidate.RemoveAction(m_actions[i]);
+        }
+      }
+      if (AllActionsReachable(candidate)) {
+        return candidate;
+      }
+    }
+    return std::nullopt;
+  }
+
+private:
+  // Moves to the next combination of remove-flags.  The first call leaves the
+  // all-kept (full-support) combination in place; later calls increment the odometer.
+  // Returns false once every combination has been produced.
+  bool Advance()
+  {
+    if (m_exhausted) {
+      return false;
+    }
+    if (m_first) {
+      m_first = false;
+      return true;
+    }
+    for (size_t i = m_removeFlags.size(); i-- > 0;) {
+      if (!m_removeFlags[i]) {
+        m_removeFlags[i] = true;
+        return true;
+      }
+      m_removeFlags[i] = false;
+    }
+    m_exhausted = true;
+    return false;
+  }
+
+  BehaviorSupportProfile m_fullSupport;
+  std::vector<GameAction> m_actions;
+  std::vector<bool> m_removeFlags;
+  bool m_first = true;
+  bool m_exhausted = false;
+};
+
+PossibleNashBehaviorSupports::PossibleNashBehaviorSupports(const Game &p_game)
+  : m_impl(std::make_unique<Impl>(p_game))
+{
+}
+
+PossibleNashBehaviorSupports::~PossibleNashBehaviorSupports() = default;
+PossibleNashBehaviorSupports::PossibleNashBehaviorSupports(
+    PossibleNashBehaviorSupports &&) noexcept = default;
+PossibleNashBehaviorSupports &
+PossibleNashBehaviorSupports::operator=(PossibleNashBehaviorSupports &&) noexcept = default;
+
+std::optional<BehaviorSupportProfile> PossibleNashBehaviorSupports::Next()
+{
+  return m_impl->Next();
 }

--- a/src/solvers/nashsupport/nashsupport.h
+++ b/src/solvers/nashsupport/nashsupport.h
@@ -23,26 +23,138 @@
 #ifndef GAMBIT_SOLVERS_NASHSUPPORT_NASHSUPPORT_H
 #define GAMBIT_SOLVERS_NASHSUPPORT_NASHSUPPORT_H
 
+#include <memory>
+#include <optional>
+
 #include "gambit.h"
 
 using namespace Gambit;
 
-class PossibleNashStrategySupportsResult {
+// Enumerates, one at a time, the strategy support profiles which can be the support of a
+// totally-mixed Nash equilibrium, using the heuristic search method of Porter, Nudelman &
+// Shoham (2004).
+//
+// This is a single-pass generator: construct one instance per game and pull candidates
+// from it, either by repeated calls to Next() or via a range-based for loop.
+class PossibleNashStrategySupports {
 public:
-  std::list<StrategySupportProfile> m_supports;
-};
-// Compute the set of strategy support profiles which can be the support of
-// a totally-mixed Nash equilibrium, using the heuristic search method of
-// Porter, Nudelman & Shoham (2004).
-std::shared_ptr<PossibleNashStrategySupportsResult> PossibleNashStrategySupports(const Game &);
+  explicit PossibleNashStrategySupports(const Game &p_game);
+  ~PossibleNashStrategySupports();
+  PossibleNashStrategySupports(PossibleNashStrategySupports &&) noexcept;
+  PossibleNashStrategySupports &operator=(PossibleNashStrategySupports &&) noexcept;
+  PossibleNashStrategySupports(const PossibleNashStrategySupports &) = delete;
+  PossibleNashStrategySupports &operator=(const PossibleNashStrategySupports &) = delete;
 
-class PossibleNashBehaviorSupportsResult {
+  // Returns the next candidate support, or std::nullopt once the search is exhausted.
+  std::optional<StrategySupportProfile> Next();
+
+  class iterator {
+  public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = StrategySupportProfile;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const StrategySupportProfile *;
+    using reference = const StrategySupportProfile &;
+
+    reference operator*() const { return *m_current; }
+    pointer operator->() const { return &*m_current; }
+    iterator &operator++()
+    {
+      m_current = m_generator->Next();
+      return *this;
+    }
+    bool operator==(const iterator &p_other) const
+    {
+      return m_current.has_value() == p_other.m_current.has_value();
+    }
+    bool operator!=(const iterator &p_other) const { return !(*this == p_other); }
+
+  private:
+    friend class PossibleNashStrategySupports;
+    iterator(PossibleNashStrategySupports *p_generator,
+             std::optional<StrategySupportProfile> p_current)
+      : m_generator(p_generator), m_current(std::move(p_current))
+    {
+    }
+
+    PossibleNashStrategySupports *m_generator;
+    std::optional<StrategySupportProfile> m_current;
+  };
+
+  // NOTE: as this is a single-pass generator, begin() must be called only once; each call
+  // pulls the first candidate from the underlying search.
+  iterator begin() { return {this, Next()}; }
+  iterator end() { return {this, std::nullopt}; }
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
+};
+
+// Enumerates, one at a time, the behavior support profiles which can be the support of a
+// totally-mixed Nash equilibrium.
+//
+// This is a single-pass generator: construct one instance per game and pull candidates
+// from it, either by repeated calls to Next() or via a range-based for loop.  Candidates
+// are produced lazily, so a consumer that only needs the first few supports (e.g. to find
+// up to k equilibria) never pays for the cost of enumerating the rest.
+//
+// TODO: This is a naive implementation that does not take into account that removing
+//       actions from a support profile can (and often does) lead to information sets
+//       becoming unreachable.
+class PossibleNashBehaviorSupports {
 public:
-  std::list<BehaviorSupportProfile> m_supports;
-};
+  explicit PossibleNashBehaviorSupports(const Game &p_game);
+  ~PossibleNashBehaviorSupports();
+  PossibleNashBehaviorSupports(PossibleNashBehaviorSupports &&) noexcept;
+  PossibleNashBehaviorSupports &operator=(PossibleNashBehaviorSupports &&) noexcept;
+  PossibleNashBehaviorSupports(const PossibleNashBehaviorSupports &) = delete;
+  PossibleNashBehaviorSupports &operator=(const PossibleNashBehaviorSupports &) = delete;
 
-// Compute the set of behavior support profiles which can be the support of
-// a totally-mixed Nash equilibrium.
-std::shared_ptr<PossibleNashBehaviorSupportsResult> PossibleNashBehaviorSupports(const Game &);
+  // Returns the next candidate support, or std::nullopt once the search is exhausted.
+  std::optional<BehaviorSupportProfile> Next();
+
+  class iterator {
+  public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = BehaviorSupportProfile;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const BehaviorSupportProfile *;
+    using reference = const BehaviorSupportProfile &;
+
+    reference operator*() const { return *m_current; }
+    pointer operator->() const { return &*m_current; }
+    iterator &operator++()
+    {
+      m_current = m_generator->Next();
+      return *this;
+    }
+    bool operator==(const iterator &p_other) const
+    {
+      return m_current.has_value() == p_other.m_current.has_value();
+    }
+    bool operator!=(const iterator &p_other) const { return !(*this == p_other); }
+
+  private:
+    friend class PossibleNashBehaviorSupports;
+    iterator(PossibleNashBehaviorSupports *p_generator,
+             std::optional<BehaviorSupportProfile> p_current)
+      : m_generator(p_generator), m_current(std::move(p_current))
+    {
+    }
+
+    PossibleNashBehaviorSupports *m_generator;
+    std::optional<BehaviorSupportProfile> m_current;
+  };
+
+  // NOTE: as this is a single-pass generator, begin() must be called only once; each call
+  // pulls the first candidate from the underlying search.
+  iterator begin() { return {this, Next()}; }
+  iterator end() { return {this, std::nullopt}; }
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
+};
 
 #endif // GAMBIT_SOLVERS_NASHSUPPORT_NASHSUPPORT_H

--- a/src/solvers/nashsupport/nfgsupport.cc
+++ b/src/solvers/nashsupport/nfgsupport.cc
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <algorithm>
 #include <numeric>
-#include <functional>
 
 #include "nashsupport.h"
 
@@ -33,36 +32,34 @@ using namespace Gambit;
 namespace {
 
 using StrategySupport = std::vector<GameStrategy>;
-using CallbackFunction = std::function<void(const std::map<GamePlayer, StrategySupport> &)>;
 
 class CartesianRange {
-  Array<size_t> m_sizes;
+  std::vector<size_t> m_sizes;
 
 public:
-  CartesianRange(const Array<size_t> &p_sizes) : m_sizes(p_sizes) {}
+  CartesianRange(const std::vector<size_t> &p_sizes) : m_sizes(p_sizes) {}
 
   class iterator {
-  private:
-    Array<size_t> m_sizes;
-    Array<size_t> m_indices;
+    std::vector<size_t> m_sizes;
+    std::vector<size_t> m_indices;
     bool m_end;
 
   public:
     using iterator_category = std::forward_iterator_tag;
 
-    iterator(const Array<size_t> &p_sizes, bool p_end = false)
+    iterator(const std::vector<size_t> &p_sizes, bool p_end = false)
       : m_sizes(p_sizes), m_indices(m_sizes.size()), m_end(p_end)
     {
       std::fill(m_indices.begin(), m_indices.end(), 1);
     }
 
-    const Array<size_t> &operator*() const { return m_indices; }
+    const std::vector<size_t> &operator*() const { return m_indices; }
 
-    const Array<size_t> &operator->() const { return m_indices; }
+    const std::vector<size_t> &operator->() const { return m_indices; }
 
     iterator &operator++()
     {
-      for (size_t i = 1; i <= m_sizes.size(); i++) {
+      for (size_t i = 0; i < m_sizes.size(); i++) {
         if (++m_indices[i] <= m_sizes[i]) {
           return *this;
         }
@@ -115,19 +112,16 @@ bool AnyDominatedStrategies(const Game &game, std::map<GamePlayer, StrategySuppo
 }
 
 class StrategySubsets {
-private:
   GamePlayer m_player;
   size_t m_size;
 
 public:
   class iterator {
-  private:
     GamePlayerRep::Strategies m_strategies;
     StrategySupport m_current;
     std::vector<bool> m_include;
     bool m_end;
 
-  private:
     void UpdateCurrent()
     {
       m_current.clear();
@@ -179,47 +173,15 @@ public:
   iterator end() { return {m_player->GetStrategies(), m_size, true}; }
 };
 
-void GenerateSupportProfiles(const Game &game,
-                             std::map<GamePlayer, StrategySupport> currentSupports,
-                             std::list<StrategySubsets> domains, CallbackFunction callback)
+std::vector<size_t> ComputeOuterDim(const std::vector<size_t> &numActions, bool preferBalance,
+                                    int numPlayers)
 {
-  auto domain = domains.front();
-  domains.pop_front();
-  for (auto support : domain) {
-    currentSupports[domain.GetPlayer()] = support;
-    if (AnyDominatedStrategies(game, currentSupports)) {
-      continue;
-    }
-    if (domains.empty()) {
-      callback(currentSupports);
-    }
-    else {
-      GenerateSupportProfiles(game, currentSupports, domains, callback);
-    }
-  }
-}
-
-/// Solve over supports with a total number of strategies `size` and a maximum difference
-/// in player support size of `diff`.
-void GenerateSizeDiff(const Game &game, int size, size_t diff, CallbackFunction callback)
-{
-  auto players = game->GetPlayers();
-  CartesianRange range(game->GetStrategies().shape_array());
-  for (auto size_profile : range) {
-    if (*std::max_element(size_profile.cbegin(), size_profile.cend()) -
-                *std::min_element(size_profile.cbegin(), size_profile.cend()) !=
-            diff ||
-        std::accumulate(size_profile.cbegin(), size_profile.cend(), 0) != size) {
-      continue;
-    }
-    std::list<StrategySubsets> domains;
-    std::transform(players.begin(), players.end(), size_profile.begin(),
-                   std::back_inserter(domains),
-                   [](const GamePlayer &player, size_t sz) -> StrategySubsets {
-                     return {player, sz};
-                   });
-    GenerateSupportProfiles(game, std::map<GamePlayer, StrategySupport>(), domains, callback);
-  }
+  const int maxsize = std::accumulate(numActions.begin(), numActions.end(), 0) - numPlayers + 1;
+  const int maxdiff = *std::max_element(numActions.cbegin(), numActions.cend());
+  std::vector<size_t> dim(2);
+  dim[0] = preferBalance ? maxsize : maxdiff;
+  dim[1] = preferBalance ? maxdiff : maxsize;
+  return dim;
 }
 
 StrategySupportProfile
@@ -238,29 +200,157 @@ StrategiesToSupport(const Game &p_game, const std::map<GamePlayer, StrategySuppo
 
 } // end anonymous namespace
 
-std::shared_ptr<PossibleNashStrategySupportsResult>
-PossibleNashStrategySupports(const Game &p_game)
-{
-  auto result = std::make_shared<PossibleNashStrategySupportsResult>();
-  auto numActions = p_game->GetStrategies().shape_array();
-
-  const int maxsize =
-      std::accumulate(numActions.begin(), numActions.end(), 0) - p_game->NumPlayers() + 1;
-  const int maxdiff = *std::max_element(numActions.cbegin(), numActions.cend());
-
-  const bool preferBalance = p_game->NumPlayers() == 2;
-  Array<size_t> dim(2);
-  dim[1] = (preferBalance) ? maxsize : maxdiff;
-  dim[2] = (preferBalance) ? maxdiff : maxsize;
-
-  CartesianRange range(dim);
-  const std::list<MixedStrategyProfile<double>> solutions;
-  for (auto x : range) {
-    GenerateSizeDiff(p_game, ((preferBalance) ? x[1] : x[2]) + p_game->NumPlayers() - 1,
-                     ((preferBalance) ? x[2] : x[1]) - 1,
-                     [p_game, result](const std::map<GamePlayer, StrategySupport> &p_profile) {
-                       result->m_supports.push_back(StrategiesToSupport(p_game, p_profile));
-                     });
+class PossibleNashStrategySupports::Impl {
+public:
+  explicit Impl(const Game &p_game)
+    : m_game(p_game), m_numActions(p_game->GetStrategies().shape()),
+      m_preferBalance(p_game->NumPlayers() == 2),
+      m_xRange(ComputeOuterDim(m_numActions, m_preferBalance, p_game->NumPlayers())),
+      m_xIt(m_xRange.begin()), m_xEnd(m_xRange.end()), m_sizeProfileRange(m_numActions),
+      m_spIt(m_sizeProfileRange.end()), m_spEnd(m_sizeProfileRange.end()), m_current(p_game)
+  {
   }
-  return result;
+
+  std::optional<StrategySupportProfile> Next()
+  {
+    if (!Advance()) {
+      return std::nullopt;
+    }
+    return m_current;
+  }
+
+private:
+  struct Frame {
+    GamePlayer player;
+    StrategySubsets::iterator cur;
+    StrategySubsets::iterator end;
+  };
+
+  bool Advance()
+  {
+    while (true) {
+      if (!m_stack.empty() && AdvanceDFS()) {
+        return true;
+      }
+      while (!NextSizeProfile()) {
+        if (!NextX()) {
+          return false;
+        }
+      }
+    }
+  }
+
+  bool AdvanceDFS()
+  {
+    while (!m_stack.empty()) {
+      Frame &frame = m_stack.back();
+      if (frame.cur == frame.end) {
+        m_currentSupports.erase(frame.player);
+        m_stack.pop_back();
+        if (!m_stack.empty()) {
+          ++m_stack.back().cur;
+        }
+        continue;
+      }
+      m_currentSupports[frame.player] = *frame.cur;
+      if (AnyDominatedStrategies(m_game, m_currentSupports)) {
+        ++frame.cur;
+        continue;
+      }
+      if (m_stack.size() == m_domains.size()) {
+        m_current = StrategiesToSupport(m_game, m_currentSupports);
+        ++frame.cur;
+        return true;
+      }
+      StrategySubsets &nextDomain = m_domains[m_stack.size()];
+      m_stack.push_back(Frame{nextDomain.GetPlayer(), nextDomain.begin(), nextDomain.end()});
+    }
+    return false;
+  }
+
+  // Advances to the next (size, diff) preference pair, resetting the size-profile search
+  // to its start.  Returns false once all pairs have been tried.
+  bool NextX()
+  {
+    if (m_xIt == m_xEnd) {
+      return false;
+    }
+    const std::vector<size_t> &x = *m_xIt;
+    m_size = static_cast<int>(m_preferBalance ? x[0] : x[1]) + m_game->NumPlayers() - 1;
+    m_diff = (m_preferBalance ? x[1] : x[0]) - 1;
+    ++m_xIt;
+    m_spIt = m_sizeProfileRange.begin();
+    m_spEnd = m_sizeProfileRange.end();
+    return true;
+  }
+
+  // Advances to the next size profile (for the current (size, diff) pair) whose total and
+  // spread match, setting up the per-player subset domains and DFS stack for it. Returns
+  // false once all size profiles have been tried for the current pair.
+  bool NextSizeProfile()
+  {
+    while (m_spIt != m_spEnd) {
+      const std::vector<size_t> &sizeProfile = *m_spIt;
+      ++m_spIt;
+      if (*std::max_element(sizeProfile.cbegin(), sizeProfile.cend()) -
+                  *std::min_element(sizeProfile.cbegin(), sizeProfile.cend()) !=
+              m_diff ||
+          std::accumulate(sizeProfile.cbegin(), sizeProfile.cend(), 0) != m_size) {
+        continue;
+      }
+      SetupDomains(sizeProfile);
+      return true;
+    }
+    return false;
+  }
+
+  void SetupDomains(const std::vector<size_t> &p_sizeProfile)
+  {
+    auto players = m_game->GetPlayers();
+    m_domains.clear();
+    std::transform(players.begin(), players.end(), p_sizeProfile.begin(),
+                   std::back_inserter(m_domains),
+                   [](const GamePlayer &player, size_t sz) -> StrategySubsets {
+                     return {player, sz};
+                   });
+    m_currentSupports.clear();
+    m_stack.clear();
+    m_stack.push_back(
+        Frame{m_domains.front().GetPlayer(), m_domains.front().begin(), m_domains.front().end()});
+  }
+
+  Game m_game;
+  std::vector<size_t> m_numActions;
+  bool m_preferBalance;
+
+  CartesianRange m_xRange;
+  CartesianRange::iterator m_xIt;
+  CartesianRange::iterator m_xEnd;
+  int m_size = 0;
+  size_t m_diff = 0;
+
+  CartesianRange m_sizeProfileRange;
+  CartesianRange::iterator m_spIt;
+  CartesianRange::iterator m_spEnd;
+
+  std::vector<StrategySubsets> m_domains;
+  std::vector<Frame> m_stack;
+  std::map<GamePlayer, StrategySupport> m_currentSupports;
+  StrategySupportProfile m_current;
+};
+
+PossibleNashStrategySupports::PossibleNashStrategySupports(const Game &p_game)
+  : m_impl(std::make_unique<Impl>(p_game))
+{
+}
+
+PossibleNashStrategySupports::~PossibleNashStrategySupports() = default;
+PossibleNashStrategySupports::PossibleNashStrategySupports(
+    PossibleNashStrategySupports &&) noexcept = default;
+PossibleNashStrategySupports &
+PossibleNashStrategySupports::operator=(PossibleNashStrategySupports &&) noexcept = default;
+
+std::optional<StrategySupportProfile> PossibleNashStrategySupports::Next()
+{
+  return m_impl->Next();
 }


### PR DESCRIPTION
This re-writes the generation of candidate Nash supports for totally-mixed equilibria to be an algorithm exposing an iterator that generates the supports lazily on demand, rather than materialising the whole (often extremely large) set of supports up-front.
