### PR TITLE
Audit and align CLI tool options, help text, and docs

### DIFF
--- a/doc/tools.enummixed.rst
+++ b/doc/tools.enummixed.rst
@@ -20,16 +20,6 @@ See the :ref:`algorithm description <enummixed>` for full details.
    computation in floating-point, and expresses all output using decimal
    representations with the specified number of digits.
 
-.. cmdoption:: -D
-
-   Since all Nash equilibria involve only strategies which survive
-   iterative elimination of strictly dominated strategies, the program
-   carries out the elimination automatically prior to computation.
-   This is recommended, since it almost always results in superior
-   performance.
-   Specifying `-D` skips the elimination step and performs the
-   enumeration on the full game.
-
 .. cmdoption:: -c
 
    The program outputs the extreme equilibria as it finds them,

--- a/doc/tools.enumpoly.rst
+++ b/doc/tools.enumpoly.rst
@@ -6,7 +6,7 @@
 Compute equilibria of a game using polynomial systems of equations
 See the :ref:`algorithm description <enumpoly>` for full details.
 
-When the verbose switch `-v` is used, the program outputs each support
+When the verbose switch `-V` is used, the program outputs each support
 as it is considered. The supports are presented as a comma-separated
 list of binary strings, where each entry represents one player. The
 digit 1 represents a strategy which is present in the support, and the
@@ -16,7 +16,7 @@ support is printed with the label "candidate,".
 The approach of subdividing the space of totally mixed profiles assumes
 solutions to the system of equations and inequalities are isolated
 points.  In the case of degeneracies in the resulting system,
-When the verbose switch `-v` is used, these supports are identified on
+When the verbose switch `-V` is used, these supports are identified on
 standard output with the label "singular,".   This will occur
 if there is a positive-dimensional set of equilibria which all
 share the listed support.  However, the converse is not true:
@@ -33,13 +33,6 @@ support of some set of equilibria.
 .. cmdoption:: -h
 
    Prints a help message listing the available options.
-
-.. cmdoption:: -H
-
-   By default, the program uses an enumeration method designed to
-   visit as few supports as possible in searching for all equilibria.
-   With this switch,  This switch only has an
-   effect when solving strategic games.
 
 .. cmdoption:: -S
 
@@ -66,12 +59,16 @@ support of some set of equilibria.
 
    Suppresses printing of the banner at program launch.
 
-.. cmdoption:: -v
+.. cmdoption:: -V, --verbose
 
    Sets verbose mode. In verbose mode, supports are printed on
    standard output with the label "candidate" as they are considered, and
    singular supports are identified with the label "singular." By
    default, no information about supports is printed.
+
+.. cmdoption:: -v, --version
+
+   Prints version information and exits.
 
 Computing equilibria of the example in Figure 1 of :cite:p:`Sel75`, sometimes called
 "Selten's horse"::

--- a/doc/tools.gnm.rst
+++ b/doc/tools.gnm.rst
@@ -68,10 +68,14 @@ subsets of equilibria being found.
    Specifies the number of steps to take within a support cell.  Larger values
    trade off speed for security in tracing the path.  Default is 100.
 
-.. cmdoption:: -v
+.. cmdoption:: -V, --verbose
 
    Show intermediate output of the algorithm.  If this option is
    not specified, only the equilibria found are reported.
+
+.. cmdoption:: -v, --version
+
+   Prints version information and exits.
 
 Computing an equilibrium of
 the reduced strategic form of the example in Figure 2 of :cite:p:`Sel75`::

--- a/doc/tools.lcp.rst
+++ b/doc/tools.lcp.rst
@@ -45,6 +45,14 @@ See the :ref:`algorithm description <lcp>` for full details.
    have been found. This has no effect when using the extensive representation
    of a game, in which case the method always only returns one equilibrium.
 
+.. cmdoption:: -r DEPTH
+
+   When working with the reduced strategic game and the number of equilibria
+   sought (via `-e`) is not 1, this switch instructs the program to terminate
+   the recursive search at depth DEPTH. This has no effect when using the
+   extensive representation of a game, in which case the method always only
+   returns one equilibrium.
+
 .. cmdoption:: -h
 
    Prints a help message listing the available options.

--- a/doc/tools.liap.rst
+++ b/doc/tools.liap.rst
@@ -24,6 +24,12 @@ See the :ref:`algorithm description <liap>` for full details.
    agent Nash equilibria.  The default is now to compute using the strategic
    form even for extensive games.
 
+.. versionchanged:: 16.7.0
+
+   The `-S` switch has been removed.  Since the introduction of `-A` in
+   16.5.0, the default (without `-A`) was already to compute using the
+   strategic form for extensive games, making `-S` redundant.
+
 
 .. program:: gambit-liap
 
@@ -43,7 +49,8 @@ See the :ref:`algorithm description <liap>` for full details.
 
 .. cmdoption:: -n
 
-   Specify the number of starting points to randomly generate.
+   Specify the number of starting points to randomly generate.  Ignored
+   if `-s` is given.
 
 .. cmdoption:: -i
 
@@ -73,13 +80,6 @@ See the :ref:`algorithm description <liap>` for full details.
    one mixed strategy profile per line, in the same format used for
    output of equilibria (excluding the initial NE tag).
 
-.. cmdoption:: -S
-
-   By default, the program uses behavior strategies for extensive
-   games; this switch instructs the program to use reduced strategic game
-   strategies for extensive games. (This has no effect for strategic
-   games, since a strategic game is its own reduced strategic game.)
-
 .. cmdoption:: -v
 
    Sets verbose mode. In verbose mode, initial points, as well as
@@ -89,7 +89,7 @@ See the :ref:`algorithm description <liap>` for full details.
 
 Computing an equilibrium in mixed strategies of the example in Figure 2 of :cite:p:`Sel75`::
 
-   $ gambit-liap -S catalog/journals/ijgt/selten1975/fig2.efg
+   $ gambit-liap catalog/journals/ijgt/selten1975/fig2.efg
    Compute Nash equilibria by minimizing the Lyapunov function
    Gambit version |release|, Copyright (C) 1994-2026, The Gambit Project
    This is free software, distributed under the GNU GPL

--- a/doc/tools.simpdiv.rst
+++ b/doc/tools.simpdiv.rst
@@ -8,7 +8,11 @@ See the :ref:`algorithm description <simpdiv>`.
 
 The algorithm begins with any mixed strategy profile consisting of
 rational numbers as probabilities. Without any options, the algorithm
-begins with the centroid, and computes one Nash equilibrium. To
+begins with the pure strategy profile in which each player plays his
+or her first strategy, and computes one Nash equilibrium. This is a
+not-unreasonable default, in that it starts with a very coarse grid
+and, if the game has an equilibrium in pure strategies, or in mixed
+strategies with small denominators, it will find it quickly. To
 attempt to compute other equilibria that may exist, use the
 :option:`gambit-simpdiv -r` or :option:`gambit-simpdiv -s`
 options to specify additional starting points for the algorithm.
@@ -56,7 +60,7 @@ options to specify additional starting points for the algorithm.
    .. versionadded:: 16.2.0
 
    Specify the maximum regret criterion for acceptance as an approximate Nash equilibrium
-   (default is 1e-8).  See :ref:`pygambit-nash-maxregret` for interpretation and guidance.
+   (default is 1e-7).  See :ref:`pygambit-nash-maxregret` for interpretation and guidance.
 
 .. cmdoption:: -d DECIMALS
 
@@ -69,11 +73,15 @@ options to specify additional starting points for the algorithm.
    this option sacrifices some precision in reporting the output of the method, in exchange for
    probabilities which are more human-readable.
 
-.. cmdoption:: -v
+.. cmdoption:: -V, --verbose
 
    Sets verbose mode. In verbose mode, initial points, as well as
    the approximations computed at each grid refinement, are all output,
    in addition to the approximate equilibrium profile found.
+
+.. cmdoption:: -v, --version
+
+   Prints version information and exits.
 
 
 Computing an equilibrium in mixed strategies of the example in Figure 2 of :cite:p:`Sel75`::

--- a/src/core/rational.cc
+++ b/src/core/rational.cc
@@ -289,7 +289,8 @@ std::istream &operator>>(std::istream &f, Rational &y)
   while (isspace(ch)) {
     f.get(ch);
     if (f.eof() || f.bad()) {
-      throw ValueException();
+      f.setstate(std::ios::failbit);
+      return f;
     }
   }
 

--- a/src/gui/dlnash.cc
+++ b/src/gui/dlnash.cc
@@ -158,7 +158,7 @@ wxString ExternalCommand(const NashComputationSpec &p_spec)
           return prefix + wxT("enumpure") + strategic;
         }
         else if constexpr (std::is_same_v<Method, EnumMixedNashSpec>) {
-          return prefix + wxT("enummixed") + strategic;
+          return prefix + wxT("enummixed");
         }
         else if constexpr (std::is_same_v<Method, EnumPolyNashSpec>) {
           return prefix +
@@ -167,14 +167,13 @@ wxString ExternalCommand(const NashComputationSpec &p_spec)
                  strategic;
         }
         else if constexpr (std::is_same_v<Method, GNMNashSpec>) {
-          return prefix +
-                 wxString::Format("gnm -d 10 -n %d -m %.17g -c %d -f %d -i %d",
-                                  method.perturbations, method.lambdaEnd, method.steps,
-                                  method.localNewtonInterval, method.localNewtonMaxIterations) +
-                 strategic;
+          return prefix + wxString::Format("gnm -d 10 -n %d -m %.17g -c %d -f %d -i %d",
+                                           method.perturbations, method.lambdaEnd, method.steps,
+                                           method.localNewtonInterval,
+                                           method.localNewtonMaxIterations);
         }
         else if constexpr (std::is_same_v<Method, IPANashSpec>) {
-          return prefix + wxString::Format("ipa -d 10 -n %d", method.perturbations) + strategic;
+          return prefix + wxString::Format("ipa -d 10 -n %d", method.perturbations);
         }
         else if constexpr (std::is_same_v<Method, LPNashSpec>) {
           return prefix + wxT("lp") + strategic;
@@ -184,10 +183,9 @@ wxString ExternalCommand(const NashComputationSpec &p_spec)
                  strategic;
         }
         else if constexpr (std::is_same_v<Method, LiapNashSpec>) {
-          return prefix +
-                 wxString::Format("liap -d 10 -n %d -i %d -m %.17g", method.startingPoints,
-                                  method.maxIterations, method.maxRegret) +
-                 strategic;
+          return prefix + wxString::Format("liap -d 10 -n %d -i %d -m %.17g",
+                                           method.startingPoints, method.maxIterations,
+                                           method.maxRegret);
         }
         else if constexpr (std::is_same_v<Method, LogitNashSpec>) {
           return prefix +
@@ -201,7 +199,7 @@ wxString ExternalCommand(const NashComputationSpec &p_spec)
           return prefix +
                  wxString::Format("simpdiv -d 10 -n %d -r %d -g %d -m ", method.startingPoints,
                                   method.randomDenominator, method.gridResize) +
-                 wxString(regret.str()) + strategic;
+                 wxString(regret.str());
         }
       },
       p_spec.method);

--- a/src/pygambit/nash.py
+++ b/src/pygambit/nash.py
@@ -438,7 +438,7 @@ def simpdiv_solve(
         from any starting profile, and the equilibrium found may (and generally will)
         depend on the initial profile chosen.
 
-    maxregret : Rational, default 1e-8
+    maxregret : Rational, default 1e-7
         The acceptance criterion for approximate Nash equilibrium; the maximum
         regret of any player must be no more than `maxregret` times the
         difference of the maximum and minimum payoffs of the game

--- a/src/solvers/simpdiv/simpdiv.cc
+++ b/src/solvers/simpdiv/simpdiv.cc
@@ -525,27 +525,20 @@ NashSimpdivStrategySolver::Solve(const MixedStrategyProfile<Rational> &p_start) 
   return sol;
 }
 
-///
-/// Compute an equilibrium using the default starting point.
-///
-/// This computes the equilibrium reached from the starting point profile
-/// in which all players put probability one on their first strategy.
-/// This is a not-unreasonable default in that it starts with a very
-/// coarse grid and, if the game has an equilibrium in pure strategies,
-/// or in mixed strategies with small denominators, it will find it quickly.
-/// Starting with a strategy profile with a smaller denominator can lead
-/// to a long initial search before reaching a candidate neighborhood
-/// for an equilibrium.
-///
 std::list<MixedStrategyProfile<Rational>>
 NashSimpdivStrategySolver::Solve(const Game &p_game) const
+{
+  return Solve(SimpdivDefaultStart(p_game));
+}
+
+MixedStrategyProfile<Rational> SimpdivDefaultStart(const Game &p_game)
 {
   MixedStrategyProfile<Rational> start = p_game->NewMixedStrategyProfile(Rational(0));
   start = Rational(0);
   for (const auto &player : p_game->GetPlayers()) {
     start[player->GetStrategies().front()] = Rational(1);
   }
-  return Solve(start);
+  return start;
 }
 
 std::list<MixedStrategyProfile<Rational>>

--- a/src/solvers/simpdiv/simpdiv.h
+++ b/src/solvers/simpdiv/simpdiv.h
@@ -44,13 +44,27 @@ using SimpdivEventCallbackType = std::function<void(const SimpdivEvent &)>;
 inline void NullSimpdivEventCallback(const SimpdivEvent &) {}
 
 ///
+/// Returns the mixed strategy profile in which each player plays their
+/// first strategy with probability one.
+///
+/// This is the default starting point for SimpdivStrategySolve() when no
+/// other starting profile is specified.  It is a not-unreasonable default in
+/// that it starts with a very coarse grid and, if the game has an
+/// equilibrium in pure strategies, or in mixed strategies with small
+/// denominators, it will find it quickly.  Starting with a strategy profile
+/// with a smaller denominator can lead to a long initial search before
+/// reaching a candidate neighborhood for an equilibrium.
+///
+MixedStrategyProfile<Rational> SimpdivDefaultStart(const Game &p_game);
+
+///
 /// This is a simplicial subdivision algorithm with restart, for finding
 /// mixed strategy solutions to general finite n-person games.  It is based on
 /// van Der Laan, Talman and van Der Heyden, Math of Oper Res, 1987.
 ///
 std::list<MixedStrategyProfile<Rational>> SimpdivStrategySolve(
     const MixedStrategyProfile<Rational> &p_start,
-    const Rational &p_maxregret = Rational(1, 1000000), int p_gridResize = 2,
+    const Rational &p_maxregret = Rational(1, 10000000), int p_gridResize = 2,
     int p_leashLength = 0,
     StrategyCallbackType<Rational> p_onEquilibrium = NullStrategyCallback<Rational>,
     SimpdivEventCallbackType p_onEvent = NullSimpdivEventCallback);

--- a/src/tools/convert/convert.cc
+++ b/src/tools/convert/convert.cc
@@ -51,11 +51,12 @@ void PrintHelp(char *progname)
   std::cerr << "  -r PLAYER        the player to show on rows (default is 1)\n";
   std::cerr << "  -h               print this help message\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
 {
+  opterr = 0;
   int c;
   int rowPlayer = 1, colPlayer = 2;
   bool quiet = false;

--- a/src/tools/enummixed/enummixed.cc
+++ b/src/tools/enummixed/enummixed.cc
@@ -64,11 +64,12 @@ void PrintHelp(char *progname)
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
 {
+  opterr = 0;
   int c;
   bool useFloat = false, quiet = false;
   bool showConnect = false;
@@ -77,11 +78,11 @@ int main(int argc, char *argv[])
   int long_opt_index = 0;
   option long_options[] = {
       {"help", 0, nullptr, 'h'}, {"version", 0, nullptr, 'v'}, {nullptr, 0, nullptr, 0}};
-  while ((c = getopt_long(argc, argv, "d:vhqcS", long_options, &long_opt_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "d:vhqc", long_options, &long_opt_index)) != -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'd':
       useFloat = true;
       numDecimals = atoi(optarg);
@@ -91,8 +92,6 @@ int main(int argc, char *argv[])
       break;
     case 'c':
       showConnect = true;
-      break;
-    case 'S':
       break;
     case 'q':
       quiet = true;

--- a/src/tools/enumpoly/enumpoly.cc
+++ b/src/tools/enumpoly/enumpoly.cc
@@ -57,9 +57,9 @@ void PrintHelp(char *progname)
   std::cerr << "                   (default is to search in all supports)\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -V, --verbose    verbose mode (shows supports investigated)\n";
-  std::cerr << "  -v, --version    print version information\n";
   std::cerr << "                   (default is only to show equilibria)\n";
-  exit(1);
+  std::cerr << "  -v, --version    print version information\n";
+  exit(0);
 }
 
 void PrintProfile(std::ostream &p_stream, const std::string &p_label,
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'd':
       g_numDecimals = atoi(optarg);
       break;

--- a/src/tools/enumpure/enumpure.cc
+++ b/src/tools/enumpure/enumpure.cc
@@ -48,10 +48,11 @@ void PrintHelp(char *progname)
   std::cerr << "Options:\n";
   std::cerr << "  -S               report equilibria in strategies even for extensive games\n";
   std::cerr << "  -A               compute agent form equilibria\n";
+  std::cerr << "  -D               print detailed information about equilibria\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
@@ -68,7 +69,7 @@ int main(int argc, char *argv[])
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'D':
       printDetail = true;
       break;

--- a/src/tools/gt/nfggnm.cc
+++ b/src/tools/gt/nfggnm.cc
@@ -76,6 +76,7 @@ void PrintHelp(char *progname)
   std::cerr << "  -d DECIMALS      show equilibria as floating point with DECIMALS digits\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -n COUNT         number of perturbation vectors to generate\n";
+  std::cerr << "                   (ignored if -s is given)\n";
   std::cerr << "  -s FILE          file containing perturbation vectors\n";
   std::cerr << "  -m LAMBDA        lambda to end tracing (must be negative, default "
             << std::to_string(GNM_LAMBDA_END_DEFAULT) << ")\n";
@@ -88,7 +89,7 @@ void PrintHelp(char *progname)
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -V, --verbose    verbose mode (shows intermediate output)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
@@ -108,12 +109,12 @@ int main(int argc, char *argv[])
                            {"verbose", 0, nullptr, 'V'},
                            {nullptr, 0, nullptr, 0}};
   int c;
-  while ((c = getopt_long(argc, argv, "d:n:s:m:f:i:c:qvVhS", long_options, &long_opt_index)) !=
+  while ((c = getopt_long(argc, argv, "d:n:s:m:f:i:c:qvVh", long_options, &long_opt_index)) !=
          -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'q':
       quiet = true;
       break;
@@ -140,8 +141,6 @@ int main(int argc, char *argv[])
       break;
     case 'c':
       steps = atoi(optarg);
-      break;
-    case 'S':
       break;
     case 'h':
       PrintHelp(argv[0]);

--- a/src/tools/gt/nfggt.cc
+++ b/src/tools/gt/nfggt.cc
@@ -30,15 +30,17 @@ std::vector<MixedStrategyProfile<double>> ReadStrategyPerturbations(const Game &
   std::vector<MixedStrategyProfile<double>> profiles;
   while (!p_stream.eof() && !p_stream.bad()) {
     MixedStrategyProfile<double> p(p_game->NewMixedStrategyProfile(0.0));
-    for (size_t i = 1; i <= p.MixedProfileLength(); i++) {
+    if (p_stream.peek() == EOF) {
+      break;
+    }
+    p_stream >> p[1];
+    for (size_t i = 2; i <= p.MixedProfileLength(); i++) {
       if (p_stream.eof() || p_stream.bad()) {
         break;
       }
+      char comma;
+      p_stream >> comma;
       p_stream >> p[i];
-      if (i < p.MixedProfileLength()) {
-        char comma;
-        p_stream >> comma;
-      }
     }
     // Read in the rest of the line and discard
     std::string foo;

--- a/src/tools/gt/nfgipa.cc
+++ b/src/tools/gt/nfgipa.cc
@@ -52,9 +52,11 @@ void PrintHelp(char *progname)
   std::cerr << "  -d DECIMALS      show equilibria as floating point with DECIMALS digits\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -n COUNT         number of perturbation vectors to generate\n";
+  std::cerr << "                   (ignored if -s is given)\n";
+  std::cerr << "  -s FILE          file containing perturbation vectors\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
@@ -62,17 +64,17 @@ int main(int argc, char *argv[])
   opterr = 0;
   bool quiet = false;
   int numDecimals = 6, numVectors = 1;
-  const std::string startFile;
+  std::string startFile;
 
   int long_opt_index = 0;
   option long_options[] = {
       {"help", 0, nullptr, 'h'}, {"version", 0, nullptr, 'v'}, {nullptr, 0, nullptr, 0}};
   int c;
-  while ((c = getopt_long(argc, argv, "d:n:vqh", long_options, &long_opt_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "d:n:s:vqh", long_options, &long_opt_index)) != -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'q':
       quiet = true;
       break;
@@ -81,6 +83,9 @@ int main(int argc, char *argv[])
       break;
     case 'n':
       numVectors = atoi(optarg);
+      break;
+    case 's':
+      startFile = optarg;
       break;
     case 'h':
       PrintHelp(argv[0]);
@@ -137,7 +142,7 @@ int main(int argc, char *argv[])
     }
     return 0;
   }
-  catch (std::runtime_error &e) {
+  catch (std::exception &e) {
     std::cerr << "Error: " << e.what() << std::endl;
     return 1;
   }

--- a/src/tools/lcp/lcp.cc
+++ b/src/tools/lcp/lcp.cc
@@ -43,25 +43,30 @@ void PrintHelp(char *progname)
   PrintBanner(std::cerr);
   std::cerr << "Usage: " << progname << " [OPTIONS] [file]\n";
   std::cerr << "If file is not specified, attempts to read game from standard input.\n";
-  std::cerr << "With no options, reports all Nash equilibria found.\n\n";
+  std::cerr << "For an extensive game, computes one equilibrium via the sequence form.\n";
+  std::cerr << "For a strategic game (or with -S), with no options, reports all\n";
+  std::cerr << "accessible Nash equilibria.\n\n";
 
   std::cerr << "Options:\n";
   std::cerr << "  -d DECIMALS      compute using floating-point arithmetic;\n";
   std::cerr << "                   display results with DECIMALS digits\n";
   std::cerr << "  -S               use strategic game\n";
   std::cerr << "  -e EQA           terminate after finding EQA equilibria\n";
-  std::cerr << "                   (default is to find all accessible equilbria)\n";
+  std::cerr << "                   (strategic games only; default is to find all\n";
+  std::cerr << "                   accessible equilibria)\n";
   std::cerr << "  -r DEPTH         terminate recursion at DEPTH\n";
-  std::cerr << "                   (only if number of equilibria sought is not 1)\n";
+  std::cerr << "                   (strategic games only; only if number of\n";
+  std::cerr << "                   equilibria sought is not 1)\n";
   std::cerr << "  -D               print detailed information about equilibria\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
 {
+  opterr = 0;
   int c;
   bool useFloat = false, useStrategic = false, quiet = false;
   bool printDetail = false;
@@ -74,7 +79,7 @@ int main(int argc, char *argv[])
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'd':
       useFloat = true;
       numDecimals = atoi(optarg);

--- a/src/tools/liap/liap.cc
+++ b/src/tools/liap/liap.cc
@@ -62,10 +62,11 @@ void PrintHelp(char *progname)
   std::cerr << "With no options, attempts to compute one equilibrium starting at centroid.\n";
 
   std::cerr << "Options:\n";
-  std::cerr << "  -A               compute agent form equilibria\n";
+  std::cerr << "  -A               compute agent form equilibria for extensive games\n";
   std::cerr << "  -d DECIMALS      print probabilities with DECIMALS digits\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -n COUNT         number of starting points to generate\n";
+  std::cerr << "                   (ignored if -s is given)\n";
   std::cerr << "  -i MAXITER       maximum number of iterations per point (default is 1000)\n";
   std::cerr << "  -m MAXREGRET     maximum regret acceptable as a proportion of range of\n";
   std::cerr << "                   payoffs in the game\n";
@@ -74,7 +75,7 @@ void PrintHelp(char *progname)
   std::cerr << "  -V, --verbose    verbose mode (shows intermediate output)\n";
   std::cerr << "                   (default is to only show equilibria)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 std::vector<MixedStrategyProfile<double>> ReadStrategyProfiles(const Game &p_game,
@@ -83,15 +84,17 @@ std::vector<MixedStrategyProfile<double>> ReadStrategyProfiles(const Game &p_gam
   std::vector<MixedStrategyProfile<double>> profiles;
   while (!p_stream.eof() && !p_stream.bad()) {
     MixedStrategyProfile<double> p(p_game->NewMixedStrategyProfile(0.0));
-    for (size_t i = 1; i <= p.MixedProfileLength(); i++) {
+    if (p_stream.peek() == EOF) {
+      break;
+    }
+    p_stream >> p[1];
+    for (size_t i = 2; i <= p.MixedProfileLength(); i++) {
       if (p_stream.eof() || p_stream.bad()) {
         break;
       }
+      char comma;
+      p_stream >> comma;
       p_stream >> p[i];
-      if (i < p.MixedProfileLength()) {
-        char comma;
-        p_stream >> comma;
-      }
     }
     // Read in the rest of the line and discard
     std::string foo;
@@ -107,15 +110,17 @@ std::vector<MixedBehaviorProfile<double>> ReadBehaviorProfiles(const Game &p_gam
   std::vector<MixedBehaviorProfile<double>> profiles;
   while (!p_stream.eof() && !p_stream.bad()) {
     MixedBehaviorProfile<double> p(p_game);
-    for (size_t i = 1; i <= p.BehaviorProfileLength(); i++) {
+    if (p_stream.peek() == EOF) {
+      break;
+    }
+    p_stream >> p[1];
+    for (size_t i = 2; i <= p.BehaviorProfileLength(); i++) {
       if (p_stream.eof() || p_stream.bad()) {
         break;
       }
+      char comma;
+      p_stream >> comma;
       p_stream >> p[i];
-      if (i < p.BehaviorProfileLength()) {
-        char comma;
-        p_stream >> comma;
-      }
     }
     // Read in the rest of the line and discard
     std::string foo;
@@ -128,8 +133,8 @@ std::vector<MixedBehaviorProfile<double>> ReadBehaviorProfiles(const Game &p_gam
 int main(int argc, char *argv[])
 {
   opterr = 0;
-  bool quiet = false, reportStrategic = false, solveAgent = false, verbose = false;
-  const int numTries = 10;
+  bool quiet = false, solveAgent = false, verbose = false;
+  int numTries = 10;
   int maxitsN = 1000;
   int numDecimals = 6;
   double maxregret = 1.0e-4;
@@ -141,13 +146,16 @@ int main(int argc, char *argv[])
                            {"verbose", 0, nullptr, 'V'},
                            {nullptr, 0, nullptr, 0}};
   int c;
-  while ((c = getopt_long(argc, argv, "d:n:i:s:m:hqVvAS", long_options, &long_opt_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "d:n:i:s:m:hqVvA", long_options, &long_opt_index)) != -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'd':
       numDecimals = atoi(optarg);
+      break;
+    case 'n':
+      numTries = atoi(optarg);
       break;
     case 'm':
       maxregret = atof(optarg);
@@ -160,9 +168,6 @@ int main(int argc, char *argv[])
       break;
     case 'h':
       PrintHelp(argv[0]);
-      break;
-    case 'S':
-      reportStrategic = true;
       break;
     case 'A':
       solveAgent = true;

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -45,6 +45,7 @@ void PrintHelp(char *progname)
 
   std::cerr << "Options:\n";
   std::cerr << "  -d DECIMALS      show equilibria as floating point with DECIMALS digits\n";
+  std::cerr << "  -S               use strategic game\n";
   std::cerr << "  -s STEP          initial stepsize (default is .03)\n";
   std::cerr << "  -a ACCEL         maximum acceleration (default is 1.1)\n";
   std::cerr << "  -m MAXREGRET     maximum regret acceptable as a proportion of range of\n";
@@ -57,7 +58,7 @@ void PrintHelp(char *progname)
   std::cerr << "  -e               print only the terminal equilibrium\n";
   std::cerr << "                   (default is to print the entire branch)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 //
@@ -66,14 +67,16 @@ void PrintHelp(char *progname)
 bool ReadProfile(std::istream &p_stream, MixedStrategyProfile<double> &p_profile)
 {
   for (size_t i = 1; i <= p_profile.MixedProfileLength(); i++) {
-    if (p_stream.eof() || p_stream.bad()) {
+    p_stream >> p_profile[i];
+    if (!p_stream) {
       return false;
     }
-
-    p_stream >> p_profile[i];
     if (i < p_profile.MixedProfileLength()) {
       char comma;
       p_stream >> comma;
+      if (!p_stream) {
+        return false;
+      }
     }
   }
   // Read in the rest of the line and discard
@@ -122,12 +125,11 @@ int main(int argc, char *argv[])
   option long_options[] = {
       {"help", 0, nullptr, 'h'}, {"version", 0, nullptr, 'v'}, {nullptr, 0, nullptr, 0}};
   int c;
-  while ((c = getopt_long(argc, argv, "d:s:a:m:vqehSL:p:l:", long_options, &long_opt_index)) !=
-         -1) {
+  while ((c = getopt_long(argc, argv, "d:s:a:m:vqehSL:l:", long_options, &long_opt_index)) != -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'q':
       quiet = true;
       break;
@@ -198,7 +200,9 @@ int main(int argc, char *argv[])
     if (!mleFile.empty() && (!game->IsTree() || useStrategic)) {
       MixedStrategyProfile<double> frequencies(game->NewMixedStrategyProfile(0.0));
       std::ifstream mleData(mleFile.c_str());
-      ReadProfile(mleData, frequencies);
+      if (!ReadProfile(mleData, frequencies)) {
+        throw std::runtime_error("Error reading strategy frequencies from '" + mleFile + "'.");
+      }
 
       auto printer = [fullGraph,
                       decimals](const LogitEvent<LogitQREMixedStrategyProfile> &p_event) {

--- a/src/tools/lp/lp.cc
+++ b/src/tools/lp/lp.cc
@@ -45,20 +45,22 @@ void PrintHelp(char *progname)
   PrintBanner(std::cerr);
   std::cerr << "Usage: " << progname << " [OPTIONS] [file]\n";
   std::cerr << "If file is not specified, attempts to read game from standard input.\n";
-  std::cerr << "With no options, reports all Nash equilibria found.\n\n";
+  std::cerr << "With no options, computes one Nash equilibrium.\n\n";
 
   std::cerr << "Options:\n";
   std::cerr << "  -d DECIMALS      compute using floating-point arithmetic;\n";
   std::cerr << "                   display results with DECIMALS digits\n";
   std::cerr << "  -S               use strategic game\n";
+  std::cerr << "  -D               print detailed information about equilibria\n";
   std::cerr << "  -h, --help       print this help message\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -v, --version    print version information\n";
-  exit(1);
+  exit(0);
 }
 
 int main(int argc, char *argv[])
 {
+  opterr = 0;
   int c;
   int numDecimals = 6;
   bool useFloat = false, useStrategic = false, quiet = false, printDetail = false;
@@ -70,7 +72,7 @@ int main(int argc, char *argv[])
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'd':
       useFloat = true;
       numDecimals = atoi(optarg);

--- a/src/tools/simpdiv/nfgsimpdiv.cc
+++ b/src/tools/simpdiv/nfgsimpdiv.cc
@@ -53,15 +53,17 @@ std::vector<MixedStrategyProfile<Rational>> ReadProfiles(const Game &p_game,
   std::vector<MixedStrategyProfile<Rational>> profiles;
   while (!p_stream.eof() && !p_stream.bad()) {
     MixedStrategyProfile<Rational> p(p_game->NewMixedStrategyProfile(Rational(0)));
-    for (size_t i = 1; i <= p.MixedProfileLength(); i++) {
+    p_stream >> p[1];
+    if (!p_stream) {
+      break;
+    }
+    for (size_t i = 2; i <= p.MixedProfileLength(); i++) {
       if (p_stream.eof() || p_stream.bad()) {
         break;
       }
+      char comma;
+      p_stream >> comma;
       p_stream >> p[i];
-      if (i < p.MixedProfileLength()) {
-        char comma;
-        p_stream >> comma;
-      }
     }
     // Read in the rest of the line and discard
     std::string foo;
@@ -119,12 +121,12 @@ void PrintHelp(char *progname)
   std::cerr << "  -d DECIMALS      show profiles as floating point with DECIMALS digits\n";
   std::cerr << "                   (default is to display rational numbers)\n";
   std::cerr << "  -m MAXREGRET     maximum regret acceptable as a proportion of range of\n";
-  std::cerr << "                   payoffs in the game\n";
+  std::cerr << "                   payoffs in the game (default is 1e-7)\n";
   std::cerr << "  -q               quiet mode (suppresses banner)\n";
   std::cerr << "  -V, --verbose    verbose mode (shows intermediate output)\n";
-  std::cerr << "  -v, --version    print version information\n";
   std::cerr << "                   (default is to only show equilibria)\n";
-  exit(1);
+  std::cerr << "  -v, --version    print version information\n";
+  exit(0);
 }
 
 int main(int argc, char *argv[])
@@ -142,11 +144,11 @@ int main(int argc, char *argv[])
                                   {"verbose", 0, nullptr, 'V'},
                                   {nullptr, 0, nullptr, 0}};
   int c;
-  while ((c = getopt_long(argc, argv, "g:hVvn:r:s:m:d:qS", long_options, &long_opt_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "g:hVvn:r:s:m:d:q", long_options, &long_opt_index)) != -1) {
     switch (c) {
     case 'v':
       PrintBanner(std::cerr);
-      exit(1);
+      exit(0);
     case 'g':
       gridResize = atoi(optarg);
       break;
@@ -174,8 +176,6 @@ int main(int argc, char *argv[])
       break;
     case 'V':
       verbose = true;
-      break;
-    case 'S':
       break;
     case '?':
       if (isprint(optopt)) {
@@ -219,11 +219,7 @@ int main(int argc, char *argv[])
       starts = NewRandomStrategyProfiles(game, stopAfter, randDenom, engine);
     }
     else {
-      starts.push_back(game->NewMixedStrategyProfile(Rational(0)));
-      starts.back() = Rational(0);
-      for (const auto &player : game->GetPlayers()) {
-        starts.back()[player->GetStrategies().back()] = Rational(1);
-      }
+      starts.push_back(SimpdivDefaultStart(game));
     }
     for (auto start : starts) {
       if (decimals > 0) {


### PR DESCRIPTION
Cross-checked each command-line tool's --help, getopt option string, switch-case implementation, Sphinx docs, and GUI invocation against each other, and fixed the inconsistencies found:

* liap: fix -n crash (unhandled case); remove dead -S; align -A/-n help and docs with actual behavior
* nfgipa: wire up -s to actually read starting perturbations instead of discarding it; widen exception handling to catch std::domain_error from gametracer
* nfggnm/enummixed/nfgsimpdiv: remove dead/no-op -S
* logit: document existing -S; check -L profile extraction for failure instead of silently discarding malformed/missing input
* lcp/lp: correct --help and docs on how many equilibria are found, and by which representation
* simpdiv: fix default starting profile to use each player's first strategy, not last (regressed by a prior warnings cleanup); expose this as SimpdivDefaultStart() as the single implementation, used by both the library and the CLI tool, instead of two diverging copies
* fix misplaced -V/-v help lines in simpdiv and enumpoly; fix stale enumpoly/gnm/enummixed/simpdiv docs (nonexistent -H, removed -D, wrong centroid claim, -v/-V mislabeling)
* fix shared trailing-newline bug in profile-reading helpers (gt, liap, simpdiv) that started a spurious all-zero profile
* Rational::operator>> now fails gracefully at end-of-stream instead of throwing, matching built-in types; simplify simpdiv's reader now that it no longer needs to work around the old behavior
* -h/-v now exit 0, not 1, across all tools
* add missing opterr=0 (convert, enummixed, lcp, lp) to stop duplicate "unknown option" messages
* dlnash.cc updated to match the above (drop -S for tools that no longer take it; fix IPA invocation, which was passing -S though IPA never accepted it)

_