### PR TITLE
Implement `Game.relabel_actions` to reassign action labels.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@
 ### Added
 - Added `Game.make_infoset`, forming a collection of personal decision nodes into a single
   information set; the primitive operation for editing information structures.  (#999)
+- Added `Game.relabel_actions`, which simultaneously reassigns the labels of actions at an
+  information set via a mapping from current to replacement labels.  (#1026)
 
 ### Fixed
 - Converting a behavior profile to a strategy profile, and computing pure-strategy payoffs
@@ -32,6 +34,8 @@
   information set and the new player.  (#999)
 - `Game.sort_infosets` has been removed; it was deprecated in 16.5.0, as the iteration order of
   information sets and their members is now maintained automatically.  (#999)
+- Assigning to `Action.label` has been removed; use `Game.relabel_actions`, which enforces
+  nonempty, unique labels.  (#1026)
 
 ## [16.7.0] - 2026-07-11
 

--- a/doc/gui.efg.rst
+++ b/doc/gui.efg.rst
@@ -74,6 +74,41 @@ that a move can be added for a new, as-yet-undefined player, a move
 can be added directly into an existing information set, and a move can
 be immediately given more than two actions.
 
+A single action can also be added to an existing move without
+drag-and-drop, by clicking on any node belonging to the move and
+selecting :menuselection:`Edit --> Insert action`.  The new action is
+given an automatically generated numeric label, which can be changed
+afterward as described below in :ref:`editing-moves`.
+
+
+.. _editing-moves:
+
+Editing move properties
+------------------------
+
+The properties of an existing move -- the label of its information
+set, the player to which it belongs, and the labels of its actions --
+can be changed by clicking on any node belonging to the move and
+selecting :menuselection:`Edit --> Move`. This displays the
+:guilabel:`Move properties` dialog, which lists a text field for the
+information set's label, a dropdown for the player to which the move
+belongs, and one text field per action, prefilled with the action's
+current label. For moves belonging to the chance player, a probability
+field is shown alongside each action instead of the player dropdown.
+
+Action labels must be nonempty, and unique among the actions at the
+move; the information set's label, if not left blank, must similarly
+be unique among the information sets belonging to the same player. Any
+field that currently violates one of these rules is highlighted, and a
+description of the problem is shown below the list of actions; the
+:guilabel:`OK` button is disabled until all fields are valid. Because
+the labels of all the actions at the move are reassigned
+simultaneously when :guilabel:`OK` is clicked, two actions can have
+their labels swapped directly, for instance by relabeling
+:guilabel:`Left` to :guilabel:`Right` and :guilabel:`Right` to
+:guilabel:`Left` at the same time.
+
+
 .. _copying-trees:
 
 Copying and moving subtrees

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -72,6 +72,7 @@ Transforming game information structure
    Game.set_infoset
    Game.leave_infoset
    Game.set_chance_probs
+   Game.relabel_actions
    Game.reveal
 
 

--- a/src/games/file.cc
+++ b/src/games/file.cc
@@ -753,14 +753,11 @@ void ParseChanceNode(GameFileLexer &p_state, Game &p_game, GameNode &p_node, Tre
     p_state.GetNextToken();
 
     if (!infoset) {
-      infoset = p_game->AppendMove(p_node, p_game->GetChance(), action_labels.size());
+      infoset =
+          p_game->AppendMove(p_node, p_game->GetChance(),
+                             std::vector<std::string>(action_labels.begin(), action_labels.end()));
       p_treeData.m_infosetMap[0][infosetId] = infoset;
       infoset->SetLabel(label);
-      auto action_label = action_labels.begin();
-      for (auto action : infoset->GetActions()) {
-        action->SetLabel(*action_label);
-        ++action_label;
-      }
       p_game->SetChanceProbs(infoset, probs);
     }
     else {
@@ -810,14 +807,10 @@ void ParsePersonalNode(GameFileLexer &p_state, Game p_game, GameNode p_node, Tre
     p_state.GetNextToken();
 
     if (!infoset) {
-      infoset = p_game->AppendMove(p_node, player, action_labels.size());
+      infoset = p_game->AppendMove(
+          p_node, player, std::vector<std::string>(action_labels.begin(), action_labels.end()));
       p_treeData.m_infosetMap[playerId][infosetId] = infoset;
       infoset->SetLabel(label);
-      auto action_label = action_labels.begin();
-      for (auto action : infoset->GetActions()) {
-        action->SetLabel(*action_label);
-        ++action_label;
-      }
     }
     else {
       CheckInfosetActions(p_state, player, infosetId, infoset, label, action_labels);

--- a/src/games/file.cc
+++ b/src/games/file.cc
@@ -685,14 +685,21 @@ void CheckInfosetActions(const GameFileLexer &p_state, const int p_playerId, con
                          ")");
   }
 
+  // The infoset's actual labels are normalized at creation (see ParseNode/ParsePersonalNode),
+  // so a later restatement of the same infoset must be normalized the same way before
+  // comparing, or a file that consistently repeats a duplicate/empty action label would be
+  // (incorrectly) rejected as inconsistent.
+  auto normalized_labels = p_labels;
+  NormalizeLabelStrings(normalized_labels);
+
   const auto &actions = p_infoset->GetActions();
-  if (actions.size() != p_labels.size()) {
+  if (actions.size() != normalized_labels.size()) {
     p_state.OnParseError("Infoset action count mismatch "
                          "(player " +
                          std::to_string(p_playerId) + ", infoset " + std::to_string(p_infosetId) +
                          ")");
   }
-  auto label_it = p_labels.begin();
+  auto label_it = normalized_labels.begin();
   for (auto action : actions) {
     if (action->GetLabel() != *label_it) {
       p_state.OnParseError("Infoset action labels do not match previous definition "
@@ -753,9 +760,11 @@ void ParseChanceNode(GameFileLexer &p_state, Game &p_game, GameNode &p_node, Tre
     p_state.GetNextToken();
 
     if (!infoset) {
-      infoset =
-          p_game->AppendMove(p_node, p_game->GetChance(),
-                             std::vector<std::string>(action_labels.begin(), action_labels.end()));
+      auto normalized_labels = action_labels;
+      NormalizeLabelStrings(normalized_labels);
+      infoset = p_game->AppendMove(
+          p_node, p_game->GetChance(),
+          std::vector<std::string>(normalized_labels.begin(), normalized_labels.end()));
       p_treeData.m_infosetMap[0][infosetId] = infoset;
       infoset->SetLabel(label);
       p_game->SetChanceProbs(infoset, probs);
@@ -807,8 +816,11 @@ void ParsePersonalNode(GameFileLexer &p_state, Game p_game, GameNode p_node, Tre
     p_state.GetNextToken();
 
     if (!infoset) {
+      auto normalized_labels = action_labels;
+      NormalizeLabelStrings(normalized_labels);
       infoset = p_game->AppendMove(
-          p_node, player, std::vector<std::string>(action_labels.begin(), action_labels.end()));
+          p_node, player,
+          std::vector<std::string>(normalized_labels.begin(), normalized_labels.end()));
       p_treeData.m_infosetMap[playerId][infosetId] = infoset;
       infoset->SetLabel(label);
     }
@@ -866,14 +878,10 @@ void NormalizeGameLabels(const Game &p_game)
   const auto set_label = [](const auto &e, const std::string &s) { e->SetLabel(s); };
   NormalizeLabels(p_game->GetPlayers(), get_label, set_label);
   NormalizeLabels(p_game->GetOutcomes(), get_label, set_label);
-  if (p_game->IsTree()) {
-    for (const auto &player : p_game->GetPlayersWithChance()) {
-      for (const auto &infoset : player->GetInfosets()) {
-        NormalizeLabels(infoset->GetActions(), get_label, set_label);
-      }
-    }
-  }
-  else {
+  // Action labels are not normalized here: for tree games, ParseNode/ParsePersonalNode
+  // already normalize each infoset's actions individually, at creation, from the raw
+  // labels as parsed (see there for why the raw labels must be kept around too).
+  if (!p_game->IsTree()) {
     for (const auto &player : p_game->GetPlayers()) {
       NormalizeLabels(player->GetStrategies(), get_label, set_label);
     }

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -387,11 +387,6 @@ public:
   GameInfoset GetInfoset() const;
 
   const std::string &GetLabel() const { return m_label; }
-  void SetLabel(const std::string &p_label)
-  {
-    CheckLabel(p_label);
-    m_label = p_label;
-  }
 
   bool Precedes(const GameNode &) const;
 };

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -1247,8 +1247,9 @@ public:
   {
     throw UndefinedException();
   }
-  virtual GameInfoset AppendMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                                 bool p_generateLabels = false)
+  /// Append a move for p_player at p_node, with actions labeled per p_actions.
+  virtual GameInfoset AppendMove(GameNode p_node, GamePlayer p_player,
+                                 const std::vector<std::string> &p_actions)
   {
     throw UndefinedException();
   }
@@ -1256,8 +1257,15 @@ public:
   {
     throw UndefinedException();
   }
-  virtual GameInfoset InsertMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                                 bool p_generateLabels = false)
+  /// Insert a move for p_player prior to p_node, with p_actions actions bearing
+  /// automatically generated, sequentially numbered labels.
+  virtual GameInfoset InsertMove(GameNode p_node, GamePlayer p_player, int p_actions)
+  {
+    throw UndefinedException();
+  }
+  /// Insert a move for p_player prior to p_node, with actions labeled per p_actions.
+  virtual GameInfoset InsertMove(GameNode p_node, GamePlayer p_player,
+                                 const std::vector<std::string> &p_actions)
   {
     throw UndefinedException();
   }

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -437,6 +437,10 @@ public:
   bool IsChanceInfoset() const;
 
   void SetLabel(const std::string &p_label);
+  /// Validate that p_label is a nonempty, valid label for an action of this
+  /// information set, unique among its actions disregarding any in p_ignore.
+  void CheckActionLabel(const std::string &p_label,
+                        const std::set<const GameActionRep *> &p_ignore) const;
   const std::string &GetLabel() const { return m_label; }
 
   /// @name Actions
@@ -1280,6 +1284,12 @@ public:
     throw UndefinedException();
   }
   virtual void DeleteAction(GameAction) { throw UndefinedException(); }
+  /// Simultaneously reassign action labels at an information set.
+  /// Keys of p_labels are current action labels; values are their replacements.
+  virtual void RelabelActions(const GameInfoset &, const std::map<std::string, std::string> &)
+  {
+    throw UndefinedException();
+  }
   virtual void SetOutcome(const GameNode &p_node, const GameOutcome &p_outcome)
   {
     throw UndefinedException();
@@ -1517,6 +1527,19 @@ inline Game GameActionRep::GetGame() const { return m_infoset->GetGame(); }
 
 inline Game GameInfosetRep::GetGame() const { return m_game->shared_from_this(); }
 inline GamePlayer GameInfosetRep::GetPlayer() const { return m_player->shared_from_this(); }
+inline void GameInfosetRep::CheckActionLabel(const std::string &p_label,
+                                             const std::set<const GameActionRep *> &p_ignore) const
+{
+  if (p_label.empty()) {
+    throw ValueException("Action label must not be empty");
+  }
+  CheckLabel(p_label);
+  for (const auto &action : m_actions) {
+    if (p_ignore.count(action.get()) == 0 && action->GetLabel() == p_label) {
+      throw ValueException("Action label must be unique within the information set");
+    }
+  }
+}
 inline void GameInfosetRep::SetLabel(const std::string &p_label)
 {
   if (p_label == m_label) {

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -1818,7 +1818,7 @@ GameInfoset GameTreeRep::MakeEvent(const std::vector<GameNode> &p_nodes,
                                                    chance.get(), reference.size());
   auto dest = newEvent->m_actions.begin();
   for (const auto &action : reference) {
-    (*dest)->SetLabel(action->GetLabel());
+    (*dest)->m_label = action->m_label;
     ++dest;
   }
   std::copy(p_probs.begin(), p_probs.end(), newEvent->m_probs.begin());

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -721,24 +721,28 @@ GameInfoset GameTreeRep::LeaveInfoset(GameNode p_node)
   return node->m_infoset->shared_from_this();
 }
 
-GameInfoset GameTreeRep::AppendMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                                    bool p_generateLabels)
+GameInfoset GameTreeRep::AppendMove(GameNode p_node, GamePlayer p_player,
+                                    const std::vector<std::string> &p_actions)
 {
   const GameNodeRep *node = p_node.get();
-  if (p_actions <= 0 || !node->m_children.empty()) {
+  if (p_actions.empty() || !node->m_children.empty()) {
     throw UndefinedException();
   }
   if (p_node->m_game != this || p_player->m_game != this) {
     throw MismatchException();
   }
+  for (const auto &label : p_actions) {
+    CheckLabel(label);
+  }
 
   IncrementVersion();
-  auto newInfoset = std::make_shared<GameInfosetRep>(this, p_player->m_infosets.size() + 1,
-                                                     p_player.get(), p_actions);
+  auto newInfoset = std::make_shared<GameInfosetRep>(
+      this, p_player->m_infosets.size() + 1, p_player.get(), static_cast<int>(p_actions.size()));
   p_player->m_infosets.push_back(newInfoset);
-  if (p_generateLabels) {
-    std::for_each(newInfoset->m_actions.begin(), newInfoset->m_actions.end(),
-                  [act = 1](const GameAction &a) mutable { a->m_label = std::to_string(act++); });
+  auto label_it = p_actions.begin();
+  for (const auto &action : newInfoset->m_actions) {
+    action->m_label = *label_it;
+    ++label_it;
   }
   return AppendMove(p_node, newInfoset);
 }
@@ -767,8 +771,7 @@ GameInfoset GameTreeRep::AppendMove(GameNode p_node, GameInfoset p_infoset)
   return node->m_infoset->shared_from_this();
 }
 
-GameInfoset GameTreeRep::InsertMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                                    bool p_generateLabels)
+GameInfoset GameTreeRep::InsertMove(GameNode p_node, GamePlayer p_player, int p_actions)
 {
   if (p_actions <= 0) {
     throw UndefinedException();
@@ -781,9 +784,32 @@ GameInfoset GameTreeRep::InsertMove(GameNode p_node, GamePlayer p_player, int p_
   auto newInfoset = std::make_shared<GameInfosetRep>(this, p_player->m_infosets.size() + 1,
                                                      p_player.get(), p_actions);
   p_player->m_infosets.push_back(newInfoset);
-  if (p_generateLabels) {
-    std::for_each(newInfoset->m_actions.begin(), newInfoset->m_actions.end(),
-                  [act = 1](const GameAction &a) mutable { a->m_label = std::to_string(act++); });
+  std::for_each(newInfoset->m_actions.begin(), newInfoset->m_actions.end(),
+                [act = 1](const GameAction &a) mutable { a->m_label = std::to_string(act++); });
+  return InsertMove(p_node, newInfoset);
+}
+
+GameInfoset GameTreeRep::InsertMove(GameNode p_node, GamePlayer p_player,
+                                    const std::vector<std::string> &p_actions)
+{
+  if (p_actions.empty()) {
+    throw UndefinedException();
+  }
+  if (p_player->m_game != this) {
+    throw MismatchException();
+  }
+  for (const auto &label : p_actions) {
+    CheckLabel(label);
+  }
+
+  IncrementVersion();
+  auto newInfoset = std::make_shared<GameInfosetRep>(
+      this, p_player->m_infosets.size() + 1, p_player.get(), static_cast<int>(p_actions.size()));
+  p_player->m_infosets.push_back(newInfoset);
+  auto label_it = p_actions.begin();
+  for (const auto &action : newInfoset->m_actions) {
+    action->m_label = *label_it;
+    ++label_it;
   }
   return InsertMove(p_node, newInfoset);
 }

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -244,6 +244,46 @@ GameAction GameTreeRep::InsertAction(GameInfoset p_infoset, GameAction p_action 
   return action;
 }
 
+void GameTreeRep::RelabelActions(const GameInfoset &p_infoset,
+                                 const std::map<std::string, std::string> &p_labels)
+{
+  if (p_infoset->m_game != this) {
+    throw MismatchException();
+  }
+  // Resolve each key to exactly one action at the information set.
+  std::map<GameActionRep *, std::string> assignment;
+  std::set<const GameActionRep *> relabeled;
+  for (const auto &[old_label, new_label] : p_labels) {
+    GameActionRep *match = nullptr;
+    for (const auto &action : p_infoset->m_actions) {
+      if (action->GetLabel() == old_label) {
+        if (match) {
+          throw ValueException("Action label '" + old_label +
+                               "' is ambiguous at this information set");
+        }
+        match = action.get();
+      }
+    }
+    if (!match) {
+      throw ValueException("No action with label '" + old_label + "' at this information set");
+    }
+    assignment[match] = new_label;
+    relabeled.insert(match);
+  }
+  // Replacement labels must be legal, unique against untouched actions, and pairwise distinct
+  std::set<std::string> targets;
+  for (const auto &[action, new_label] : assignment) {
+    p_infoset->CheckActionLabel(new_label, relabeled);
+    if (!targets.insert(new_label).second) {
+      throw ValueException("Action label '" + new_label +
+                           "' would be duplicated by the relabelling");
+    }
+  }
+  for (const auto &[action, new_label] : assignment) {
+    action->m_label = new_label;
+  }
+}
+
 void GameTreeRep::RemoveMember(GameInfosetRep *p_infoset, GameNodeRep *p_node)
 {
   IncrementVersion();

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -251,6 +251,13 @@ void GameTreeRep::RelabelActions(const GameInfoset &p_infoset,
     throw MismatchException();
   }
   // Resolve each key to exactly one action at the information set.
+  //
+  // The ambiguous-match check below defends against a state that pygambit's own
+  // callers can no longer produce (append_move and add_action both guarantee
+  // unique, nonempty action labels, and file loading normalizes labels before
+  // returning a game), but this is a public entry point on the base Game
+  // interface, so a duplicate label reaching here from some other caller must
+  // still be rejected rather than silently resolved to an arbitrary action.
   std::map<GameActionRep *, std::string> assignment;
   std::set<const GameActionRep *> relabeled;
   for (const auto &[old_label, new_label] : p_labels) {
@@ -646,7 +653,7 @@ GameInfoset GameTreeRep::MakeInfoset(const std::vector<GameNode> &p_nodes,
                                                      p_player.get(), reference.size());
   auto dest = newInfoset->m_actions.begin();
   for (const auto &action : reference) {
-    (*dest)->SetLabel(action->GetLabel());
+    (*dest)->m_label = action->GetLabel();
     ++dest;
   }
   p_player->m_infosets.push_back(newInfoset);
@@ -707,7 +714,7 @@ GameInfoset GameTreeRep::LeaveInfoset(GameNode p_node)
   node->m_infoset->m_members.push_back(p_node);
   for (auto old_act = oldInfoset->m_actions.begin(), new_act = node->m_infoset->m_actions.begin();
        old_act != oldInfoset->m_actions.end(); ++old_act, ++new_act) {
-    (*new_act)->SetLabel((*old_act)->GetLabel());
+    (*new_act)->m_label = (*old_act)->GetLabel();
   }
   ClearComputedValues();
   InvalidateInfosetOrdering();
@@ -731,7 +738,7 @@ GameInfoset GameTreeRep::AppendMove(GameNode p_node, GamePlayer p_player, int p_
   p_player->m_infosets.push_back(newInfoset);
   if (p_generateLabels) {
     std::for_each(newInfoset->m_actions.begin(), newInfoset->m_actions.end(),
-                  [act = 1](const GameAction &a) mutable { a->SetLabel(std::to_string(act++)); });
+                  [act = 1](const GameAction &a) mutable { a->m_label = std::to_string(act++); });
   }
   return AppendMove(p_node, newInfoset);
 }
@@ -776,7 +783,7 @@ GameInfoset GameTreeRep::InsertMove(GameNode p_node, GamePlayer p_player, int p_
   p_player->m_infosets.push_back(newInfoset);
   if (p_generateLabels) {
     std::for_each(newInfoset->m_actions.begin(), newInfoset->m_actions.end(),
-                  [act = 1](const GameAction &a) mutable { a->SetLabel(std::to_string(act++)); });
+                  [act = 1](const GameAction &a) mutable { a->m_label = std::to_string(act++); });
   }
   return InsertMove(p_node, newInfoset);
 }

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -184,6 +184,7 @@ public:
   Game SetChanceProbs(const GameInfoset &, const Array<Number> &) override;
   GameAction InsertAction(GameInfoset, GameAction p_where = nullptr) override;
   void DeleteAction(GameAction) override;
+  void RelabelActions(const GameInfoset &, const std::map<std::string, std::string> &) override;
   void SetOutcome(const GameNode &p_node, const GameOutcome &p_outcome) override;
 
   std::vector<GameNode> GetPlays(GameNode node) const override;

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -165,11 +165,12 @@ public:
 
   /// @name Modification
   //@{
-  GameInfoset AppendMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                         bool p_generateLabels = false) override;
+  GameInfoset AppendMove(GameNode p_node, GamePlayer p_player,
+                         const std::vector<std::string> &p_actions) override;
   GameInfoset AppendMove(GameNode p_node, GameInfoset p_infoset) override;
-  GameInfoset InsertMove(GameNode p_node, GamePlayer p_player, int p_actions,
-                         bool p_generateLabels = false) override;
+  GameInfoset InsertMove(GameNode p_node, GamePlayer p_player, int p_actions) override;
+  GameInfoset InsertMove(GameNode p_node, GamePlayer p_player,
+                         const std::vector<std::string> &p_actions) override;
   GameInfoset InsertMove(GameNode p_node, GameInfoset p_infoset) override;
   void CopyTree(GameNode dest, GameNode src) override;
   void MoveTree(GameNode dest, GameNode src) override;

--- a/src/gui/dleditmove.cc
+++ b/src/gui/dleditmove.cc
@@ -27,6 +27,8 @@
 #include <wx/scrolwin.h>
 #include <wx/richmsgdlg.h>
 
+#include <functional>
+
 #include "gambit.h"
 #include "dleditmove.h"
 #include "valnumber.h"
@@ -34,23 +36,32 @@
 
 namespace Gambit::GUI {
 
+namespace {
+const wxColour kInvalidLabelBg(255, 220, 220);
+} // namespace
+
 class ActionPanel final : public wxScrolledWindow {
   std::vector<wxString> m_actionProbValues;
   std::vector<LabelTextCtrl *> m_actionLabels;
   std::vector<wxTextCtrl *> m_actionProbs;
+  wxColour m_defaultBg;
 
 public:
-  ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset);
+  ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset,
+              const std::function<void()> &p_onChanged);
 
   int NumActions() const { return static_cast<int>(m_actionLabels.size()); }
 
   wxString GetActionLabel(int p_act) const;
   Array<Number> GetActionProbs() const;
 
-  void FocusActionLabel(int p_act) { m_actionLabels.at(p_act - 1)->SetFocus(); }
+  // Highlights any empty or duplicate action labels, and returns a description of the
+  // first problem found, or an empty string if all labels are valid.
+  wxString ValidateLabels();
 };
 
-ActionPanel::ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset)
+ActionPanel::ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset,
+                         const std::function<void()> &p_onChanged)
   : wxScrolledWindow(p_parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                      wxVSCROLL | wxTAB_TRAVERSAL)
 {
@@ -86,6 +97,14 @@ ActionPanel::ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset)
 
     auto *name = new LabelTextCtrl(this, wxID_ANY, wxString::FromUTF8(action->GetLabel()));
     m_actionLabels.push_back(name);
+    name->Bind(wxEVT_TEXT, [p_onChanged](wxCommandEvent &p_event) {
+      p_onChanged();
+      p_event.Skip();
+    });
+    name->Bind(wxEVT_KILL_FOCUS, [p_onChanged](wxFocusEvent &p_event) {
+      p_onChanged();
+      p_event.Skip();
+    });
     gridSizer->Add(name, 1, wxEXPAND);
 
     if (isChance) {
@@ -110,6 +129,10 @@ ActionPanel::ActionPanel(wxWindow *p_parent, const GameInfoset &p_infoset)
 
   const wxSize bestSize = topSizer->CalcMin();
   SetMinSize(wxSize(FromDIP(isChance ? 400 : 300), std::min(bestSize.GetHeight(), FromDIP(250))));
+
+  if (!m_actionLabels.empty()) {
+    m_defaultBg = m_actionLabels.front()->GetBackgroundColour();
+  }
 }
 
 wxString ActionPanel::GetActionLabel(int p_act) const
@@ -124,6 +147,31 @@ Array<Number> ActionPanel::GetActionProbs() const
     probs[act] = Number(m_actionProbs.at(act - 1)->GetValue().ToStdString());
   }
   return probs;
+}
+
+wxString ActionPanel::ValidateLabels()
+{
+  const int numActions = NumActions();
+  wxString message;
+
+  for (int act = 1; act <= numActions; act++) {
+    const wxString value = m_actionLabels.at(act - 1)->GetValue();
+    bool invalid = value.empty();
+    for (int other = 1; !invalid && other <= numActions; other++) {
+      if (other != act && m_actionLabels.at(other - 1)->GetValue() == value) {
+        invalid = true;
+      }
+    }
+
+    m_actionLabels.at(act - 1)->SetBackgroundColour(invalid ? kInvalidLabelBg : m_defaultBg);
+    m_actionLabels.at(act - 1)->Refresh();
+
+    if (invalid && message.empty()) {
+      message = value.empty() ? _("Action labels cannot be empty.")
+                              : _("Action labels must be unique within the information set.");
+    }
+  }
+  return message;
 }
 
 //======================================================================
@@ -141,6 +189,15 @@ EditMoveDialog::EditMoveDialog(wxWindow *p_parent, const GameInfoset &p_infoset)
   labelSizer->Add(new wxStaticText(this, wxID_STATIC, _("Information set label")), 0,
                   wxALL | wxALIGN_CENTER_VERTICAL, 5);
   m_infosetLabel = new LabelTextCtrl(this, wxID_ANY, wxString::FromUTF8(p_infoset->GetLabel()));
+  m_infosetLabelDefaultBg = m_infosetLabel->GetBackgroundColour();
+  m_infosetLabel->Bind(wxEVT_TEXT, [this](wxCommandEvent &p_event) {
+    UpdateValidation();
+    p_event.Skip();
+  });
+  m_infosetLabel->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent &p_event) {
+    UpdateValidation();
+    p_event.Skip();
+  });
   labelSizer->Add(m_infosetLabel, 1, wxALL | wxEXPAND, 5);
   topSizer->Add(labelSizer, 0, wxEXPAND);
 
@@ -172,7 +229,7 @@ EditMoveDialog::EditMoveDialog(wxWindow *p_parent, const GameInfoset &p_infoset)
 
   auto *actionBoxSizer =
       new wxStaticBoxSizer(new wxStaticBox(this, wxID_STATIC, _("Actions")), wxVERTICAL);
-  m_actionPanel = new ActionPanel(this, p_infoset);
+  m_actionPanel = new ActionPanel(this, p_infoset, [this]() { UpdateValidation(); });
 
   const int visibleRows = std::min(static_cast<int>(p_infoset->GetActions().size()), 10);
   const int rowHeight = FromDIP(32);
@@ -182,6 +239,10 @@ EditMoveDialog::EditMoveDialog(wxWindow *p_parent, const GameInfoset &p_infoset)
 
   actionBoxSizer->Add(m_actionPanel, 1, wxALL | wxEXPAND, 5);
   topSizer->Add(actionBoxSizer, 1, wxALL | wxEXPAND, 5);
+
+  m_errorText = new wxStaticText(this, wxID_STATIC, wxEmptyString);
+  m_errorText->SetForegroundColour(*wxRED);
+  topSizer->Add(m_errorText, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
 
   if (auto *buttons = CreateSeparatedButtonSizer(wxOK | wxCANCEL)) {
     topSizer->Add(buttons, 0, wxALL | wxEXPAND, 5);
@@ -194,50 +255,44 @@ EditMoveDialog::EditMoveDialog(wxWindow *p_parent, const GameInfoset &p_infoset)
   CenterOnParent();
 
   Bind(wxEVT_BUTTON, &EditMoveDialog::OnOK, this, wxID_OK);
+
+  UpdateValidation();
 }
 
-bool EditMoveDialog::ValidateLabels()
+void EditMoveDialog::UpdateValidation()
 {
-  const wxString infosetLabel = m_infosetLabel->GetNormalizedValue();
+  wxString message;
+
+  const wxString infosetLabel = m_infosetLabel->GetValue();
+  bool infosetValid = true;
   if (!infosetLabel.empty()) {
     for (const auto &infoset : m_infoset->GetPlayer()->GetInfosets()) {
       if (infoset != m_infoset && infoset->GetLabel() == infosetLabel) {
-        wxRichMessageDialog(this, _("Information set label must be unique for the player."),
-                            _("Error"), wxOK | wxCENTRE | wxICON_ERROR)
-            .ShowModal();
-        m_infosetLabel->SetFocus();
-        return false;
+        infosetValid = false;
+        break;
       }
     }
   }
-
-  std::set<wxString> actionLabels;
-  for (int act = 1; act <= m_actionPanel->NumActions(); ++act) {
-    const wxString actionLabel = m_actionPanel->GetActionLabel(act);
-    if (actionLabel.empty()) {
-      wxRichMessageDialog(this, _("Action labels cannot be empty."), _("Error"),
-                          wxOK | wxCENTRE | wxICON_ERROR)
-          .ShowModal();
-      m_actionPanel->FocusActionLabel(act);
-      return false;
-    }
-
-    if (contains(actionLabels, actionLabel)) {
-      wxRichMessageDialog(this, _("Action labels must be unique within the information set."),
-                          _("Error"), wxOK | wxCENTRE | wxICON_ERROR)
-          .ShowModal();
-      m_actionPanel->FocusActionLabel(act);
-      return false;
-    }
-
-    actionLabels.insert(actionLabel);
+  m_infosetLabel->SetBackgroundColour(infosetValid ? m_infosetLabelDefaultBg : kInvalidLabelBg);
+  m_infosetLabel->Refresh();
+  if (!infosetValid) {
+    message = _("Information set label must be unique for the player.");
   }
-  return true;
+
+  const wxString actionMessage = m_actionPanel->ValidateLabels();
+  if (message.empty()) {
+    message = actionMessage;
+  }
+
+  m_errorText->SetLabel(message);
+  if (auto *ok = FindWindow(wxID_OK)) {
+    ok->Enable(message.empty());
+  }
 }
 
 void EditMoveDialog::OnOK(wxCommandEvent &p_event)
 {
-  if (!ValidateLabels()) {
+  if (!m_errorText->GetLabel().empty()) {
     return;
   }
 

--- a/src/gui/dleditmove.cc
+++ b/src/gui/dleditmove.cc
@@ -279,12 +279,9 @@ void EditMoveDialog::UpdateValidation()
     message = _("Information set label must be unique for the player.");
   }
 
-  if (actionLabels.contains(actionLabel)) {
-    wxRichMessageDialog(this, _("Action labels must be unique within the information set."),
-                        _("Error"), wxOK | wxCENTRE | wxICON_ERROR)
-        .ShowModal();
-    m_actionPanel->FocusActionLabel(act);
-    return false;
+  const wxString actionMessage = m_actionPanel->ValidateLabels();
+  if (message.empty()) {
+    message = actionMessage;
   }
 
   m_errorText->SetLabel(message);

--- a/src/gui/dleditmove.h
+++ b/src/gui/dleditmove.h
@@ -32,9 +32,11 @@ class EditMoveDialog final : public wxDialog {
   GameInfoset m_infoset;
   wxChoice *m_player;
   LabelTextCtrl *m_infosetLabel;
+  wxColour m_infosetLabelDefaultBg;
   ActionPanel *m_actionPanel;
+  wxStaticText *m_errorText;
 
-  bool ValidateLabels();
+  void UpdateValidation();
   void OnOK(wxCommandEvent &);
 
 public:

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -462,9 +462,10 @@ void GameDocument::DoSetInfosetLabel(GameInfoset p_infoset, const wxString &p_la
   NotifyChanged(GameModificationType::GameLabels);
 }
 
-void GameDocument::DoSetActionLabel(GameAction p_action, const wxString &p_label)
+void GameDocument::DoRelabelActions(GameInfoset p_infoset,
+                                    const std::map<std::string, std::string> &p_labels)
 {
-  p_action->SetLabel(p_label.ToStdString(wxConvUTF8));
+  m_game->RelabelActions(p_infoset, p_labels);
   NotifyChanged(GameModificationType::GameLabels);
 }
 
@@ -497,8 +498,18 @@ void GameDocument::DoInsertAction(GameNode p_node)
   if (!p_node || !p_node->GetInfoset()) {
     return;
   }
-  const GameAction action = m_game->InsertAction(p_node->GetInfoset());
-  action->SetLabel(std::to_string(action->GetNumber()));
+  const GameInfoset infoset = p_node->GetInfoset();
+  const GameAction action = m_game->InsertAction(infoset);
+
+  std::set<std::string> actionLabels;
+  for (const auto &sibling : infoset->GetActions()) {
+    actionLabels.insert(sibling->GetLabel());
+  }
+  int number = action->GetNumber();
+  while (contains(actionLabels, std::to_string(number))) {
+    number++;
+  }
+  m_game->RelabelActions(infoset, {{action->GetLabel(), std::to_string(number)}});
   NotifyChanged(GameModificationType::GameForm);
 }
 

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -527,7 +527,7 @@ void GameDocument::DoAppendMove(GameNode p_node, GameInfoset p_infoset)
 
 void GameDocument::DoInsertMove(GameNode p_node, GamePlayer p_player, unsigned int p_actions)
 {
-  m_game->InsertMove(p_node, p_player, p_actions, true);
+  m_game->InsertMove(p_node, p_player, p_actions);
   NotifyChanged(GameModificationType::GameForm);
 }
 

--- a/src/gui/gamedoc.h
+++ b/src/gui/gamedoc.h
@@ -23,6 +23,8 @@
 #ifndef GAMBIT_GUI_GAMEDOC_H
 #define GAMBIT_GUI_GAMEDOC_H
 
+#include <map>
+
 #include "gambit.h"
 #include "style.h"
 #include "analysis.h"
@@ -299,7 +301,7 @@ public:
   void DoDeleteStrategy(GameStrategy p_strategy);
   void DoSetStrategyLabel(GameStrategy p_strategy, const wxString &p_label);
   void DoSetInfosetLabel(GameInfoset p_infoset, const wxString &p_label);
-  void DoSetActionLabel(GameAction p_action, const wxString &p_label);
+  void DoRelabelActions(GameInfoset p_infoset, const std::map<std::string, std::string> &p_labels);
   void DoSetActionProbs(GameInfoset p_infoset, const Array<Number> &p_probs);
   void DoSetInfoset(GameNode p_node, GameInfoset p_infoset);
   void DoLeaveInfoset(GameNode p_node);

--- a/src/gui/gameframe.cc
+++ b/src/gui/gameframe.cc
@@ -1034,9 +1034,12 @@ void GameFrame::OnEditMove(wxCommandEvent &)
         m_doc->DoSetPlayer(infoset, m_doc->GetGame()->GetPlayer(dialog.GetPlayer()));
       }
 
+      std::map<std::string, std::string> labels;
       for (const auto &action : infoset->GetActions()) {
-        m_doc->DoSetActionLabel(action, dialog.GetActionLabel(action->GetNumber()));
+        labels[action->GetLabel()] =
+            dialog.GetActionLabel(action->GetNumber()).ToStdString(wxConvUTF8);
       }
+      m_doc->DoRelabelActions(infoset, labels);
       if (infoset->IsChanceInfoset()) {
         m_doc->DoSetActionProbs(infoset, dialog.GetActionProbs());
       }

--- a/src/pygambit/action.pxi
+++ b/src/pygambit/action.pxi
@@ -72,25 +72,18 @@ class Action:
 
     @property
     def label(self) -> str:
-        """Get or set the text label of the action.
+        """The text label of the action.
 
         .. versionchanged:: 17.0.0
             A label may now be any well-formed UTF-8 text, not just ASCII; it must still
             contain no control characters, and must not begin/end with whitespace or have
             two consecutive whitespace characters.  "Whitespace" means any Unicode space
             separator (e.g. U+00A0 NO-BREAK SPACE), not just the ASCII space.
+
+            The label is now read-only, and must be nonempty and unique within its
+            information set; use `Game.relabel_actions` to change it.
         """
         return self.action.deref().GetLabel().decode("utf-8")
-
-    @label.setter
-    def label(self, value: str) -> None:
-        if value == self.label:
-            return
-        if value == "" or value in (act.label for act in self.infoset.actions):
-            warnings.warn("In a future version, actions must have unique labels "
-                          "within their information set",
-                          FutureWarning)
-        self.action.deref().SetLabel(value.encode("utf-8"))
 
     @property
     def infoset(self) -> Infoset:

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -121,7 +121,6 @@ cdef extern from "games/game.h":
         bint Precedes(c_GameNode) except +
 
         string GetLabel() except +
-        void SetLabel(string) except +ValueError
 
     cdef cppclass c_GameInfosetRep "GameInfosetRep":
         cppclass Actions:

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -355,9 +355,10 @@ cdef extern from "games/game.h":
         bool IsPerfectRecall() except +
         bool IsAbsentMinded(c_GameInfoset) except +
 
-        c_GameInfoset AppendMove(c_GameNode, c_GamePlayer, int) except +ValueError
+        c_GameInfoset AppendMove(c_GameNode, c_GamePlayer, stdvector[string]) except +ValueError
         c_GameInfoset AppendMove(c_GameNode, c_GameInfoset) except +ValueError
         c_GameInfoset InsertMove(c_GameNode, c_GamePlayer, int) except +ValueError
+        c_GameInfoset InsertMove(c_GameNode, c_GamePlayer, stdvector[string]) except +ValueError
         c_GameInfoset InsertMove(c_GameNode, c_GameInfoset) except +ValueError
         void CopyTree(c_GameNode dest, c_GameNode src) except +ValueError
         void MoveTree(c_GameNode dest, c_GameNode src) except +ValueError

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -4,6 +4,7 @@ from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.list cimport list as stdlist
 from libcpp.vector cimport vector as stdvector
 from libcpp.set cimport set as stdset
+from libcpp.map cimport map as stdmap
 from libcpp.optional cimport optional
 
 
@@ -369,6 +370,7 @@ cdef extern from "games/game.h":
         c_GameInfoset LeaveInfoset(c_GameNode) except +
         c_GameAction InsertAction(c_GameInfoset, c_GameAction) except +ValueError
         void DeleteAction(c_GameAction) except +ValueError
+        void RelabelActions(c_GameInfoset, stdmap[string, string]) except +ValueError
         void SetOutcome(c_GameNode, c_GameOutcome) except +
         c_Game SetChanceProbs(c_GameInfoset, Array[c_Number]) except +
 

--- a/src/pygambit/gambit.pyx
+++ b/src/pygambit/gambit.pyx
@@ -21,7 +21,6 @@
 #
 import decimal
 import fractions
-import warnings
 import typing
 
 import cython

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1774,7 +1774,7 @@ class Game:
         resolved_node = cython.cast(Node, resolved_nodes[0])
         self.game.deref().AppendMove(resolved_node.node, resolved_player.player, len(actions))
         for label, action in zip(actions, resolved_node.infoset.actions, strict=True):
-            action.label = label
+            cython.cast(Action, action).action.deref().SetLabel(label.encode("utf-8"))
         resolved_infoset = cython.cast(NodeInfoset, resolved_node.infoset)._resolve()
         for n in resolved_nodes[1:]:
             self.game.deref().AppendMove(cython.cast(Node, n).node, resolved_infoset.infoset)
@@ -1979,6 +1979,76 @@ class Game:
                 "delete_action(): cannot delete the only action at an information set"
             )
         self.game.deref().DeleteAction(resolved_action.action)
+
+    def relabel_actions(self,
+                        infoset: Infoset | str,
+                        labels: typing.Mapping[str, str],
+                        strict: bool = True) -> None:
+        """Simultaneously reassign the labels of actions at `infoset`.
+
+        `labels` maps current action labels to their replacements.  The reassignment
+        is simultaneous, so labels can be swapped directly, e.g. ``{"a": "b", "b": "a"}``.
+        Actions are not re-ordered: each relabelled action keeps its position and,
+        at a chance information set, its probability.  After the operation, the
+        labels at the information set must be nonempty and unique.
+
+        .. versionadded:: 17.0.0
+
+        Parameters
+        ----------
+        infoset : Infoset or str
+            The information set at which to relabel actions.  If a string is passed,
+            the information set is determined by finding the personal-player
+            information set with that label, if any.
+        labels : Mapping[str, str]
+            A mapping from current action labels to replacement labels.  Entries
+            whose key equals their value are ignored.
+        strict : bool, default True
+            If `True`, every key of `labels` must be the label of an action at
+            `infoset`, and unknown keys raise ``KeyError``.  If `False`, unknown
+            keys are ignored.
+
+        Raises
+        ------
+        MismatchError
+            If `infoset` is an `Infoset` from a different game.
+        KeyError
+            If `infoset` is a string matching no information set; or, when `strict`
+            is `True`, if a key of `labels` matches no action at `infoset`.
+        TypeError
+            If `labels` is not a mapping, or any key or value is not a string.
+        ValueError
+            If a key of `labels` matches more than one action at `infoset` (possible
+            in games read from files predating unique-label enforcement); or if any
+            replacement label is empty, is not a valid label, or would result in a
+            duplicate label at the information set.
+        """
+        resolved_infoset = cython.cast(Infoset, self._resolve_infoset(infoset, "relabel_actions"))
+        if not hasattr(labels, "items"):
+            raise TypeError(
+                f"relabel_actions(): labels must be a mapping, "
+                f"not {labels.__class__.__name__}"
+            )
+        current = [action.label for action in resolved_infoset.actions]
+        c_labels = stdmap[string, string]()
+        for old, new in labels.items():
+            if not isinstance(old, str) or not isinstance(new, str):
+                raise TypeError("relabel_actions(): labels must map str to str")
+            matches = current.count(old)
+            if matches > 1:
+                raise ValueError(
+                    f"relabel_actions(): label '{old}' is ambiguous at this information set"
+                )
+            if matches == 0:
+                if strict:
+                    raise KeyError(f"relabel_actions(): no action with label '{old}'")
+                continue
+            if new == old:
+                continue
+            c_labels[old.encode("utf-8")] = new.encode("utf-8")
+        if c_labels.empty():
+            return
+        self.game.deref().RelabelActions(resolved_infoset.infoset, c_labels)
 
     def make_infoset(self,
                      nodes: Node | NodeReferenceSet,

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1757,7 +1757,7 @@ class Game:
         Raises
         ------
         UndefinedOperationError
-            If `nodes` are not all terminal, or `actions` is not a positive number.
+            If `nodes` are not all terminal, or `actions` is empty.
         MismatchError
             If an element from `nodes` is a `Node` from a different game,
             or `player` is a `Player` from a different game.
@@ -1777,9 +1777,10 @@ class Game:
             raise UndefinedOperationError("append_move(): `nodes` must be terminal nodes")
 
         resolved_node = cython.cast(Node, resolved_nodes[0])
-        self.game.deref().AppendMove(resolved_node.node, resolved_player.player, len(actions))
-        for label, action in zip(actions, resolved_node.infoset.actions, strict=True):
-            cython.cast(Action, action).action.deref().SetLabel(label.encode("utf-8"))
+        c_actions = stdvector[string]()
+        for label in actions:
+            c_actions.push_back(label.encode("utf-8"))
+        self.game.deref().AppendMove(resolved_node.node, resolved_player.player, c_actions)
         resolved_infoset = cython.cast(NodeInfoset, resolved_node.infoset)._resolve()
         for n in resolved_nodes[1:]:
             self.game.deref().AppendMove(cython.cast(Node, n).node, resolved_infoset.infoset)
@@ -1806,23 +1807,32 @@ class Game:
             self.game.deref().AppendMove(cython.cast(Node, n).node, resolved_infoset.infoset)
 
     def insert_move(self, node: Node | str,
-                    player: Player | str, actions: int) -> None:
-        """Insert a move for `player` prior to the node `node`, with `actions` actions.
-        `node` becomes the first child of the newly-inserted node.
+                    player: Player | str, actions: list[str]) -> None:
+        """Insert a move for `player` prior to the node `node`, with actions labeled
+        according to `actions`.  `node` becomes the first child of the newly-inserted node.
 
         Raises
         ------
         UndefinedOperationError
-            If `actions` is not a positive number.
+            If `actions` is empty.
         MismatchError
             If `node` is a `Node` from a different game, or `player` is a `Player` from a
             different game.
+        ValueError
+            If `actions` contains an empty or a duplicated label.
         """
         resolved_node = cython.cast(Node, self._resolve_node(node, "insert_move"))
         resolved_player = cython.cast(Player, self._resolve_player(player, "insert_move"))
-        if actions < 1:
-            raise UndefinedOperationError("insert_move(): `actions` must be a positive number")
-        self.game.deref().InsertMove(resolved_node.node, resolved_player.player, actions)
+        if not actions:
+            raise UndefinedOperationError("insert_move(): `actions` must be a nonempty list")
+        if any(not label for label in actions):
+            raise ValueError("insert_move(): action labels must not be empty")
+        if len(set(actions)) != len(actions):
+            raise ValueError("insert_move(): action labels must be unique")
+        c_actions = stdvector[string]()
+        for label in actions:
+            c_actions.push_back(label.encode("utf-8"))
+        self.game.deref().InsertMove(resolved_node.node, resolved_player.player, c_actions)
 
     def insert_infoset(self, node: Node | str,
                        infoset: Infoset | str) -> None:

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -1762,11 +1762,16 @@ class Game:
             If an element from `nodes` is a `Node` from a different game,
             or `player` is a `Player` from a different game.
         ValueError
-            If `nodes` has duplicated elements, or is empty.
+            If `nodes` has duplicated elements, or is empty; or if `actions` contains
+            an empty or a duplicated label.
         """
         resolved_player = cython.cast(Player, self._resolve_player(player, "append_move"))
         if not actions:
             raise UndefinedOperationError("append_move(): `actions` must be a nonempty list")
+        if any(not label for label in actions):
+            raise ValueError("append_move(): action labels must not be empty")
+        if len(set(actions)) != len(actions):
+            raise ValueError("append_move(): action labels must be unique")
         resolved_nodes = self._resolve_nodes(nodes, "append_move", "nodes")
         if any(len(n.children) > 0 for n in resolved_nodes):
             raise UndefinedOperationError("append_move(): `nodes` must be terminal nodes")
@@ -1930,8 +1935,9 @@ class Game:
     def add_action(self,
                    infoset: Infoset | str,
                    before: Action | str | None = None) -> None:
-        """Add an action at the information set `infoset`.   If `before` is not null, the new
-        action is inserted before `before`.
+        """Add an action at the information set `infoset`, with an automatically generated
+        numeric label unique among the actions at `infoset`.  If `before` is not null, the
+        new action is inserted before `before`.
 
         Parameters
         ----------
@@ -1949,15 +1955,24 @@ class Game:
         """
         resolved_infoset = cython.cast(Infoset, self._resolve_infoset(infoset, "add_action"))
         if before is None:
-            self.game.deref().InsertAction(resolved_infoset.infoset,
-                                           cython.cast(c_GameAction, NULL))
+            c_action = self.game.deref().InsertAction(resolved_infoset.infoset,
+                                                      cython.cast(c_GameAction, NULL))
         else:
             resolved_action = cython.cast(
                 Action, self._resolve_action(before, "add_action", "before")
             )
             if resolved_infoset != resolved_action.infoset:
                 raise MismatchError("add_action(): must specify an action from the same infoset")
-            self.game.deref().InsertAction(resolved_infoset.infoset, resolved_action.action)
+            c_action = self.game.deref().InsertAction(resolved_infoset.infoset,
+                                                      resolved_action.action)
+
+        current = {action.label for action in resolved_infoset.actions}
+        number = c_action.deref().GetNumber()
+        while str(number) in current:
+            number += 1
+        c_labels = stdmap[string, string]()
+        c_labels[c_action.deref().GetLabel()] = str(number).encode("utf-8")
+        self.game.deref().RelabelActions(resolved_infoset.infoset, c_labels)
 
     def delete_action(self, action: Action | str) -> None:
         """Deletes `action` from its information set.  The subtrees which

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -99,6 +99,19 @@ def test_relabel_actions_ambiguous_label_raises_valueerror():
         game.relabel_actions(game.root.infoset, {"Bet": "Raise"})
 
 
+def test_relabel_actions_not_a_mapping_raises_typeerror():
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(TypeError):
+        game.relabel_actions(game.root.infoset, [("King", "Queen")])
+
+
+@pytest.mark.parametrize("labels", [{1: "Queen"}, {"King": 1}])
+def test_relabel_actions_non_str_label_raises_typeerror(labels: dict):
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(TypeError):
+        game.relabel_actions(game.root.infoset, labels)
+
+
 @pytest.mark.parametrize(
     "game,inprobs,outprobs",
     [

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -89,16 +89,6 @@ def test_relabel_actions_scope_is_the_information_set():
     assert [action.label for action in queen.actions] == ["Raise", "Fold"]
 
 
-def test_relabel_actions_ambiguous_label_raises_valueerror():
-    """A game may already carry duplicate action labels, in which case a key of the
-    mapping does not identify a single action.
-    """
-    game = gbt.Game.new_tree(players=["Alice"])
-    game.append_move(game.root, "Alice", ["Bet", "Bet"])
-    with pytest.raises(ValueError):
-        game.relabel_actions(game.root.infoset, {"Bet": "Raise"})
-
-
 def test_relabel_actions_not_a_mapping_raises_typeerror():
     game = games.create_stripped_down_poker_efg()
     with pytest.raises(TypeError):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -6,23 +6,11 @@ from . import games
 
 
 @pytest.mark.parametrize("label", games.VALID_LABELS)
-def test_set_action_label(label: str):
+def test_action_label(label: str):
     game = games.create_stripped_down_poker_efg()
     action = next(iter(game.root.infoset.actions))
-    action.label = label
+    game.relabel_actions(game.root.infoset, {action.label: label})
     assert action.label == label
-
-
-def test_set_empty_action_futurewarning():
-    game = games.create_stripped_down_poker_efg()
-    with pytest.warns(FutureWarning):
-        next(iter(game.root.infoset.actions)).label = ""
-
-
-def test_set_duplicate_action_futurewarning():
-    game = games.create_stripped_down_poker_efg()
-    with pytest.warns(FutureWarning):
-        next(iter(game.root.infoset.actions)).label = "Queen"
 
 
 @pytest.mark.parametrize("label", games.INVALID_LABELS)
@@ -30,16 +18,85 @@ def test_action_label_invalid_raises_valueerror(label: str):
     game = games.create_stripped_down_poker_efg()
     action = next(iter(game.root.infoset.actions))
     with pytest.raises(ValueError):
-        action.label = label
+        game.relabel_actions(game.root.infoset, {action.label: label})
 
 
-@pytest.mark.parametrize("label", games.UNICODE_LABELS)
-def test_action_label_unicode_accepted(label: str):
-    """Non-ASCII UTF-8 labels are accepted as of #862 (17.0)."""
+def test_relabel_action_empty_raises_valueerror():
     game = games.create_stripped_down_poker_efg()
     action = next(iter(game.root.infoset.actions))
-    action.label = label
-    assert action.label == label
+    with pytest.raises(ValueError):
+        game.relabel_actions(game.root.infoset, {action.label: ""})
+
+
+def test_relabel_actions_duplicate_raises_valueerror():
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(ValueError):
+        game.relabel_actions(game.root.infoset, {"King": "Queen"})
+
+
+def test_relabel_actions_simultaneous_swap():
+    """Reassignment is simultaneous, so a swap is well-defined; applying the entries one
+    at a time would collide on the intermediate state.
+    """
+    game = games.create_stripped_down_poker_efg()
+    game.relabel_actions(game.root.infoset, {"King": "Queen", "Queen": "King"})
+    assert [action.label for action in game.root.infoset.actions] == ["Queen", "King"]
+
+
+def test_relabel_actions_duplicate_targets_raises_valueerror():
+    """Both replacements are free of the actions left untouched but collide with each
+    other, so checking each against the untouched actions alone would let this through.
+    """
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(ValueError):
+        game.relabel_actions(game.root.infoset, {"King": "Ace", "Queen": "Ace"})
+
+
+def test_relabel_actions_unknown_label_raises_keyerror():
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(KeyError):
+        game.relabel_actions(game.root.infoset, {"Jack": "Ace"})
+
+
+def test_relabel_actions_unknown_label_not_strict_is_ignored():
+    game = games.create_stripped_down_poker_efg()
+    game.relabel_actions(game.root.infoset, {"Jack": "Ace", "King": "Ace"}, strict=False)
+    assert [action.label for action in game.root.infoset.actions] == ["Ace", "Queen"]
+
+
+def test_relabel_actions_failure_leaves_game_unchanged():
+    """The whole mapping is validated before any label is written, so a mapping that
+    fails part way through leaves no partial reassignment behind.
+    """
+    game = games.create_stripped_down_poker_efg()
+    with pytest.raises(ValueError):
+        game.relabel_actions(game.root.infoset, {"King": "Ace", "Queen": ""})
+    assert [action.label for action in game.root.infoset.actions] == ["King", "Queen"]
+
+
+def test_relabel_actions_scope_is_the_information_set():
+    """Action labels are unique within an information set, not within a player: Alice's
+    two information sets both offer "Bet", and relabelling one leaves the other untouched
+    and free to take the same new label.
+    """
+    game = games.create_stripped_down_poker_efg()
+    king = game.players["Alice"].infosets["Alice has King"]
+    queen = game.players["Alice"].infosets["Alice has Queen"]
+    game.relabel_actions(king, {"Bet": "Raise"})
+    assert [action.label for action in king.actions] == ["Raise", "Fold"]
+    assert [action.label for action in queen.actions] == ["Bet", "Fold"]
+    game.relabel_actions(queen, {"Bet": "Raise"})
+    assert [action.label for action in queen.actions] == ["Raise", "Fold"]
+
+
+def test_relabel_actions_ambiguous_label_raises_valueerror():
+    """A game may already carry duplicate action labels, in which case a key of the
+    mapping does not identify a single action.
+    """
+    game = gbt.Game.new_tree(players=["Alice"])
+    game.append_move(game.root, "Alice", ["Bet", "Bet"])
+    with pytest.raises(ValueError):
+        game.relabel_actions(game.root.infoset, {"Bet": "Raise"})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -28,6 +28,34 @@ def test_read_efg_repeated_outcome_id_consistent():
     assert len(g.outcomes) == 1
 
 
+def test_read_efg_empty_action_labels_are_normalized():
+    g = _parse_efg('EFG 2 R "t" { "A" "B" }\n""\np "" 1 1 "" { "" "" } 0\n'
+                   't "" 1 "" { 1, -1 }\nt "" 2 "" { 2, -2 }\n')
+    assert [a.label for a in g.root.infoset.actions] == ["_1", "_2"]
+
+
+def test_read_efg_duplicate_action_labels_are_normalized():
+    g = _parse_efg('EFG 2 R "t" { "A" "B" }\n""\np "" 1 1 "" { "l" "l" } 0\n'
+                   't "" 1 "" { 1, -1 }\nt "" 2 "" { 2, -2 }\n')
+    assert [a.label for a in g.root.infoset.actions] == ["l_1", "l_2"]
+
+
+def test_read_efg_repeated_infoset_duplicate_labels_consistent():
+    """A personal infoset spanning two nodes restates its (duplicate) action labels at
+    each node; both restatements must normalize the same way, or the second would be
+    (incorrectly) rejected as inconsistent with the first.
+    """
+    g = _parse_efg(
+        'EFG 2 R "t" { "A" "B" }\n""\n'
+        'p "" 1 1 "" { "l" "l" } 0\n'
+        'p "" 1 1 "" { "l" "l" } 0\n'
+        't "" 1 "" { 1, -1 }\n'
+        't "" 2 "" { 2, -2 }\n'
+        't "" 3 "" { 3, -3 }\n'
+    )
+    assert [a.label for a in g.root.infoset.actions] == ["l_1", "l_2"]
+
+
 def test_string_empty():
     with pytest.raises(ValueError) as excinfo:
         _parse_efg("")
@@ -153,6 +181,15 @@ def test_efg_label_malformed_utf8_rejected():
     bytes directly through a binary buffer, bypassing the encode step in read_game().
     """
     file_bytes = b'EFG 2 R "t" { "A\x80" "B" }\n""\np "" 1 1 "" { "l" "r" } 0\n'
+    with io.BytesIO(file_bytes) as f, pytest.raises(ValueError, match="Invalid label"):
+        gbt.read_efg(f)
+
+
+def test_efg_action_label_malformed_utf8_rejected():
+    """Malformed UTF-8 in an action label is rejected the same way, via the format check
+    inside AppendMove/InsertMove rather than the (now-removed) Action.SetLabel.
+    """
+    file_bytes = b'EFG 2 R "t" { "A" "B" }\n""\np "" 1 1 "" { "l\x80" "r" } 0\n'
     with io.BytesIO(file_bytes) as f, pytest.raises(ValueError, match="Invalid label"):
         gbt.read_efg(f)
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -576,11 +576,25 @@ def test_append_move_error_infoset_mismatch():
         game1.append_infoset(game1.root, game2.root.infoset)
 
 
+def test_append_move_error_empty_label():
+    """Test that an empty label in `actions` is rejected."""
+    game = games.read_from_file("basic_extensive_game.efg")
+    with pytest.raises(ValueError):
+        game.append_move(game.root, game.players["Player 1"], ["a", ""])
+
+
+def test_append_move_error_duplicate_label():
+    """Test that duplicated labels in `actions` are rejected."""
+    game = games.read_from_file("basic_extensive_game.efg")
+    with pytest.raises(ValueError):
+        game.append_move(game.root, game.players["Player 1"], ["a", "a"])
+
+
 def test_insert_move_error_player_actions():
     """Test to ensure there are actions when inserting with a player"""
     game = games.read_from_file("basic_extensive_game.efg")
     with pytest.raises(gbt.UndefinedOperationError):
-        game.insert_move(game.root, game.players["Player 1"], 0)
+        game.insert_move(game.root, game.players["Player 1"], [])
 
 
 def test_insert_move_error_player_mismatch():
@@ -588,7 +602,21 @@ def test_insert_move_error_player_mismatch():
     game1 = gbt.Game.new_tree()
     game2 = games.read_from_file("basic_extensive_game.efg")
     with pytest.raises(gbt.MismatchError):
-        game1.insert_move(game1.root, game2.players["Player 1"], 1)
+        game1.insert_move(game1.root, game2.players["Player 1"], ["a"])
+
+
+def test_insert_move_error_empty_label():
+    """Test that an empty label in `actions` is rejected."""
+    game = games.read_from_file("basic_extensive_game.efg")
+    with pytest.raises(ValueError):
+        game.insert_move(game.root, game.players["Player 1"], ["a", ""])
+
+
+def test_insert_move_error_duplicate_label():
+    """Test that duplicated labels in `actions` are rejected."""
+    game = games.read_from_file("basic_extensive_game.efg")
+    with pytest.raises(ValueError):
+        game.insert_move(game.root, game.players["Player 1"], ["a", "a"])
 
 
 def test_node_infoset_becomes_null_when_truncated():
@@ -1004,11 +1032,19 @@ def test_len_after_insert_move():
 
     node_to_insert_above = game.root.children["L"].children["R"]  # the [1, 0] node
     player = game.players["Player 2"]
-    num_actions_to_add = 3
+    actions_to_add = ["a", "b", "c"]
 
-    game.insert_move(node_to_insert_above, player, num_actions_to_add)
+    game.insert_move(node_to_insert_above, player, actions_to_add)
 
-    assert len(game.nodes) == initial_number_of_nodes + num_actions_to_add
+    assert len(game.nodes) == initial_number_of_nodes + len(actions_to_add)
+
+
+def test_insert_move_actions_labeled():
+    """Test that the inserted move's actions are labeled according to `actions`."""
+    game = gbt.catalog.load("journals/ijgt/selten1975/fig1")
+    node = game.root.children["L"].children["R"]
+    game.insert_move(node, game.players["Player 2"], ["Up", "Down"])
+    assert [a.label for a in node.parent.infoset.actions] == ["Up", "Down"]
 
 
 def test_len_after_insert_infoset():


### PR DESCRIPTION
### Issues closed by this PR
- Closes #1026

### Description of the changes in this PR

Adds `Game.relabel_actions(infoset, labels, strict=True)`, mapping current action labels to their replacements.

Assignment to `Action.label` is removed, along with the `FutureWarning` issued since 16.5.0 for empty or 
duplicate action labels (#614).  Action labels are now required to be nonempty and unique within their 
information set, enforced by the new `GameInfosetRep::CheckActionLabel`.