### PR TITLE
Catalog: 6x6 game with 75 eq -- small payoffs versios

### DIFF
--- a/build_support/catalog/catalog.am
+++ b/build_support/catalog/catalog.am
@@ -30,6 +30,7 @@ CATALOG_FILES = \
 	catalog/conf/itcs/jakobsen2016/fig1c.efg \
 	catalog/conf/itcs/jakobsen2016/fig3.efg \
 	catalog/journals/dcg/vonstengel1999/6x6_game_with_75_eq.nfg \
+	catalog/journals/dcg/vonstengel1999/6x6_game_with_75_eq_small_payoffs.nfg \
 	catalog/journals/geb/bagwell1995.efg \
 	catalog/journals/geb/gilboa1997/fig1.efg \
 	catalog/journals/geb/gilboa1997/fig2.efg \

--- a/catalog/journals/dcg/vonstengel1999/6x6_game_with_75_eq_small_payoffs.nfg
+++ b/catalog/journals/dcg/vonstengel1999/6x6_game_with_75_eq_small_payoffs.nfg
@@ -1,0 +1,49 @@
+NFG 1 R "von Stengel's 6x6 bimatrix game with 75 equilibria (small payoffs)" { "1" "2" }
+
+{ { "1" "2" "3" "4" "5" "6" }
+{ "1" "2" "3" "4" "5" "6" }
+}
+"Taken from :cite:p:`SvS06`, this version has much smaller payoffs than the original version from
+:cite:p:`vS97` and referenced in :cite:p:`vS99`, which is also in this folder of the catalog.
+It is a 6x6 bimatrix game with 75 equilibria,
+which is more than the previously conjectured bound of :math:`2^6 - 1 = 63`."
+
+{
+{ "" -81, 72 }
+{ "" -180, -180 }
+{ "" 20, 297 }
+{ "" -30, -333 }
+{ "" 270, 270 }
+{ "" 90, -153 }
+{ "" 36, 36 }
+{ "" 72, -81 }
+{ "" -3, 126 }
+{ "" 17, -126 }
+{ "" -153, 90 }
+{ "" -36, -36 }
+{ "" -126, 17 }
+{ "" -333, -30 }
+{ "" 42, 42 }
+{ "" -33, -33 }
+{ "" 297, 20 }
+{ "" 126, -3 }
+{ "" 126, -3 }
+{ "" 297, 20 }
+{ "" -33, -33 }
+{ "" 42, 42 }
+{ "" -333, -30 }
+{ "" -126, 17 }
+{ "" -36, -36 }
+{ "" -153, 90 }
+{ "" 17, -126 }
+{ "" -3, 126 }
+{ "" 72, -81 }
+{ "" 36, 36 }
+{ "" 90, -153 }
+{ "" 270, 270 }
+{ "" -30, -333 }
+{ "" 20, 297 }
+{ "" -180, -180 }
+{ "" -81, 72 }
+}
+1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -443,3 +443,14 @@
   note        = {Technical Report 264, Departement Informatik},
   category  = {articles_equilibria}
 }
+
+@article{SvS06,
+  author = {Rahul Savani and Bernhard von Stengel},
+  title = {Hard-to-Solve Bimatrix Games},
+  journal = {Econometrica},
+  volume = {74},
+  number = {2},
+  pages = {397--429},
+  year  = {2006},
+  category  = {articles_equilibria}
+}

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -110,7 +110,7 @@
 }
 
 @article{Nau2004,
-  author    = {Nau, Robert and Gomez Canovas, Sabrina and Hansen, Pierre},
+  author    = {Nau, R.  and Gomez Canovas, S. and Hansen, P.},
   title     = {On the geometry of {N}ash equilibria and correlated equilibria},
   journal   = {International Journal of Game Theory},
   volume    = {32},
@@ -383,7 +383,7 @@
 }
 
 @book{Wat13,
-  author    = {Watson, Joel},
+  author    = {Watson, J.},
   title     = {Strategy: An Introduction to Game Theory},
   edition   = {3rd},
   publisher = {W. W. Norton \& Company},
@@ -418,7 +418,7 @@
 
 @book{ShoLeyB08,
   title={Multiagent systems: Algorithmic, game-theoretic, and logical foundations},
-  author={Shoham, Yoav and Leyton-Brown, Kevin},
+  author={Shoham, Y. and Leyton-Brown, K.},
   year={2008},
   publisher={Cambridge University Press},
   category  = {textbooks}
@@ -426,7 +426,7 @@
 
 @article{vS99,
   title        = {New Maximal Numbers of Equilibria in Bimatrix Games},
-  author       = {Bernhard von Stengel},
+  author       = {von Stengel, B.},
   journal      = {Discrete Comput. Geom.},
   volume       = {21},
   number       = {4},
@@ -436,7 +436,7 @@
 }
 
 @techreport{vS97,
-  author      = {Bernhard von Stengel},
+  author      = {von Stengel, B.},
   title       = {New lower bounds for the number of equilibria in bimatrix games},
   institution = {ETH Z\"urich},
   year        = {1997},
@@ -445,7 +445,7 @@
 }
 
 @article{SvS06,
-  author = {Rahul Savani and Bernhard von Stengel},
+  author = {Savani, R. and von Stengel, B.},
   title = {Hard-to-Solve Bimatrix Games},
   journal = {Econometrica},
   volume = {74},


### PR DESCRIPTION
Adds to the catalog a version of von Stengel's 6x6 game with 75 equilibria which uses much smaller payoffs that the original version (which is already in the catalog)
