### PR TITLE
Implement `Game.relabel_strategies` to reassign the strategy labels of a player.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
   its actions to be specified up front, just as `Game.make_event` does.  (#999)
 - `Game.get_behavior` returns a map-like view of the actions a reduced strategy prescribes at its player's
   information sets; the unreachable information sets are absent.  (#1002)
+- Added `Game.relabel_strategies`, which simultaneously reassigns the labels of a player's strategies.  (#1047)
 
 ### Changed
 - Adopted the C++20 standard; build system now enforces exactly C++20 (not a minimum) (cf. #1027)
@@ -83,6 +84,8 @@
   stub overrides it forced on the strategic, AGG, and BAGG representations; it was subsumed by
   `MakeEvent`, and by this point was used only in support of the GUI's "Edit Move" dialog, which
   now builds the equivalent `MakeEvent` call directly.  (#999)
+- Assigning to `Strategy.label` has been removed; use `Game.relabel_strategies`, which enforces
+  nonempty, unique labels.  (#1047)
 
 ## [16.7.0] - 2026-07-11
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,9 @@
 ### Fixed
 - Converting a behavior profile to a strategy profile, and computing pure-strategy payoffs
   no longer inserts spurious entries into a strategy's internal action map.
+- `Game.add_player`, on a game in strategic form, no longer leaves the new player's sole
+  strategy with an empty label; it is now labeled `"1"`, as `Game.new_table` already labels
+  every other player's initial strategies.  (#1047)
 
 ### Removed
 - `Game.set_player` has been removed; use `Game.make_infoset`, specifying the members of the

--- a/doc/pygambit.api.rst
+++ b/doc/pygambit.api.rst
@@ -88,6 +88,7 @@ Transforming game components
    Game.set_outcome
    Game.add_strategy
    Game.delete_strategy
+   Game.relabel_strategies
 
 
 Information about the game

--- a/doc/tutorials/01_quickstart.ipynb
+++ b/doc/tutorials/01_quickstart.ipynb
@@ -76,16 +76,7 @@
    "id": "9d8203e8",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "tom, jerry = g.players\n",
-    "tom.label = \"Tom\"\n",
-    "jerry.label = \"Jerry\"\n",
-    "\n",
-    "for player in g.players:\n",
-    "    cooperate, defect = player.strategies\n",
-    "    cooperate.label = \"Cooperate\"\n",
-    "    defect.label = \"Defect\""
-   ]
+   "source": "tom, jerry = g.players\ntom.label = \"Tom\"\njerry.label = \"Jerry\"\n\nfor player in g.players:\n    cooperate, defect = player.strategies\n    g.relabel_strategies(player, {cooperate.label: \"Cooperate\", defect.label: \"Defect\"})"
   },
   {
    "cell_type": "markdown",

--- a/doc/tutorials/interoperability_tutorials/gamut.ipynb
+++ b/doc/tutorials/interoperability_tutorials/gamut.ipynb
@@ -387,43 +387,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "gamut-bos-gen",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<center><h1>Chicken</h1></center>\n",
-       "<table><tr><td colspan=\"2\" rowspan=\"2\"></td><td colspan=\"2\" align=\"center\"><b>Player2</b></td></tr><tr><td align=\"center\"><b>Swerve</b></td><td align=\"center\"><b>Straight</b></td></tr><tr><td rowspan=\"2\" align=\"center\" valign=\"middle\"><b>Player1</b></td><td align=\"center\"><b>Swerve</b></td><td align=center>2,2</td><td align=center>1,4</td></tr><tr><td align=\"center\"><b>Straight</b></td><td align=center>4,1</td><td align=center>0,0</td></tr></table>\n"
-      ],
-      "text/plain": [
-       "Game(title='Chicken')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "g_chicken = gbt.catalog.generate_gamut(\n",
-    "    \"Chicken\",\n",
-    "    params={\n",
-    "        \"int_payoffs\": True,\n",
-    "        \"int_mult\": 1,\n",
-    "        \"normalize\": True,\n",
-    "        \"min_payoff\": 0,\n",
-    "        \"max_payoff\": 4,\n",
-    "    },\n",
-    "    gamut_jar=\"~/Downloads/gamut.jar\",\n",
-    ")\n",
-    "g_chicken.title = \"Chicken\"\n",
-    "for player in g_chicken.players:\n",
-    "    for strategy, label in zip(player.strategies, [\"Swerve\", \"Straight\"], strict=True):\n",
-    "        strategy.label = label\n",
-    "g_chicken"
-   ]
+   "outputs": [],
+   "source": "g_chicken = gbt.catalog.generate_gamut(\n    \"Chicken\",\n    params={\n        \"int_payoffs\": True,\n        \"int_mult\": 1,\n        \"normalize\": True,\n        \"min_payoff\": 0,\n        \"max_payoff\": 4,\n    },\n    gamut_jar=\"~/Downloads/gamut.jar\",\n)\ng_chicken.title = \"Chicken\"\nfor player in g_chicken.players:\n    labels = {strategy.label: label\n              for strategy, label in zip(player.strategies, [\"Swerve\", \"Straight\"], strict=True)}\n    g_chicken.relabel_strategies(player, labels)\ng_chicken"
   },
   {
    "cell_type": "markdown",

--- a/doc/tutorials/interoperability_tutorials/openspiel.ipynb
+++ b/doc/tutorials/interoperability_tutorials/openspiel.ipynb
@@ -156,17 +156,7 @@
    "id": "b684325e",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "gbt_matrix_rps_game = gbt.catalog.generate_openspiel(\"matrix_rps\")\n",
-    "\n",
-    "gbt_matrix_rps_game.title = \"Rock-Paper-Scissors\"\n",
-    "\n",
-    "for player in gbt_matrix_rps_game.players:\n",
-    "    for strategy, name in zip(player.strategies, [\"Rock\", \"Paper\", \"Scissors\"], strict=True):\n",
-    "        strategy.label = name\n",
-    "\n",
-    "gbt_matrix_rps_game"
-   ]
+   "source": "gbt_matrix_rps_game = gbt.catalog.generate_openspiel(\"matrix_rps\")\n\ngbt_matrix_rps_game.title = \"Rock-Paper-Scissors\"\n\nfor player in gbt_matrix_rps_game.players:\n    names = [\"Rock\", \"Paper\", \"Scissors\"]\n    labels = {strategy.label: name\n              for strategy, name in zip(player.strategies, names, strict=True)}\n    gbt_matrix_rps_game.relabel_strategies(player, labels)\n\ngbt_matrix_rps_game"
   },
   {
    "cell_type": "markdown",

--- a/src/games/file.cc
+++ b/src/games/file.cc
@@ -546,7 +546,12 @@ Game BuildNfg(GameFileLexer &p_parser, TableFileGame &p_data)
       strategyLabels.push_back(p_data.GetStrategy(player->GetNumber(), strategy->GetNumber()));
     }
     NormalizeLabelStrings(strategyLabels);
-    RelabelWithoutCollision(player->GetStrategies(), strategyLabels);
+    std::map<std::string, std::string> labels;
+    size_t index = 0;
+    for (auto strategy : player->GetStrategies()) {
+      labels[strategy->GetLabel()] = strategyLabels[index++];
+    }
+    nfg->RelabelStrategies(player, labels);
   }
 
   if (p_parser.GetCurrentToken() == TOKEN_LBRACE) {
@@ -907,11 +912,10 @@ void NormalizeGameLabels(const Game &p_game)
   // Action labels are not normalized here: for tree games, ParseNode/ParsePersonalNode
   // already normalize each infoset's actions individually, at creation, from the raw
   // labels as parsed (see there for why the raw labels must be kept around too).
-  if (!p_game->IsTree()) {
-    for (const auto &player : p_game->GetPlayers()) {
-      NormalizeLabels(player->GetStrategies(), get_label, set_label);
-    }
-  }
+  // Strategy labels are not normalized here either: every strategic-form construction
+  // path (BuildNfg via RelabelStrategies, and the "1".."N" numbering GameAGGRep/
+  // GameBAGGRep assign directly) already guarantees unique, nonempty labels per player
+  // by the time a game reaches here.
 }
 
 Game ReadEfgFile(std::istream &p_stream)

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -648,8 +648,10 @@ public:
   GameStrategy GetStrategy(int st) const;
   /// Returns the collection of strategies available to the player
   Strategies GetStrategies() const;
-  /// Validate that p_label is a nonempty, valid, unique label for a strategy of this player.
-  void CheckStrategyLabel(const std::string &p_label) const;
+  /// Validate that p_label is a valid label for a strategy of this player,
+  /// disregarding any strategies in p_ignore.
+  void CheckStrategyLabel(const std::string &p_label,
+                          const std::set<const GameStrategyRep *> &p_ignore) const;
   //@}
 
   /// @name Sequences
@@ -1377,6 +1379,12 @@ public:
   }
   /// Remove the strategy from the game
   virtual void DeleteStrategy(const GameStrategy &p_strategy) { throw UndefinedException(); }
+  /// Simultaneously reassign strategy labels for a player: keys are current labels.
+  /// Keys of p_labels are current action labels; values are their replacements.
+  virtual void RelabelStrategies(const GamePlayer &, const std::map<std::string, std::string> &)
+  {
+    throw UndefinedException();
+  }
   /// Returns the total number of actions in the game
   virtual int BehavProfileLength() const = 0;
   //@}
@@ -1522,18 +1530,20 @@ inline void GameStrategyRep::SetLabel(const std::string &p_label)
   if (p_label == m_label) {
     return;
   }
-  GetPlayer()->CheckStrategyLabel(p_label);
+  GetPlayer()->CheckStrategyLabel(p_label, {this});
   m_label = p_label;
 }
 
-inline void GamePlayerRep::CheckStrategyLabel(const std::string &p_label) const
+inline void
+GamePlayerRep::CheckStrategyLabel(const std::string &p_label,
+                                  const std::set<const GameStrategyRep *> &p_ignore) const
 {
   if (p_label.empty()) {
     throw ValueException("Strategy label must not be empty");
   }
   CheckLabel(p_label);
   for (const auto &strategy : m_strategies) {
-    if (strategy->GetLabel() == p_label) {
+    if (p_ignore.count(strategy.get()) == 0 && strategy->GetLabel() == p_label) {
       throw ValueException("Strategy label must be unique for the player");
     }
   }

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -521,8 +521,6 @@ public:
   //@{
   /// Returns the text label associated with the strategy
   const std::string &GetLabel() const { return m_label; }
-  /// Sets the text label associated with the strategy
-  void SetLabel(const std::string &p_label);
 
   /// Returns the game on which the strategy is defined
   Game GetGame() const;
@@ -1525,14 +1523,6 @@ inline void GameOutcomeRep::SetPayoff(const GamePlayer &p_player, const Number &
 
 inline GamePlayer GameStrategyRep::GetPlayer() const { return m_player->shared_from_this(); }
 inline Game GameStrategyRep::GetGame() const { return m_player->GetGame(); }
-inline void GameStrategyRep::SetLabel(const std::string &p_label)
-{
-  if (p_label == m_label) {
-    return;
-  }
-  GetPlayer()->CheckStrategyLabel(p_label, {this});
-  m_label = p_label;
-}
 
 inline void
 GamePlayerRep::CheckStrategyLabel(const std::string &p_label,

--- a/src/games/gametable.cc
+++ b/src/games/gametable.cc
@@ -497,6 +497,7 @@ GamePlayer GameTableRep::NewPlayer(const std::string &p_label)
 {
   CheckPlayerLabel(p_label);
   auto player = std::make_shared<GamePlayerRep>(this, m_players.size() + 1, p_label, 1);
+  player->m_strategies.front()->m_label = "1";
   IncrementVersion();
   m_players.push_back(player);
   for (const auto &outcome : m_outcomes) {

--- a/src/games/gametable.cc
+++ b/src/games/gametable.cc
@@ -531,7 +531,7 @@ GameStrategy GameTableRep::NewStrategy(const GamePlayer &p_player, const std::st
   if (p_player->GetGame().get() != this) {
     throw MismatchException();
   }
-  p_player->CheckStrategyLabel(p_label);
+  p_player->CheckStrategyLabel(p_label, {});
   auto strategy = std::make_shared<GameStrategyRep>(p_player.get(),
                                                     p_player->m_strategies.size() + 1, p_label);
   IncrementVersion();
@@ -565,6 +565,43 @@ void GameTableRep::DeleteStrategy(const GameStrategy &p_strategy)
   player->m_strategies.erase(deletedIt);
   RebuildTable(old_radices, player->GetNumber() - 1, deletedDigit);
   p_strategy->Invalidate();
+}
+
+void GameTableRep::RelabelStrategies(const GamePlayer &p_player,
+                                     const std::map<std::string, std::string> &p_labels)
+{
+  if (p_player->GetGame().get() != this) {
+    throw MismatchException();
+  }
+  std::map<GameStrategyRep *, std::string> assignment;
+  std::set<const GameStrategyRep *> relabeled;
+  for (const auto &[old_label, new_label] : p_labels) {
+    GameStrategyRep *match = nullptr;
+    for (const auto &strategy : p_player->m_strategies) {
+      if (strategy->GetLabel() == old_label) {
+        if (match) {
+          throw ValueException("Strategy label '" + old_label + "' is ambiguous for this player");
+        }
+        match = strategy.get();
+      }
+    }
+    if (!match) {
+      throw ValueException("No strategy with label '" + old_label + "' for this player");
+    }
+    assignment[match] = new_label;
+    relabeled.insert(match);
+  }
+  std::set<std::string> targets;
+  for (const auto &[strategy, new_label] : assignment) {
+    p_player->CheckStrategyLabel(new_label, relabeled);
+    if (!targets.insert(new_label).second) {
+      throw ValueException("Strategy label '" + new_label +
+                           "' would be duplicated by the relabelling");
+    }
+  }
+  for (const auto &[strategy, new_label] : assignment) {
+    strategy->m_label = new_label;
+  }
 }
 
 //------------------------------------------------------------------------

--- a/src/games/gametable.h
+++ b/src/games/gametable.h
@@ -100,6 +100,7 @@ public:
   //@{
   GameStrategy NewStrategy(const GamePlayer &, const std::string &) override;
   void DeleteStrategy(const GameStrategy &p_strategy) override;
+  void RelabelStrategies(const GamePlayer &, const std::map<std::string, std::string> &) override;
   //@}
 
   /// @name Writing data files

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -1819,8 +1819,7 @@ Game GameTreeRep::NormalizeChanceProbs(GameInfosetRep *p_infoset)
     throw MismatchException();
   }
   if (!p_infoset->IsChanceInfoset()) {
-    throw UndefinedException(
-        "Action probabilities can only be normalized for chance information sets");
+    throw UndefinedException("Action probabilities can only be normalized for events");
   }
   IncrementVersion();
   auto &probs = p_infoset->m_probs;

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -452,7 +452,8 @@ void GameDocument::DoDeleteStrategy(GameStrategy p_strategy)
 
 void GameDocument::DoSetStrategyLabel(GameStrategy p_strategy, const wxString &p_label)
 {
-  p_strategy->SetLabel(p_label.ToStdString(wxConvUTF8));
+  m_game->RelabelStrategies(p_strategy->GetPlayer(),
+                            {{p_strategy->GetLabel(), p_label.ToStdString(wxConvUTF8)}});
   NotifyChanged(GameModificationType::GameLabels);
 }
 

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -417,9 +417,6 @@ GamePlayer GameDocument::DoNewPlayer()
     number++;
   }
   const GamePlayer player = m_game->NewPlayer("Player " + lexical_cast<std::string>(number));
-  if (!m_game->IsTree()) {
-    player->GetStrategy(1)->SetLabel("1");
-  }
   NotifyChanged(GameModificationType::GameForm);
   return player;
 }

--- a/src/pygambit/action.pxi
+++ b/src/pygambit/action.pxi
@@ -102,7 +102,7 @@ class Action:
         """
         if not self.infoset.is_chance:
             raise UndefinedOperationError(
-                "action probabilities are only defined at chance information sets"
+                "action probabilities are only defined at events"
             )
         py_string = cython.cast(
             string,

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -335,6 +335,7 @@ cdef extern from "games/game.h":
         c_GameStrategy GetStrategy(int) except +IndexError
         c_GameStrategy NewStrategy(c_GamePlayer, string) except +ValueError
         void DeleteStrategy(c_GameStrategy) except +
+        void RelabelStrategies(c_GamePlayer, stdmap[string, string]) except +ValueError
         int MixedProfileLength() except +
 
         c_GameInfoset GetInfoset(int) except +IndexError

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -107,7 +107,6 @@ cdef extern from "games/game.h":
         int GetId() except +
         c_GamePlayer GetPlayer() except +
         string GetLabel() except +
-        void SetLabel(string) except +ValueError
         c_GameAction GetAction(c_GameInfoset) except +
 
     cdef cppclass c_GameSequenceRep "GameSequenceRep":

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -2250,9 +2250,8 @@ class Game:
 
         `labels` maps current action labels to their replacements.  The reassignment
         is simultaneous, so labels can be swapped directly, e.g. ``{"a": "b", "b": "a"}``.
-        Actions are not re-ordered: each relabelled action keeps its position and,
-        at a chance information set, its probability.  After the operation, the
-        labels at the information set must be nonempty and unique.
+        Actions are not re-ordered: each relabelled action keeps its position and, at an event,
+        its probability.  After the operation, the labels must be nonempty and unique.
 
         .. versionadded:: 17.0.0
 
@@ -2594,6 +2593,84 @@ class Game:
         if len(resolved_strategy.player.strategies) == 1:
             raise UndefinedOperationError("Cannot delete the only strategy for a player")
         self.game.deref().DeleteStrategy(resolved_strategy.strategy)
+
+    def relabel_strategies(self,
+                           player: Player | str,
+                           labels: typing.Mapping[str, str],
+                           strict: bool = True) -> None:
+        """Simultaneously reassign the labels of `player`'s strategies.
+
+        `labels` maps current strategy labels to their replacements.  The reassignment
+        is simultaneous, so labels can be swapped directly, e.g. ``{"1": "2", "2": "1"}``.
+        Strategies are not re-ordered: each relabelled strategy keeps its position.
+        After the operation, the player's strategy labels must be nonempty and unique.
+
+        .. versionadded:: 17.0.0
+
+        Parameters
+        ----------
+        player : Player or str
+            The player whose strategies to relabel.  If a string is passed, the player
+            is determined by finding the player with that label, if any.
+        labels : Mapping[str, str]
+            A mapping from current strategy labels to replacement labels.  Entries
+            whose key equals their value are ignored.
+        strict : bool, default True
+            If `True`, every key of `labels` must be the label of a strategy of
+            `player`, and unknown keys raise ``KeyError``.  If `False`, unknown keys
+            are ignored.
+
+        Raises
+        ------
+        MismatchError
+            If `player` is a `Player` from a different game.
+        KeyError
+            If `player` is a string matching no player; or, when `strict` is `True`,
+            if a key of `labels` matches no strategy of `player`.
+        TypeError
+            If `labels` is not a mapping, or any key or value is not a string.
+        UndefinedOperationError
+            If the game has a tree representation, where strategies are derived from
+            the tree.
+        ValueError
+            If a key of `labels` matches more than one strategy of `player`; or if any
+            replacement label is empty, is not a valid label, or would result in a
+            duplicate label for the player.
+
+        See Also
+        --------
+        relabel_actions : Change the labels of actions at an information set.
+        """
+        if self.is_tree:
+            raise UndefinedOperationError(
+                "Relabelling strategies is only applicable to games in strategic form"
+            )
+        resolved_player = cython.cast(Player, self._resolve_player(player, "relabel_strategies"))
+        if not hasattr(labels, "items"):
+            raise TypeError(
+                f"relabel_strategies(): labels must be a mapping, "
+                f"not {labels.__class__.__name__}"
+            )
+        current = [strategy.label for strategy in resolved_player.strategies]
+        c_labels = stdmap[string, string]()
+        for old, new in labels.items():
+            if not isinstance(old, str) or not isinstance(new, str):
+                raise TypeError("relabel_strategies(): labels must map str to str")
+            matches = current.count(old)
+            if matches > 1:
+                raise ValueError(
+                    f"relabel_strategies(): label '{old}' is ambiguous for this player"
+                )
+            if matches == 0:
+                if strict:
+                    raise KeyError(f"relabel_strategies(): no strategy with label '{old}'")
+                continue
+            if new == old:
+                continue
+            c_labels[old.encode("utf-8")] = new.encode("utf-8")
+        if c_labels.empty():
+            return
+        self.game.deref().RelabelStrategies(resolved_player.player, c_labels)
 
 
 @dataclasses.dataclass

--- a/src/pygambit/game.pxi
+++ b/src/pygambit/game.pxi
@@ -2425,6 +2425,10 @@ class Game:
             In extensive games, the label cannot be ``"Chance"``, which is reserved for the
             chance player.
 
+        .. versionchanged:: 17.0.0
+            In a game with a strategic representation, the new player's sole strategy is
+            labeled ``"1"``.
+
         Parameters
         ----------
         label : str

--- a/src/pygambit/strategy.pxi
+++ b/src/pygambit/strategy.pxi
@@ -60,13 +60,10 @@ class Strategy:
             two consecutive whitespace characters.  "Whitespace" means any Unicode space
             separator (e.g. U+00A0 NO-BREAK SPACE), not just the ASCII space.
 
-            The label is now read-only; use `Game.relabel_strategies` to change it.
+            The label is now read-only, and must be nonempty and unique among the player's
+            strategies; use `Game.relabel_strategies` to change it.
         """
         return self.strategy.deref().GetLabel().decode("utf-8")
-
-    @label.setter
-    def label(self, value: str) -> None:
-        self.strategy.deref().SetLabel(value.encode("utf-8"))
 
     @property
     def game(self) -> Game:

--- a/src/pygambit/strategy.pxi
+++ b/src/pygambit/strategy.pxi
@@ -52,17 +52,15 @@ class Strategy:
 
     @property
     def label(self) -> str:
-        """Get or set the text label associated with the strategy.
-
-        .. versionchanged:: 16.7.0
-            A strategy label must be nonempty and unique among the player's strategies;
-            an empty or duplicate label now raises ``ValueError``.
+        """The text label of the strategy.
 
         .. versionchanged:: 17.0.0
             A label may now be any well-formed UTF-8 text, not just ASCII; it must still
             contain no control characters, and must not begin/end with whitespace or have
             two consecutive whitespace characters.  "Whitespace" means any Unicode space
             separator (e.g. U+00A0 NO-BREAK SPACE), not just the ASCII space.
+
+            The label is now read-only; use `Game.relabel_strategies` to change it.
         """
         return self.strategy.deref().GetLabel().decode("utf-8")
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -56,6 +56,31 @@ def test_read_efg_repeated_infoset_duplicate_labels_consistent():
     assert [a.label for a in g.root.infoset.actions] == ["l_1", "l_2"]
 
 
+_NFG_PAYOFF_BODY = '\n{\n{ "" 1, 1 }\n{ "" 0, 0 }\n{ "" 0, 0 }\n{ "" 1, 1 }\n}\n1 2 3 4\n'
+
+
+def test_read_nfg_empty_strategy_labels_are_normalized():
+    g = _parse_nfg('NFG 1 R "t" { "A" "B" }\n\n{ { "" "" }\n{ "x" "y" }\n}\n""\n' +
+                   _NFG_PAYOFF_BODY)
+    assert [s.label for s in g.players["A"].strategies] == ["_1", "_2"]
+
+
+def test_read_nfg_duplicate_strategy_labels_are_normalized():
+    g = _parse_nfg('NFG 1 R "t" { "A" "B" }\n\n{ { "l" "l" }\n{ "x" "y" }\n}\n""\n' +
+                   _NFG_PAYOFF_BODY)
+    assert [s.label for s in g.players["A"].strategies] == ["l_1", "l_2"]
+
+
+def test_read_nfg_strategy_labels_swap_default_numbering():
+    """A player's strategy labels as parsed are the reverse of "1", "2", the default
+    numeric labels table construction assigns first; relabelling one at a time would
+    collide on the intermediate state, the hazard RelabelStrategies exists to avoid.
+    """
+    g = _parse_nfg('NFG 1 R "t" { "A" "B" }\n\n{ { "2" "1" }\n{ "x" "y" }\n}\n""\n' +
+                   _NFG_PAYOFF_BODY)
+    assert [s.label for s in g.players["A"].strategies] == ["2", "1"]
+
+
 def test_string_empty():
     with pytest.raises(ValueError) as excinfo:
         _parse_efg("")

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -105,8 +105,8 @@ def test_game_get_outcome_by_index():
 def test_game_get_outcome_by_label():
     game = gbt.Game.new_table([2, 2])
     pl1, pl2 = game.players
-    next(iter(pl1.strategies)).label = "defect"
-    next(iter(pl2.strategies)).label = "cooperate"
+    game.relabel_strategies(pl1, {next(iter(pl1.strategies)).label: "defect"})
+    game.relabel_strategies(pl2, {next(iter(pl2.strategies)).label: "cooperate"})
     assert game["defect", "cooperate"] == next(iter(game.outcomes))
 
 
@@ -137,8 +137,8 @@ def test_game_get_outcome_index_out_of_range():
 def test_game_get_outcome_unmatched_label():
     game = gbt.Game.new_table([2, 2])
     pl1, pl2 = game.players
-    next(iter(pl1.strategies)).label = "defect"
-    next(iter(pl2.strategies)).label = "cooperate"
+    game.relabel_strategies(pl1, {next(iter(pl1.strategies)).label: "defect"})
+    game.relabel_strategies(pl2, {next(iter(pl2.strategies)).label: "cooperate"})
     with pytest.raises(IndexError):
         _ = game["defect", "defect"]
 

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -238,7 +238,7 @@ def test_extensive_game_delete_strategy():
 def test_player_strategy_by_label():
     game = gbt.Game.new_table([2, 2])
     pl1 = next(iter(game.players))
-    next(iter(pl1.strategies)).label = "Cooperate"
+    game.relabel_strategies(pl1, {next(iter(pl1.strategies)).label: "Cooperate"})
     assert pl1.strategies["Cooperate"].label == "Cooperate"
 
 
@@ -264,9 +264,10 @@ def test_add_strategy_requires_label():
 
 def test_strategy_label_empty_raises_valueerror():
     game = gbt.Game.new_table([2, 2])
-    strategy = next(iter(next(iter(game.players)).strategies))
+    pl1 = next(iter(game.players))
+    strategy = next(iter(pl1.strategies))
     with pytest.raises(ValueError):
-        strategy.label = ""
+        game.relabel_strategies(pl1, {strategy.label: ""})
 
 
 def test_strategy_label_duplicate_within_player_raises_valueerror():
@@ -274,7 +275,7 @@ def test_strategy_label_duplicate_within_player_raises_valueerror():
     pl1 = next(iter(game.players))
     s1, s2 = pl1.strategies
     with pytest.raises(ValueError):
-        s2.label = s1.label
+        game.relabel_strategies(pl1, {s2.label: s1.label})
 
 
 def test_player_strategy_bad_label():

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -128,6 +128,7 @@ def test_strategic_game_add_player():
     new_player = game.add_player("Player 3")
     assert len(game.players) == 3
     assert len(new_player.strategies) == 1
+    assert next(iter(new_player.strategies)).label == "1"
 
 
 def test_extensive_game_add_player():

--- a/tests/test_strategic.py
+++ b/tests/test_strategic.py
@@ -67,3 +67,61 @@ def test_game_get_min_payoff():
 def test_game_get_max_payoff():
     game = games.read_from_file("mixed_strategy.nfg")
     assert game.max_payoff == 3
+
+
+def test_relabel_strategies_swap():
+    """Swap is well-defined; strategies keep their positions."""
+    game = gbt.Game.new_table([2, 2])
+    player, _ = game.players
+    a, b = (strategy.label for strategy in player.strategies)
+    game.relabel_strategies(player, {a: b, b: a})
+    assert [strategy.label for strategy in player.strategies] == [b, a]
+
+
+def test_relabel_strategies_duplicate_raises_valueerror():
+    """A replacement colliding with an untouched strategy, and two replacements
+    colliding with each other, are both rejected; checking each against the
+    untouched strategies alone would let the second through."""
+    game = gbt.Game.new_table([2, 2])
+    player, _ = game.players
+    a, b = (strategy.label for strategy in player.strategies)
+    with pytest.raises(ValueError):
+        game.relabel_strategies(player, {a: b})
+    with pytest.raises(ValueError):
+        game.relabel_strategies(player, {a: "X", b: "X"})
+
+
+@pytest.mark.parametrize("bad", ["", " x"])
+def test_relabel_strategies_bad_label_raises_and_leaves_game_unchanged(bad: str):
+    """The whole mapping is validated before any label is written."""
+    game = gbt.Game.new_table([2, 2])
+    player, _ = game.players
+    a, b = (strategy.label for strategy in player.strategies)
+    with pytest.raises(ValueError):
+        game.relabel_strategies(player, {a: "X", b: bad})
+    assert [strategy.label for strategy in player.strategies] == [a, b]
+
+
+def test_relabel_strategies_unknown_label_strictness():
+    game = gbt.Game.new_table([2, 2])
+    player, _ = game.players
+    a = next(iter(player.strategies)).label
+    with pytest.raises(KeyError):
+        game.relabel_strategies(player, {"no-such-strategy": "X"})
+    game.relabel_strategies(player, {"no-such-strategy": "X", a: "Y"}, strict=False)
+    assert next(iter(player.strategies)).label == "Y"
+
+
+def test_relabel_strategies_scope_is_the_player():
+    """Strategy labels are unique within a player, not within the game."""
+    game = gbt.Game.new_table([2, 2])
+    one, two = game.players
+    game.relabel_strategies(one, {next(iter(one.strategies)).label: "X"})
+    game.relabel_strategies(two, {next(iter(two.strategies)).label: "X"})
+    assert [next(iter(p.strategies)).label for p in game.players] == ["X", "X"]
+
+
+def test_relabel_strategies_tree_game_raises():
+    game = games.read_from_file("stripped_down_poker.efg")
+    with pytest.raises(gbt.UndefinedOperationError):
+        game.relabel_strategies(game.players["Alice"], {"11": "XY"})


### PR DESCRIPTION
### Description of the changes in this PR

Adds `Game.relabel_strategies(player, labels, strict=True)`, which reassigns the labels of a player's strategies 
in a normal form game (not defined for extensive form games).  
`labels` maps current labels to their replacements, and the reassignment is simultaneous, so labels can be 
swapped directly.  Strategies are not reordered: each relabelled strategy keeps its position.  
With `strict=False`, keys matching no current strategy are ignored, as in `relabel_actions`.

The operation is scoped to a player, mirroring `relabel_actions`' scoping to an information set: 
actions are strategies in the agent form of a game.  

Assigning to `Strategy.label` is removed (cf. removed `Action.label`).
