### PR TITLE
Adding a controlled direction in path.cc

### DIFF
--- a/src/pygambit/nash.h
+++ b/src/pygambit/nash.h
@@ -22,6 +22,7 @@
 
 #include "gambit.h"
 #include "solvers/logit/logit.h"
+#include "solvers/logit/path.h"
 
 using namespace std;
 using namespace Gambit;
@@ -32,8 +33,8 @@ std::list<MixedBehaviorProfile<double>> LogitBehaviorSolveWrapper(const Game &p_
                                                                   double p_maxAccel)
 {
   std::list<MixedBehaviorProfile<double>> ret;
-  ret.push_back(LogitBehaviorSolve(LogitQREMixedBehaviorProfile(p_game), p_regret, 1.0,
-                                   p_firstStep, p_maxAccel)
+  ret.push_back(LogitBehaviorSolve(LogitQREMixedBehaviorProfile(p_game), p_regret,
+                                   PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel)
                     .back()
                     .GetProfile());
   return ret;
@@ -43,16 +44,17 @@ inline std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorPrincipalBranchWrapper(const Game &p_game, double p_regret, double p_firstStep,
                                     double p_maxAccel)
 {
-  return LogitBehaviorSolve(LogitQREMixedBehaviorProfile(p_game), p_regret, 1.0, p_firstStep,
-                            p_maxAccel);
+  return LogitBehaviorSolve(LogitQREMixedBehaviorProfile(p_game), p_regret,
+                            PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel);
 }
 
 std::shared_ptr<LogitQREMixedBehaviorProfile>
 LogitBehaviorEstimateWrapper(std::shared_ptr<MixedBehaviorProfile<double>> p_frequencies,
                              bool p_stopAtLocal, double p_firstStep, double p_maxAccel)
 {
-  return make_shared<LogitQREMixedBehaviorProfile>(LogitBehaviorEstimate(
-      *p_frequencies, 1000000.0, 1.0, p_stopAtLocal, p_firstStep, p_maxAccel));
+  return make_shared<LogitQREMixedBehaviorProfile>(
+      LogitBehaviorEstimate(*p_frequencies, 1000000.0, PathTracer::TraceDirection::Positive,
+                            p_stopAtLocal, p_firstStep, p_maxAccel));
 }
 
 std::list<std::shared_ptr<LogitQREMixedBehaviorProfile>>
@@ -61,7 +63,8 @@ LogitBehaviorAtLambdaWrapper(const Game &p_game, const std::list<double> &p_targ
 {
   LogitQREMixedBehaviorProfile start(p_game);
   std::list<std::shared_ptr<LogitQREMixedBehaviorProfile>> ret;
-  for (auto &qre : LogitBehaviorSolveLambda(start, p_targetLambda, 1.0, p_firstStep, p_maxAccel)) {
+  for (auto &qre : LogitBehaviorSolveLambda(
+           start, p_targetLambda, PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel)) {
     ret.push_back(std::make_shared<LogitQREMixedBehaviorProfile>(qre));
   }
   return ret;
@@ -73,8 +76,8 @@ std::list<MixedStrategyProfile<double>> LogitStrategySolveWrapper(const Game &p_
                                                                   double p_maxAccel)
 {
   std::list<MixedStrategyProfile<double>> ret;
-  ret.push_back(LogitStrategySolve(LogitQREMixedStrategyProfile(p_game), p_regret, 1.0,
-                                   p_firstStep, p_maxAccel)
+  ret.push_back(LogitStrategySolve(LogitQREMixedStrategyProfile(p_game), p_regret,
+                                   PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel)
                     .back()
                     .GetProfile());
   return ret;
@@ -84,8 +87,8 @@ inline std::list<LogitQREMixedStrategyProfile>
 LogitStrategyPrincipalBranchWrapper(const Game &p_game, double p_regret, double p_firstStep,
                                     double p_maxAccel)
 {
-  return LogitStrategySolve(LogitQREMixedStrategyProfile(p_game), p_regret, 1.0, p_firstStep,
-                            p_maxAccel);
+  return LogitStrategySolve(LogitQREMixedStrategyProfile(p_game), p_regret,
+                            PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel);
 }
 
 std::list<std::shared_ptr<LogitQREMixedStrategyProfile>>
@@ -94,7 +97,8 @@ LogitStrategyAtLambdaWrapper(const Game &p_game, const std::list<double> &p_targ
 {
   LogitQREMixedStrategyProfile start(p_game);
   std::list<std::shared_ptr<LogitQREMixedStrategyProfile>> ret;
-  for (auto &qre : LogitStrategySolveLambda(start, p_targetLambda, 1.0, p_firstStep, p_maxAccel)) {
+  for (auto &qre : LogitStrategySolveLambda(
+           start, p_targetLambda, PathTracer::TraceDirection::Positive, p_firstStep, p_maxAccel)) {
     ret.push_back(std::make_shared<LogitQREMixedStrategyProfile>(qre));
   }
   return ret;
@@ -104,6 +108,7 @@ std::shared_ptr<LogitQREMixedStrategyProfile>
 LogitStrategyEstimateWrapper(std::shared_ptr<MixedStrategyProfile<double>> p_frequencies,
                              bool p_stopAtLocal, double p_firstStep, double p_maxAccel)
 {
-  return make_shared<LogitQREMixedStrategyProfile>(LogitStrategyEstimate(
-      *p_frequencies, 1000000.0, 1.0, p_stopAtLocal, p_firstStep, p_maxAccel));
+  return make_shared<LogitQREMixedStrategyProfile>(
+      LogitStrategyEstimate(*p_frequencies, 1000000.0, PathTracer::TraceDirection::Positive,
+                            p_stopAtLocal, p_firstStep, p_maxAccel));
 }

--- a/src/solvers/hp/hp.cc
+++ b/src/solvers/hp/hp.cc
@@ -37,8 +37,8 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
   Vector<double> x = system.ComputeInitialPoint();
 
   const PathTracer tracer;
-  double omega = 1.0;
-
+  const PathTracer::TraceDirection direction = PathTracer::TraceDirection::Positive;
+  const size_t tracking_index = 1; // Track the first variable (t) for orientation
   auto termination_condition = [](const Vector<double> &point) { return point[1] >= 1.5; };
   auto criterion_function = [](const Vector<double> &point,
                                const Vector<double> &tangent) -> double { return point[1] - 1.0; };
@@ -48,7 +48,7 @@ HPStrategySolve(const MixedStrategyProfile<double> &p_prior)
       [&system](const Vector<double> &point, Matrix<double> &jac) {
         system.GetJacobian(point, jac);
       },
-      x, omega, termination_condition,
+      x, direction, tracking_index, termination_condition,
       [&system](const Vector<double> &point) {
         std::cout << "[Path Tracer Step] t = " << point[1];
         std::cout << " | Alfas: ";

--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -309,8 +309,8 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
 namespace Gambit {
 
 std::list<LogitQREMixedBehaviorProfile>
-LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
+LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
+                   PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
                    MixedBehaviorObserverFunctionType p_observer)
 {
   if (p_start.size() == 0) {
@@ -335,7 +335,7 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
       [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
         system.GetJacobian(p_point, p_jac);
       },
-      x, p_omega,
+      x, p_direction, x.size(),
       [game, p_regret](const Vector<double> &p_point) {
         return RegretTerminationFunction(game, p_point, p_regret);
       },
@@ -345,9 +345,9 @@ LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
 
 std::list<LogitQREMixedBehaviorProfile>
 LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
-                         const std::list<double> &p_targetLambda, double p_omega,
-                         double p_firstStep, double p_maxAccel,
-                         MixedBehaviorObserverFunctionType p_observer)
+                         const std::list<double> &p_targetLambda,
+                         PathTracer::TraceDirection p_direction, double p_firstStep,
+                         double p_maxAccel, MixedBehaviorObserverFunctionType p_observer)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -369,7 +369,7 @@ LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
         [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
           system.GetJacobian(p_point, p_jac);
         },
-        x, p_omega, LambdaPositiveTerminationFunction,
+        x, p_direction, x.size(), LambdaPositiveTerminationFunction,
         [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); },
         [lam](const Vector<double> &x, const Vector<double> &) -> double {
           return x.back() - lam;
@@ -381,7 +381,8 @@ LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
 
 LogitQREMixedBehaviorProfile
 LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double p_maxLambda,
-                      double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
+                      PathTracer::TraceDirection p_direction, double p_stopAtLocal,
+                      double p_firstStep, double p_maxAccel,
                       MixedBehaviorObserverFunctionType p_observer)
 {
   const LogitQREMixedBehaviorProfile start(p_frequencies.GetGame());
@@ -405,7 +406,7 @@ LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double 
         [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
           system.GetJacobian(p_point, p_jac);
         },
-        x, p_omega,
+        x, p_direction, x.size(),
         [p_maxLambda](const Vector<double> &p_point) {
           return LambdaRangeTerminationFunction(p_point, 0, p_maxLambda);
         },

--- a/src/solvers/logit/logit.h
+++ b/src/solvers/logit/logit.h
@@ -24,6 +24,7 @@
 #define SOLVERS_LOGIT_H
 
 #include <functional>
+#include "solvers/logit/path.h"
 
 namespace Gambit {
 
@@ -85,18 +86,19 @@ using MixedStrategyObserverFunctionType =
 inline void NullMixedStrategyObserver(const LogitQREMixedStrategyProfile &) {}
 
 std::list<LogitQREMixedStrategyProfile> LogitStrategySolve(
-    const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
-    double p_firstStep, double p_maxAccel,
+    const LogitQREMixedStrategyProfile &p_start, double p_regret,
+    PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
     const MixedStrategyObserverFunctionType &p_observer = NullMixedStrategyObserver);
 
 std::list<LogitQREMixedStrategyProfile> LogitStrategySolveLambda(
     const LogitQREMixedStrategyProfile &p_start, const std::list<double> &p_targetLambda,
-    double p_omega, double p_firstStep, double p_maxAccel,
+    PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
     const MixedStrategyObserverFunctionType &p_observer = NullMixedStrategyObserver);
 
 LogitQREMixedStrategyProfile
 LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double p_maxLambda,
-                      double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
+                      PathTracer::TraceDirection p_direction, double p_stopAtLocal,
+                      double p_firstStep, double p_maxAccel,
                       MixedStrategyObserverFunctionType p_observer = NullMixedStrategyObserver);
 
 using LogitQREMixedBehaviorProfile = LogitQRE<MixedBehaviorProfile<double>>;
@@ -107,19 +109,19 @@ using MixedBehaviorObserverFunctionType =
 inline void NullMixedBehaviorObserver(const LogitQREMixedBehaviorProfile &) {}
 
 std::list<LogitQREMixedBehaviorProfile>
-LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
+LogitBehaviorSolve(const LogitQREMixedBehaviorProfile &p_start, double p_regret,
+                   PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
                    MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
 
-std::list<LogitQREMixedBehaviorProfile>
-LogitBehaviorSolveLambda(const LogitQREMixedBehaviorProfile &p_start,
-                         const std::list<double> &p_targetLambda, double p_omega,
-                         double p_firstStep, double p_maxAccel,
-                         MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
+std::list<LogitQREMixedBehaviorProfile> LogitBehaviorSolveLambda(
+    const LogitQREMixedBehaviorProfile &p_start, const std::list<double> &p_targetLambda,
+    PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
+    MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
 
 LogitQREMixedBehaviorProfile
 LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double p_maxLambda,
-                      double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
+                      PathTracer::TraceDirection p_direction, double p_stopAtLocal,
+                      double p_firstStep, double p_maxAccel,
                       MixedBehaviorObserverFunctionType p_observer = NullMixedBehaviorObserver);
 
 } // namespace Gambit

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -347,8 +347,8 @@ void EstimatorCallbackFunction::EvaluatePoint(const Vector<double> &p_point)
 } // namespace
 
 std::list<LogitQREMixedStrategyProfile>
-LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret, double p_omega,
-                   double p_firstStep, double p_maxAccel,
+LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
+                   PathTracer::TraceDirection p_direction, double p_firstStep, double p_maxAccel,
                    const MixedStrategyObserverFunctionType &p_observer)
 {
   if (p_start.size() == 0) {
@@ -374,7 +374,7 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
       [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
         system.GetJacobian(p_point, p_jac);
       },
-      x, p_omega,
+      x, p_direction, x.size(),
       [p_start, p_regret](const Vector<double> &p_point) {
         return RegretTerminationFunction(p_start.GetGame(), p_point, p_regret);
       },
@@ -384,9 +384,9 @@ LogitStrategySolve(const LogitQREMixedStrategyProfile &p_start, double p_regret,
 
 std::list<LogitQREMixedStrategyProfile>
 LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
-                         const std::list<double> &p_targetLambda, double p_omega,
-                         double p_firstStep, double p_maxAccel,
-                         const MixedStrategyObserverFunctionType &p_observer)
+                         const std::list<double> &p_targetLambda,
+                         PathTracer::TraceDirection p_direction, double p_firstStep,
+                         double p_maxAccel, const MixedStrategyObserverFunctionType &p_observer)
 {
   if (p_start.size() == 0) {
     return {p_start};
@@ -408,7 +408,7 @@ LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
         [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
           system.GetJacobian(p_point, p_jac);
         },
-        x, p_omega, LambdaPositiveTerminationFunction,
+        x, p_direction, x.size(), LambdaPositiveTerminationFunction,
         [&callback](const Vector<double> &p_point) -> void { callback.AppendPoint(p_point); },
         [lam](const Vector<double> &x, const Vector<double> &) -> double {
           return x.back() - lam;
@@ -420,7 +420,8 @@ LogitStrategySolveLambda(const LogitQREMixedStrategyProfile &p_start,
 
 LogitQREMixedStrategyProfile
 LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double p_maxLambda,
-                      double p_omega, double p_stopAtLocal, double p_firstStep, double p_maxAccel,
+                      PathTracer::TraceDirection p_direction, double p_stopAtLocal,
+                      double p_firstStep, double p_maxAccel,
                       MixedStrategyObserverFunctionType p_observer)
 {
   const LogitQREMixedStrategyProfile start(p_frequencies.GetGame());
@@ -444,7 +445,7 @@ LogitStrategyEstimate(const MixedStrategyProfile<double> &p_frequencies, double 
         [&system](const Vector<double> &p_point, Matrix<double> &p_jac) {
           system.GetJacobian(p_point, p_jac);
         },
-        x, p_omega,
+        x, p_direction, x.size(),
         [p_maxLambda](const Vector<double> &p_point) {
           return LambdaRangeTerminationFunction(p_point, 0, p_maxLambda);
         },

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -128,8 +128,9 @@ void NewtonStep(Matrix<double> &q, Matrix<double> &b, Vector<double> &u, Vector<
 TracePathResult
 PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
                       std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-                      Vector<double> &x, double &p_omega, TerminationFunctionType p_terminate,
-                      CallbackFunctionType p_callback, CriterionFunctionType p_criterion,
+                      Vector<double> &x, TraceDirection p_direction, size_t tracking_index,
+                      TerminationFunctionType p_terminate, CallbackFunctionType p_callback,
+                      CriterionFunctionType p_criterion,
                       CriterionBracketFunctionType p_criterionBracket) const
 {
   const double c_tol = 1.0e-4;   // tolerance for corrector iteration
@@ -157,12 +158,26 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   QRDecomp(b, q);
   q.GetRow(q.NumRows(), t);
   p_callback(x);
+  bool first_step = true;
+  double p_omega = static_cast<int>(p_direction);
 
   while (!p_terminate(x)) {
     bool accept = true;
 
     if (fabs(h) <= c_hmin) {
       return {x, false, "Stepsize fell below minimum threshold."};
+    }
+
+    if (first_step) {
+      // Ensure that the tangent is oriented in the same direction as
+      // the path-following direction.
+      if (t[tracking_index] < 0.0) {
+        p_omega *= -1.0;
+      }
+      else if (t[tracking_index] == 0.0) {
+        return {x, false, "Initial tangent vector is orthogonal to path-following direction."};
+      }
+      first_step = false;
     }
 
     // Predictor step

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -38,16 +38,16 @@ inline double sqr(double x) { return x * x; }
 
 void Givens(Matrix<double> &b, Matrix<double> &q, double &c1, double &c2, int l1, int l2, int l3)
 {
-  if (fabs(c1) + fabs(c2) == 0.0) {
+  if (std::abs(c1) + std::abs(c2) == 0.0) {
     return;
   }
 
   double sn;
-  if (fabs(c2) >= fabs(c1)) {
-    sn = std::sqrt(1.0 + sqr(c1 / c2)) * fabs(c2);
+  if (std::abs(c2) >= std::abs(c1)) {
+    sn = std::sqrt(1.0 + sqr(c1 / c2)) * std::abs(c2);
   }
   else {
-    sn = std::sqrt(1.0 + sqr(c2 / c1)) * fabs(c1);
+    sn = std::sqrt(1.0 + sqr(c2 / c1)) * std::abs(c1);
   }
   const double s1 = c1 / sn;
   const double s2 = c2 / sn;
@@ -146,7 +146,7 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   const double c_pert = 0.0000001; // The size of perturbation to apply to avoid bifurcation traps
   double pert = 0.0;               // The current version of the perturbation being applied
   double pert_countdown = 0.0;     // How much longer (in arclength) to apply perturbation
-  const double orientation_tol = 1.0e-8; // tolerance for detecting change in orientation
+  const double c_orientTol = 1.0e-8; // tolerance for detecting change in orientation
 
   Vector<double> u(x.size());
   // t is current tangent at x; newT is tangent at u, which is the next point.
@@ -169,17 +169,17 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   while (!p_terminate(x)) {
     bool accept = true;
 
-    if (fabs(h) <= c_hmin) {
+    if (std::abs(h) <= c_hmin) {
       return {x, false, "Stepsize fell below minimum threshold."};
     }
 
     if (first_step) {
-      if (std::abs(t[p_trackingIndex]) <= orientation_tol) {
+      if (std::abs(t[p_trackingIndex]) <= c_orientTol) {
         return {x, false, "Initial tangent vector is orthogonal to path-following direction."};
       }
       // Ensure that the tangent is oriented in the same direction as
       // the path-following direction.
-      else if (t[p_trackingIndex] < -orientation_tol) {
+      else if (t[p_trackingIndex] < -c_orientTol) {
         omega *= -1.0;
       }
       first_step = false;
@@ -246,7 +246,7 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
 
     if (!accept) {
       h /= m_maxDecel; // PC not accepted; change stepsize and retry
-      if (fabs(h) <= c_hmin) {
+      if (std::abs(h) <= c_hmin) {
         return {x, false, "Stepsize fell below minimum threshold."};
       }
       continue;
@@ -271,7 +271,7 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
     }
     else {
       // Standard steplength adaptation
-      h = fabs(h / decel);
+      h = std::abs(h / decel);
     }
 
     // PC step was successful; update and iterate

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -128,7 +128,7 @@ void NewtonStep(Matrix<double> &q, Matrix<double> &b, Vector<double> &u, Vector<
 TracePathResult
 PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
                       std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-                      Vector<double> &x, TraceDirection p_direction, size_t tracking_index,
+                      Vector<double> &x, TraceDirection p_direction, size_t p_tracking_index,
                       TerminationFunctionType p_terminate, CallbackFunctionType p_callback,
                       CriterionFunctionType p_criterion,
                       CriterionBracketFunctionType p_criterionBracket) const
@@ -146,6 +146,7 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   const double c_pert = 0.0000001; // The size of perturbation to apply to avoid bifurcation traps
   double pert = 0.0;               // The current version of the perturbation being applied
   double pert_countdown = 0.0;     // How much longer (in arclength) to apply perturbation
+  const double orientation_tol = 1.0e-8; // tolerance for detecting change in orientation
 
   Vector<double> u(x.size());
   // t is current tangent at x; newT is tangent at u, which is the next point.
@@ -159,7 +160,11 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   q.GetRow(q.NumRows(), t);
   p_callback(x);
   bool first_step = true;
-  double p_omega = static_cast<int>(p_direction);
+  double omega = (p_direction == TraceDirection::Positive) ? 1.0 : -1.0;
+
+  if (p_tracking_index > x.size() || p_tracking_index < 1) {
+    return {x, false, "Tracking index exceeds dimension of point vector."};
+  }
 
   while (!p_terminate(x)) {
     bool accept = true;
@@ -169,20 +174,20 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
     }
 
     if (first_step) {
+      if (std::abs(t[p_tracking_index]) <= orientation_tol) {
+        return {x, false, "Initial tangent vector is orthogonal to path-following direction."};
+      }
       // Ensure that the tangent is oriented in the same direction as
       // the path-following direction.
-      if (t[tracking_index] < 0.0) {
-        p_omega *= -1.0;
-      }
-      else if (t[tracking_index] == 0.0) {
-        return {x, false, "Initial tangent vector is orthogonal to path-following direction."};
+      else if (t[p_tracking_index] < -orientation_tol) {
+        omega *= -1.0;
       }
       first_step = false;
     }
 
     // Predictor step
     for (size_t k = 1; k <= x.size(); k++) {
-      u[k] = x[k] + h * p_omega * t[k];
+      u[k] = x[k] + h * omega * t[k];
     }
 
     double decel = 1.0 / m_maxDecel; // initialize deceleration factor

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -128,7 +128,7 @@ void NewtonStep(Matrix<double> &q, Matrix<double> &b, Vector<double> &u, Vector<
 TracePathResult
 PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
                       std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-                      Vector<double> &x, TraceDirection p_direction, size_t p_tracking_index,
+                      Vector<double> &x, TraceDirection p_direction, size_t p_trackingIndex,
                       TerminationFunctionType p_terminate, CallbackFunctionType p_callback,
                       CriterionFunctionType p_criterion,
                       CriterionBracketFunctionType p_criterionBracket) const
@@ -162,7 +162,7 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
   bool first_step = true;
   double omega = (p_direction == TraceDirection::Positive) ? 1.0 : -1.0;
 
-  if (p_tracking_index > x.size() || p_tracking_index < 1) {
+  if (p_trackingIndex > x.size() || p_trackingIndex < 1) {
     return {x, false, "Tracking index exceeds dimension of point vector."};
   }
 
@@ -174,12 +174,12 @@ PathTracer::TracePath(std::function<void(const Vector<double> &, Vector<double> 
     }
 
     if (first_step) {
-      if (std::abs(t[p_tracking_index]) <= orientation_tol) {
+      if (std::abs(t[p_trackingIndex]) <= orientation_tol) {
         return {x, false, "Initial tangent vector is orthogonal to path-following direction."};
       }
       // Ensure that the tangent is oriented in the same direction as
       // the path-following direction.
-      else if (t[p_tracking_index] < -orientation_tol) {
+      else if (t[p_trackingIndex] < -orientation_tol) {
         omega *= -1.0;
       }
       first_step = false;

--- a/src/solvers/logit/path.h
+++ b/src/solvers/logit/path.h
@@ -71,6 +71,7 @@ struct TracePathResult {
 //
 class PathTracer {
 public:
+  enum class TraceDirection { Positive = 1, Negative = -1 };
   PathTracer() = default;
   virtual ~PathTracer() = default;
 
@@ -80,12 +81,10 @@ public:
   void SetStepsize(double p_hStart) { m_hStart = p_hStart; }
   double GetStepsize() const { return m_hStart; }
 
-  enum class TraceDirection { Positive = 1, Negative = -1 };
-
   TracePathResult
   TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
             std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-            Vector<double> &p_x, TraceDirection p_direction, size_t tracking_index,
+            Vector<double> &p_x, TraceDirection p_direction, size_t p_tracking_index,
             TerminationFunctionType p_terminate,
             CallbackFunctionType p_callback = NullCallbackFunction,
             CriterionFunctionType p_criterion = NullCriterionFunction,

--- a/src/solvers/logit/path.h
+++ b/src/solvers/logit/path.h
@@ -84,7 +84,7 @@ public:
   TracePathResult
   TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
             std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-            Vector<double> &p_x, TraceDirection p_direction, size_t p_tracking_index,
+            Vector<double> &p_x, TraceDirection p_direction, size_t p_trackingIndex,
             TerminationFunctionType p_terminate,
             CallbackFunctionType p_callback = NullCallbackFunction,
             CriterionFunctionType p_criterion = NullCriterionFunction,

--- a/src/solvers/logit/path.h
+++ b/src/solvers/logit/path.h
@@ -80,10 +80,13 @@ public:
   void SetStepsize(double p_hStart) { m_hStart = p_hStart; }
   double GetStepsize() const { return m_hStart; }
 
+  enum class TraceDirection { Positive = 1, Negative = -1 };
+
   TracePathResult
   TracePath(std::function<void(const Vector<double> &, Vector<double> &)> p_function,
             std::function<void(const Vector<double> &, Matrix<double> &)> p_jacobian,
-            Vector<double> &p_x, double &p_omega, TerminationFunctionType p_terminate,
+            Vector<double> &p_x, TraceDirection p_direction, size_t tracking_index,
+            TerminationFunctionType p_terminate,
             CallbackFunctionType p_callback = NullCallbackFunction,
             CriterionFunctionType p_criterion = NullCriterionFunction,
             CriterionBracketFunctionType p_criterionBracker = NullCriterionBracketFunction) const;

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -206,7 +206,8 @@ int main(int argc, char *argv[])
         }
       };
       auto result =
-          LogitStrategyEstimate(frequencies, maxLambda, 1.0, false, hStart, maxDecel, printer);
+          LogitStrategyEstimate(frequencies, maxLambda, PathTracer::TraceDirection::Positive,
+                                false, hStart, maxDecel, printer);
       PrintProfile(std::cout, decimals, result);
       return 0;
     }
@@ -219,14 +220,15 @@ int main(int argc, char *argv[])
       };
       const LogitQREMixedStrategyProfile start(game);
       if (!targetLambda.empty()) {
-        auto result =
-            LogitStrategySolveLambda(start, targetLambda, 1.0, hStart, maxDecel, printer);
+        auto result = LogitStrategySolveLambda(
+            start, targetLambda, PathTracer::TraceDirection::Positive, hStart, maxDecel, printer);
         for (auto &profile : result) {
           PrintProfile(std::cout, decimals, profile);
         }
       }
       else {
-        auto result = LogitStrategySolve(start, maxregret, 1.0, hStart, maxDecel, printer);
+        auto result = LogitStrategySolve(start, maxregret, PathTracer::TraceDirection::Positive,
+                                         hStart, maxDecel, printer);
         PrintProfile(std::cout, decimals, result.back(), true);
       }
     }
@@ -238,14 +240,15 @@ int main(int argc, char *argv[])
       };
       const LogitQREMixedBehaviorProfile start(game);
       if (!targetLambda.empty()) {
-        auto result =
-            LogitBehaviorSolveLambda(start, targetLambda, 1.0, hStart, maxDecel, printer);
+        auto result = LogitBehaviorSolveLambda(
+            start, targetLambda, PathTracer::TraceDirection::Positive, hStart, maxDecel, printer);
         for (auto &profile : result) {
           PrintProfile(std::cout, decimals, profile);
         }
       }
       else {
-        auto result = LogitBehaviorSolve(start, maxregret, 1.0, hStart, maxDecel, printer);
+        auto result = LogitBehaviorSolve(start, maxregret, PathTracer::TraceDirection::Positive,
+                                         hStart, maxDecel, printer);
         PrintProfile(std::cout, decimals, result.back(), true);
       }
     }


### PR DESCRIPTION
This PR intends to update `path.cc ` so that the tracer always follows the curve in the direction chosen by the programmer. It has been proven useful in the new `HP`algorithm to avoid a random direction in `t=0`. `logit` has also been affected by the modifications: the headers have been updated.

The mechanism implemented is the following:

-In `path.h` an enum type named **`TraceDirection`**  has been declared. It can be `Positive` associated to the number 1, and `Negative`, (-1). Positive means that the tracer will move forward; negative backwards. 

-To control whether the tracer is headed into the right direction in the first iteration, it is required to know which is the index of the variable that we are following (`lambda`in `logit`, `t` in `HP`). Another parameter has been added to `TracePath` named **`tracking_index`**  that stores the position of that variable in the vector `x`.  Note that in `HP` it is the first position and in `logit` is the last one.

The check that we are heading the right way is as discussed: if the first step goes as expected (equivalent to the tangent being positive), the internal omega does not change. Otherwise, it is multiplied by -1.

An exception is raised if the tangent in the first step is 0.

The changes have succesfully passed `logit` and `hp` tests.