### PR TITLE
Update Windows installer builder config

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir installer
           cp gambit* installer
-          "${WIX}bin/candle" build_support/msw/gambit.wxs
+          "${WIX}bin/candle" -arch x64 build_support/msw/gambit.wxs
           "${WIX}bin/light" -ext WixUIExtension gambit.wixobj
       - uses: actions/upload-artifact@v7
         with:

--- a/build_support/msw/gambit.wxs.in
+++ b/build_support/msw/gambit.wxs.in
@@ -12,7 +12,7 @@
         </UI>
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder">
+            <Directory Id="ProgramFiles64Folder">
                 <Directory Id="ApplicationRootDirectory" Name="Gambit"/>
             </Directory>
             <Directory Id="ProgramMenuFolder">

--- a/build_support/msw/gambit.wxs.in
+++ b/build_support/msw/gambit.wxs.in
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Product Id="8EE11AE3-2B91-4870-895B-44C46D648BD6" Name="Gambit 16" Language="1033" Version="@GAMBIT_VERSION@" Manufacturer="The Gambit Project" UpgradeCode="135FFB28-DA7C-427C-A3DA-783B805BCC22">
+    <Product Id="*" Name="Gambit @GAMBIT_MSI_MAJOR@" Language="1033" Version="@GAMBIT_MSI_VERSION@" Manufacturer="The Gambit Project" UpgradeCode="135FFB28-DA7C-427C-A3DA-783B805BCC22">
         <Package Description="Gambit" Comments="Software Tools for Game Theory" InstallerVersion="200" Compressed="yes" />
         <Media Id="1" Cabinet="gambit.cab" EmbedCab="yes" />
+
+        <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
         <WixVariable Id="WixUILicenseRtf" Value="license.rtf"/>
         <UI>
@@ -19,48 +21,65 @@
         </Directory>
 
         <DirectoryRef Id="ApplicationRootDirectory">
-            <Component Id="Gambit.exe" Guid="AEB0EAF8-246A-4194-9628-A4ED3092CD93">
+            <Component Id="Gambit.exe" Guid="AEB0EAF8-246A-4194-9628-A4ED3092CD93" Win64="yes">
                 <File Id="gambit.exe" Source="installer\gambit.exe" KeyPath="yes" Checksum="yes"/>
-                <File Id="gambit_enummixed.exe" Source="installer\gambit-enummixed.exe" Checksum="yes"/>
-                <File Id="gambit_enumpure.exe" Source="installer\gambit-enumpure.exe" Checksum="yes"/>
-                <File Id="gambit_gnm.exe" Source="installer\gambit-gnm.exe" Checksum="yes"/>
-                <File Id="gambit_ipa.exe" Source="installer\gambit-ipa.exe" Checksum="yes"/>
-                <File Id="gambit_lcp.exe" Source="installer\gambit-lcp.exe" Checksum="yes"/>
-                <File Id="gambit_liap.exe" Source="installer\gambit-liap.exe" Checksum="yes"/>
-                <File Id="gambit_logit.exe" Source="installer\gambit-logit.exe" Checksum="yes"/>
-                <File Id="gambit_lp.exe" Source="installer\gambit-lp.exe" Checksum="yes"/>
-                <File Id="gambit_simpdiv.exe" Source="installer\gambit-simpdiv.exe" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_enummixed.exe" Guid="E529AE61-6BF7-418B-8EB7-24758D2F1A32" Win64="yes">
+                <File Id="gambit_enummixed.exe" Source="installer\gambit-enummixed.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_enumpure.exe" Guid="2B2FBF6E-ABBF-4189-AAF2-F66F63F07FE2" Win64="yes">
+                <File Id="gambit_enumpure.exe" Source="installer\gambit-enumpure.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_gnm.exe" Guid="E10C0653-EAFD-4C3D-9AE1-5BDE68A28585" Win64="yes">
+                <File Id="gambit_gnm.exe" Source="installer\gambit-gnm.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_ipa.exe" Guid="9E5E5696-080B-4205-A8DF-75800A50497B" Win64="yes">
+                <File Id="gambit_ipa.exe" Source="installer\gambit-ipa.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_lcp.exe" Guid="5A9D4F65-7748-4041-B886-C41E016815AB" Win64="yes">
+                <File Id="gambit_lcp.exe" Source="installer\gambit-lcp.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_liap.exe" Guid="BD9D75A2-D2A4-460F-AAB2-C3EA34488A1A" Win64="yes">
+                <File Id="gambit_liap.exe" Source="installer\gambit-liap.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_logit.exe" Guid="FA43C551-4B1D-4914-8D5B-596830142257" Win64="yes">
+                <File Id="gambit_logit.exe" Source="installer\gambit-logit.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_lp.exe" Guid="81CCED15-E164-4F1B-B57D-FBEB7F877E4B" Win64="yes">
+                <File Id="gambit_lp.exe" Source="installer\gambit-lp.exe" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="Gambit_simpdiv.exe" Guid="354FC5CE-9067-4910-83CB-6014CC4318EF" Win64="yes">
+                <File Id="gambit_simpdiv.exe" Source="installer\gambit-simpdiv.exe" KeyPath="yes" Checksum="yes"/>
             </Component>
         </DirectoryRef>
 
-        <DirectoryRef Id="ProgramMenuFolder">
-            <Directory Id="ProgramMenuDir" Name="Gambit 16">
-                <Component Id="ProgramMenuDir" Guid="F112A6A5-1C0C-4246-BBB8-D3466DA03D4C">
-                    <RemoveFolder Id="ProgramMenuDir" On="uninstall"/>
-                    <RegistryValue Root="HKCU" Key="Software\Gambit\Gambit 16" Type="string" Value="" KeyPath="yes"/>
-                </Component>
-            </Directory>
-        </DirectoryRef>
-
         <DirectoryRef Id="ApplicationProgramsFolder">
-            <Component Id="ApplicationShortcut" Guid="3B9A0C37-7E9A-446E-9D14-76EBCCF3F1E0">
+            <Component Id="ApplicationShortcut" Guid="3B9A0C37-7E9A-446E-9D14-76EBCCF3F1E0" Win64="yes">
                 <Shortcut Id="ApplicationStartMenuShortcut"
-                          Name="Gambit 16"
+                          Name="Gambit @GAMBIT_MSI_MAJOR@"
                           Description="Software Tools for Game Theory"
                           Target="[ApplicationRootDirectory]Gambit.exe"
                           WorkingDirectory="ApplicationRootDirectory"/>
                 <Shortcut Id="UninstallProduct"
-                          Name="Uninstall Gambit 16"
+                          Name="Uninstall Gambit @GAMBIT_MSI_MAJOR@"
                           Description="Uninstalls Gambit"
                           Target="[System64Folder]msiexec.exe"
                           Arguments="/x [ProductCode]"/>
                 <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-                <RegistryValue Root="HKCU" Key="Software\Microsoft\Gambit 16" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+                <RegistryValue Root="HKCU" Key="Software\Gambit\Gambit @GAMBIT_MSI_MAJOR@" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
             </Component>
         </DirectoryRef>
         <Feature Id="Complete" Level="1">
             <ComponentRef Id="Gambit.exe"/>
-            <ComponentRef Id="ProgramMenuDir"/>
+            <ComponentRef Id="Gambit_enummixed.exe"/>
+            <ComponentRef Id="Gambit_enumpure.exe"/>
+            <ComponentRef Id="Gambit_gnm.exe"/>
+            <ComponentRef Id="Gambit_ipa.exe"/>
+            <ComponentRef Id="Gambit_lcp.exe"/>
+            <ComponentRef Id="Gambit_liap.exe"/>
+            <ComponentRef Id="Gambit_logit.exe"/>
+            <ComponentRef Id="Gambit_lp.exe"/>
+            <ComponentRef Id="Gambit_simpdiv.exe"/>
             <ComponentRef Id="ApplicationShortcut"/>
         </Feature>
     </Product>

--- a/configure.ac
+++ b/configure.ac
@@ -148,5 +148,50 @@ AC_SUBST(REZFLAGS)
 GAMBIT_VERSION=`cat build_support/GAMBIT_VERSION`
 AC_SUBST(GAMBIT_VERSION)
 
+dnl WiX requires the Product/@Version attribute to be a purely numeric
+dnl "major.minor.build[.revision]" string, which a SemVer prerelease tag
+dnl (e.g. "17.0.0-alpha.1") is not.  Windows Installer's ProductVersion is
+dnl actually major.minor.build (not major.minor.micro): it only looks at
+dnl the first THREE fields, and silently ignores any fourth, so the build
+dnl field is where prerelease ordering has to live.
+dnl
+dnl This matches the alpha/beta/rc nomenclature used by the rest of the
+dnl release tooling (see "Making a new release" in
+dnl doc/developer.contributing.rst).  The build field is carved into
+dnl bands, each with far more headroom than a release cycle needs:
+dnl   alpha.N -> 0     + N
+dnl   beta.N  -> 10000 + N
+dnl   rc.N    -> 20000 + N
+dnl   (final) -> 60000 + N
+dnl N is the prerelease number (e.g. the "1" in "alpha.1"), with the
+dnl GAMBIT_VERSION patch component folded in as a *100 offset within each
+dnl band -- a no-op today since Gambit's patch component has always been
+dnl 0, but it keeps e.g. a hypothetical "17.0.1-alpha.1" ordered above
+dnl "17.0.0" without revisiting this scheme.
+GAMBIT_MSI_BASE=${GAMBIT_VERSION%%-*}
+GAMBIT_MSI_PRERELEASE=${GAMBIT_VERSION#$GAMBIT_MSI_BASE}
+
+save_IFS=$IFS
+IFS=.
+set -- $GAMBIT_MSI_BASE
+IFS=$save_IFS
+GAMBIT_MSI_MAJOR=$1
+GAMBIT_MSI_MINOR=$2
+GAMBIT_MSI_PATCH=$3
+
+case $GAMBIT_MSI_PRERELEASE in
+  -alpha.*) GAMBIT_MSI_STAGE=0;     GAMBIT_MSI_PRENUM=${GAMBIT_MSI_PRERELEASE#-alpha.} ;;
+  -beta.*)  GAMBIT_MSI_STAGE=10000; GAMBIT_MSI_PRENUM=${GAMBIT_MSI_PRERELEASE#-beta.} ;;
+  -rc.*)    GAMBIT_MSI_STAGE=20000; GAMBIT_MSI_PRENUM=${GAMBIT_MSI_PRERELEASE#-rc.} ;;
+  '')       GAMBIT_MSI_STAGE=60000; GAMBIT_MSI_PRENUM=0 ;;
+  *)        GAMBIT_MSI_STAGE=0;     GAMBIT_MSI_PRENUM=0 ;;
+esac
+test "$GAMBIT_MSI_STAGE" -lt 60000 && test "$GAMBIT_MSI_PRENUM" -gt 99 && GAMBIT_MSI_PRENUM=99
+
+GAMBIT_MSI_BUILD=`expr $GAMBIT_MSI_STAGE + $GAMBIT_MSI_PATCH \* 100 + $GAMBIT_MSI_PRENUM`
+GAMBIT_MSI_VERSION="$GAMBIT_MSI_MAJOR.$GAMBIT_MSI_MINOR.$GAMBIT_MSI_BUILD"
+AC_SUBST(GAMBIT_MSI_VERSION)
+AC_SUBST(GAMBIT_MSI_MAJOR)
+
 AC_CONFIG_FILES([Makefile build_support/osx/Info.plist build_support/msw/gambit.wxs])
 AC_OUTPUT

--- a/doc/developer.contributing.rst
+++ b/doc/developer.contributing.rst
@@ -280,6 +280,17 @@ When making a new release of Gambit, follow these steps:
    - `doc/conf.py` reads from GAMBIT_VERSION file at documentation build time
    - Documentation pages reference the `|release|` substitution variable to automatically reflect the updated version number.
 
+   The Windows ``.msi`` installer is the one exception: Windows Installer's ``ProductVersion``
+   must be a plain numeric ``major.minor.build`` triple.  So, ``configure.ac`` derives a separate
+   ``GAMBIT_MSI_VERSION`` for ``gambit.wxs`` instead of substituting ``GAMBIT_VERSION`` directly.
+   The build field is banded by release stage so that alpha < beta < rc < the final release of
+   the same version compares correctly to Windows Installer:
+
+   - ``X.Y.Z-alpha.N`` -> build ``0 + N``
+   - ``X.Y.Z-beta.N``  -> build ``10000 + N``
+   - ``X.Y.Z-rc.N``    -> build ``20000 + N``
+   - ``X.Y.Z`` (final) -> build ``60000``
+
 3. Update the ``ChangeLog`` file at the repository root with a summary of changes for this release.
    This file is the single source of truth for release notes — it is surfaced in the documentation
    (see :ref:`releases`) and used to populate the GitHub release automatically.


### PR DESCRIPTION
* Modernises the configuration of the windows installer to flag binaries correctly as 64-bit, various other metadata corrections and improvements
* Remap semantic versioning scheme to fit within the format required by WiX/MSW for build versions.
* 