### PR TITLE
Rationalise file and header organisation in preparation for potential C++ library

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ recursive-include src/games *.cc *.h *.imp
 recursive-include src/solvers *.cc *.h *.imp
 recursive-include catalog *
 include src/gambit.h
+include src/games.h
+include src/solvers.h
 include src/pygambit/*.pxd
 include src/pygambit/*.pyx
 include src/pygambit/*.pxi

--- a/Makefile.am
+++ b/Makefile.am
@@ -203,7 +203,6 @@ EXTRA_DIST = \
 	contrib/games/winkels.nfg \
 	contrib/games/yamamoto.nfg \
 	contrib/games/zero.nfg \
-	src/README.rst \
 	$(CATALOG_FILES)
 
 core_SOURCES = \
@@ -224,23 +223,8 @@ core_SOURCES = \
 	src/core/function.cc \
 	src/core/function.h
 
-agg_SOURCES = \
-	src/games/gameagg.cc \
-	src/games/gameagg.h \
-	src/games/gamebagg.cc \
-	src/games/gamebagg.h \
-	src/games/agg/gray.h \
-	src/games/agg/agg.cc \
-    src/games/agg/agg.h \
-	src/games/agg/bagg.cc \
-	src/games/agg/bagg.h \
-	src/games/agg/proj_func.h \
-	src/games/agg/trie_map.h \
-    src/games/agg/trie_map.imp \
-    src/games/agg/trie_map.cc
-
 game_SOURCES = \
-	src/gambit.h \
+	src/games.h \
 	src/games/ndarray.h \
 	src/games/number.h \
 	src/games/gameobject.h \
@@ -272,8 +256,19 @@ game_SOURCES = \
 	src/games/writer.h \
 	src/games/layout.cc \
     src/games/layout.h \
-	${agg_SOURCES} \
-	src/games/nash.h
+	src/games/gameagg.cc \
+	src/games/gameagg.h \
+	src/games/gamebagg.cc \
+	src/games/gamebagg.h \
+	src/games/agg/gray.h \
+	src/games/agg/agg.cc \
+    src/games/agg/agg.h \
+	src/games/agg/bagg.cc \
+	src/games/agg/bagg.h \
+	src/games/agg/proj_func.h \
+	src/games/agg/trie_map.h \
+    src/games/agg/trie_map.imp \
+    src/games/agg/trie_map.cc
 
 linalg_SOURCES = \
 	src/solvers/linalg/btableau.h \
@@ -311,6 +306,65 @@ gtracer_SOURCES = \
 	src/solvers/gtracer/gnm.cc \
 	src/solvers/gtracer/ipa.cc
 
+nashsupport_SOURCES = \
+	src/solvers/nashsupport/efgsupport.cc \
+	src/solvers/nashsupport/nfgsupport.cc \
+	src/solvers/nashsupport/nashsupport.h
+
+bimatrix_SOURCES = \
+	${linalg_SOURCES} \
+	src/solvers/lp/lp.cc \
+	src/solvers/lp/lp.h \
+	src/solvers/lcp/efglcp.cc \
+	src/solvers/lcp/nfglcp.cc \
+	src/solvers/lcp/lcp.h \
+	src/solvers/enummixed/clique.cc \
+	src/solvers/enummixed/clique.h \
+	src/solvers/enummixed/enummixed.cc \
+	src/solvers/enummixed/enummixed.h
+
+gtracerlib_SOURCES = \
+	${gtracer_SOURCES} \
+	src/solvers/gnm/gnm.cc \
+	src/solvers/gnm/gnm.h \
+	src/solvers/ipa/ipa.cc \
+	src/solvers/ipa/ipa.h
+
+liap_SOURCES = \
+	src/solvers/liap/efgliap.cc \
+	src/solvers/liap/nfgliap.cc \
+	src/solvers/liap/liap.h
+
+logit_SOURCES = \
+	src/solvers/logit/logbehav.h \
+	src/solvers/logit/logbehav.imp \
+	src/solvers/logit/path.cc \
+	src/solvers/logit/path.h \
+    src/solvers/logit/logit.h \
+	src/solvers/logit/efglogit.cc \
+	src/solvers/logit/nfglogit.cc
+
+simpdiv_SOURCES = \
+	src/solvers/simpdiv/simpdiv.cc \
+	src/solvers/simpdiv/simpdiv.h
+
+enumpoly_SOURCES = \
+	${nashsupport_SOURCES} \
+	src/solvers/enumpoly/indexproduct.h \
+	src/solvers/enumpoly/rectangle.h \
+	src/solvers/enumpoly/poly.cc \
+	src/solvers/enumpoly/poly.h \
+	src/solvers/enumpoly/polysystem.h \
+    src/solvers/enumpoly/polypartial.h \
+    src/solvers/enumpoly/polypartial.imp \
+	src/solvers/enumpoly/polysolver.cc \
+	src/solvers/enumpoly/polysolver.h \
+	src/solvers/enumpoly/efgpoly.cc \
+	src/solvers/enumpoly/nfgpoly.cc \
+	src/solvers/enumpoly/enumpoly.h
+
+noinst_HEADERS = src/gambit.h src/solvers.h src/solvers/nash.h
+
 if IS_WIN32
 AM_LDFLAGS = -static -static-libgcc -static-libstdc++
 endif
@@ -340,153 +394,82 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -DVERSION=\"$(GAMBIT_VERSION)\"
 
 AM_CXXFLAGS = ${LLVM_CXXFLAGS}
 
+## Convenience libraries
+##
+## Every command-line tool and the GUI link against these instead of each
+## recompiling the same core/games/solver sources from scratch.
+
+noinst_LIBRARIES = libcore.a libgames.a libbimatrix.a libgtracer.a \
+	libliap.a liblogit.a libsimpdiv.a libenumpoly.a
+
+libcore_a_SOURCES = ${core_SOURCES}
+libgames_a_SOURCES = ${game_SOURCES}
+libbimatrix_a_SOURCES = ${bimatrix_SOURCES}
+libgtracer_a_SOURCES = ${gtracerlib_SOURCES}
+libliap_a_SOURCES = ${liap_SOURCES}
+liblogit_a_SOURCES = ${logit_SOURCES}
+libsimpdiv_a_SOURCES = ${simpdiv_SOURCES}
+libenumpoly_a_SOURCES = ${enumpoly_SOURCES}
+
 ## Command-line tools
 
 gambit_convert_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
 	src/tools/convert/convert.cc
+gambit_convert_LDADD = libgames.a libcore.a
 
 gambit_enummixed_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${linalg_SOURCES} \
-	src/solvers/enummixed/clique.cc \
-	src/solvers/enummixed/clique.h \
-	src/solvers/enummixed/enummixed.cc \
-	src/solvers/enummixed/enummixed.h \
 	src/tools/util.h \
 	src/tools/enummixed/enummixed.cc
-
-gambit_nashsupport_SOURCES = \
-	src/solvers/nashsupport/efgsupport.cc \
-	src/solvers/nashsupport/nfgsupport.cc \
-	src/solvers/nashsupport/nashsupport.h
+gambit_enummixed_LDADD = libbimatrix.a libgames.a libcore.a
 
 gambit_enumpoly_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} ${gambit_nashsupport_SOURCES} \
-	src/solvers/enumpoly/indexproduct.h \
-	src/solvers/enumpoly/rectangle.h \
-	src/solvers/enumpoly/poly.cc \
-	src/solvers/enumpoly/poly.h \
-	src/solvers/enumpoly/polysystem.h \
-    src/solvers/enumpoly/polypartial.h \
-    src/solvers/enumpoly/polypartial.imp \
-	src/solvers/enumpoly/polysolver.cc \
-	src/solvers/enumpoly/polysolver.h \
-	src/solvers/enumpoly/efgpoly.cc \
-	src/solvers/enumpoly/nfgpoly.cc \
-	src/solvers/enumpoly/enumpoly.h \
 	src/tools/util.h \
 	src/tools/enumpoly/enumpoly.cc
+gambit_enumpoly_LDADD = libenumpoly.a libgames.a libcore.a
 
 gambit_enumpure_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
 	src/solvers/enumpure/enumpure.h \
 	src/tools/util.h \
 	src/tools/enumpure/enumpure.cc
+gambit_enumpure_LDADD = libgames.a libcore.a
 
 gambit_gnm_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${gtracer_SOURCES} \
-	src/solvers/gnm/gnm.cc \
-	src/solvers/gnm/gnm.h \
 	src/tools/gt/nfggt.cc \
 	src/tools/gt/nfggnm.cc
+gambit_gnm_LDADD = libgtracer.a libgames.a libcore.a
 
 gambit_ipa_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${gtracer_SOURCES} \
-	src/solvers/ipa/ipa.cc \
-	src/solvers/ipa/ipa.h \
 	src/tools/gt/nfggt.cc \
 	src/tools/util.h \
 	src/tools/gt/nfgipa.cc
+gambit_ipa_LDADD = libgtracer.a libgames.a libcore.a
 
 gambit_lcp_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${linalg_SOURCES} \
-	src/solvers/lcp/efglcp.cc \
-	src/solvers/lcp/nfglcp.cc \
-	src/solvers/lcp/lcp.h \
 	src/tools/util.h \
 	src/tools/lcp/lcp.cc
+gambit_lcp_LDADD = libbimatrix.a libgames.a libcore.a
 
 gambit_liap_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	src/solvers/liap/efgliap.cc \
-	src/solvers/liap/nfgliap.cc \
-	src/solvers/liap/liap.h \
 	src/tools/util.h \
 	src/tools/liap/liap.cc
+gambit_liap_LDADD = libliap.a libgames.a libcore.a
 
 gambit_logit_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	src/solvers/logit/logbehav.h \
-	src/solvers/logit/logbehav.imp \
-	src/solvers/logit/path.cc \
-	src/solvers/logit/path.h \
-    src/solvers/logit/logit.h \
-	src/solvers/logit/efglogit.cc \
-	src/solvers/logit/nfglogit.cc \
 	src/tools/util.h \
 	src/tools/logit/logit.cc
+gambit_logit_LDADD = liblogit.a libgames.a libcore.a
 
 gambit_lp_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${linalg_SOURCES} \
-	src/solvers/lp/lp.cc \
-	src/solvers/lp/lp.h \
 	src/tools/util.h \
 	src/tools/lp/lp.cc
+gambit_lp_LDADD = libbimatrix.a libgames.a libcore.a
 
 gambit_simpdiv_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	src/solvers/simpdiv/simpdiv.cc \
-	src/solvers/simpdiv/simpdiv.h \
 	src/tools/util.h \
 	src/tools/simpdiv/nfgsimpdiv.cc
+gambit_simpdiv_LDADD = libsimpdiv.a libgames.a libcore.a
 
 gambit_SOURCES = \
-	${core_SOURCES} ${game_SOURCES} \
-	${linalg_SOURCES} \
-	src/solvers/enummixed/clique.cc \
-	src/solvers/enummixed/clique.h \
-	src/solvers/enummixed/enummixed.cc \
-	src/solvers/enummixed/enummixed.h \
-	src/solvers/lcp/lcp.h \
-	src/solvers/lcp/efglcp.cc \
-	src/solvers/lcp/nfglcp.cc \
-	src/solvers/lp/lp.h \
-	src/solvers/lp/lp.cc \
-	src/solvers/logit/logbehav.h \
-	src/solvers/logit/logbehav.imp \
-	src/solvers/logit/path.cc \
-	src/solvers/logit/path.h \
-	src/solvers/logit/logit.h \
-	src/solvers/logit/efglogit.cc \
-	src/solvers/logit/nfglogit.cc \
-	${gambit_nashsupport_SOURCES} \
-	src/solvers/enumpoly/indexproduct.h \
-	src/solvers/enumpoly/rectangle.h \
-	src/solvers/enumpoly/poly.cc \
-	src/solvers/enumpoly/poly.h \
-	src/solvers/enumpoly/polysystem.h \
-	src/solvers/enumpoly/polypartial.h \
-	src/solvers/enumpoly/polypartial.imp \
-	src/solvers/enumpoly/polysolver.cc \
-	src/solvers/enumpoly/polysolver.h \
-	src/solvers/enumpoly/efgpoly.cc \
-	src/solvers/enumpoly/nfgpoly.cc \
-	src/solvers/enumpoly/enumpoly.h \
-	src/solvers/simpdiv/simpdiv.cc \
-	src/solvers/simpdiv/simpdiv.h \
-	src/solvers/liap/liap.h \
-	src/solvers/liap/efgliap.cc \
-	src/solvers/liap/nfgliap.cc \
-	${gtracer_SOURCES} \
-	src/solvers/gnm/gnm.h \
-	src/solvers/gnm/gnm.cc \
-	src/solvers/ipa/ipa.h \
-	src/solvers/ipa/ipa.cc \
 	src/gui/analysis.cc \
 	src/gui/analysis.h \
 	src/gui/app.cc \
@@ -556,12 +539,14 @@ gambit_SOURCES = \
 gambit_CXXFLAGS = $(AM_CXXFLAGS) $(WX_CXXFLAGS)
 gambit_CPPFLAGS = $(AM_CPPFLAGS) $(WX_CXXFLAGS)
 
-if IS_WIN32
-gambit_LDADD = $(RC_OBJECT_PATH) $(WX_LIBS_STATIC) -ldeflate -lzstd -llerc -lWebP
-else
-gambit_LDADD = $(RC_OBJECT_PATH) $(WX_LIBS)
-endif
+gambit_LDADD_LIBS = libbimatrix.a libliap.a liblogit.a libgtracer.a \
+	libsimpdiv.a libenumpoly.a libgames.a libcore.a
 
+if IS_WIN32
+gambit_LDADD = $(RC_OBJECT_PATH) $(gambit_LDADD_LIBS) $(WX_LIBS_STATIC) -ldeflate -lzstd -llerc -lWebP
+else
+gambit_LDADD = $(RC_OBJECT_PATH) $(gambit_LDADD_LIBS) $(WX_LIBS)
+endif
 
 osx-bundle:
 	make all

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,7 @@ choke me
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
+AC_PROG_RANLIB
 dnl LT_INIT
 AM_PROG_CC_C_O
 MINGW_AC_WIN32_NATIVE_HOST

--- a/doc/developer.overview.rst
+++ b/doc/developer.overview.rst
@@ -41,3 +41,29 @@ This hybrid architecture aims to maintain some flexibility for future developmen
 2.  Likewise, the graphical interface layer is kept cleanly separate from the core.
     Graphical-based interfaces (different libraries, languages,
     browser-based interfaces) can be developed without touching the core code.
+
+Header organization
+--------------------
+
+Each of the three core directories is exposed through a top-level umbrella header:
+
+* ``src/games.h`` covers game representation, equilibrium profile types, and file I/O
+  (that is, all of ``src/core`` and ``src/games``).
+* ``src/solvers.h`` includes ``games.h`` plus the single public header for every solver
+  algorithm (for example ``src/solvers/lcp/lcp.h``).
+* ``src/gambit.h`` is the "everything" umbrella: ``games.h`` followed by ``solvers.h``.
+
+Solver headers depend on the representation types, never the reverse, so
+``solvers.h`` sits above ``games.h`` rather than being folded into it.
+
+Within ``src/core``, ``src/games``, and ``src/solvers``, every header should be
+self-contained: it should ``#include`` whatever it directly uses, rather than relying
+on some other header -- in particular, one of the umbrella headers -- having already
+brought a dependency into scope by the time it is reached. A header that implements
+algorithm internals (for example the linear algebra in ``src/solvers/linalg`` or the
+polynomial-system machinery in ``src/solvers/enumpoly``) should depend only on
+``src/core``, not on the game representation, unless it genuinely needs it.
+
+This discipline will allow ``src/core``, ``src/games``, and ``src/solvers``
+to be built and installed as a standalone C++ library, should we decide to offer
+that in future.

--- a/src/README.rst
+++ b/src/README.rst
@@ -1,6 +1,0 @@
-Gambit is a package for representing, manuipulating, and analysing
-finite noncooperative games in extensive and normal form.
-
-See the project homepage at www.gambit-project.org for more information.
-
-Documentation of Gambit is hosted at https://gambitproject.readthedocs.io.

--- a/src/core/rational.h
+++ b/src/core/rational.h
@@ -30,6 +30,9 @@ Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include <cmath>
 #include <compare>
+#include <string>
+
+#include "util.h"
 
 #include "integer.h"
 

--- a/src/games.h
+++ b/src/games.h
@@ -2,8 +2,8 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/gambit.h
-// Top-level include file for all of Gambit
+// FILE: src/games.h
+// Top-level include file for Gambit's game representation
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,10 +20,22 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_H
-#define GAMBIT_H
+#ifndef GAMBIT_GAMES_H
+#define GAMBIT_GAMES_H
 
-#include "games.h"
-#include "solvers.h"
+#include "core/core.h"
 
-#endif // GAMBIT_H
+#include "games/game.h"
+#include "games/writer.h"
+
+#include "games/behavspt.h"
+#include "games/behavmixed.h"
+#include "games/behavpure.h"
+#include "games/seqpure.h"
+#include "games/seqmixed.h"
+
+#include "games/stratspt.h"
+#include "games/stratpure.h"
+#include "games/stratmixed.h"
+
+#endif // GAMBIT_GAMES_H

--- a/src/games/agg/agg.cc
+++ b/src/games/agg/agg.cc
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/agg.cc
+// FILE: src/games/agg/agg.cc
 // Implementation of Action Graph Game representation
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/games/agg/agg.h
+++ b/src/games/agg/agg.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/agg.h
+// FILE: src/games/agg/agg.h
 // Interface of Action Graph Game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_AGG_AGG_H
-#define GAMBIT_AGG_AGG_H
+#ifndef GAMBIT_GAMES_AGG_AGG_H
+#define GAMBIT_GAMES_AGG_AGG_H
 
 #include <iostream>
 #include <map>
@@ -381,4 +381,4 @@ private:
 
 } // namespace Gambit::agg
 
-#endif // GAMBIT_AGG_AGG_H
+#endif // GAMBIT_GAMES_AGG_AGG_H

--- a/src/games/agg/bagg.h
+++ b/src/games/agg/bagg.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/bagg.h
+// FILE: src/games/agg/bagg.h
 // Interface of Bayesian Action Graph Game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_AGG_BAGG_H
-#define GAMBIT_AGG_BAGG_H
+#ifndef GAMBIT_GAMES_AGG_BAGG_H
+#define GAMBIT_GAMES_AGG_BAGG_H
 
 #include <iostream>
 #include "agg.h"
@@ -131,4 +131,4 @@ std::ostream &operator<<(std::ostream &s, const BAGG &g);
 
 } // end namespace Gambit
 
-#endif // GAMBIT_AGG_BAGG_H
+#endif // GAMBIT_GAMES_AGG_BAGG_H

--- a/src/games/agg/gray.h
+++ b/src/games/agg/gray.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/GrayComposition.h
+// FILE: src/games/agg/gray.h
 // Interface file for GrayComposition
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_AGG_GRAY_H
-#define GAMBIT_AGG_GRAY_H
+#ifndef GAMBIT_GAMES_AGG_GRAY_H
+#define GAMBIT_GAMES_AGG_GRAY_H
 
 #include <vector>
 
@@ -112,4 +112,4 @@ private:
 
 } // end namespace Gambit::agg
 
-#endif // GAMBIT_AGG_GRAY_H
+#endif // GAMBIT_GAMES_AGG_GRAY_H

--- a/src/games/agg/proj_func.h
+++ b/src/games/agg/proj_func.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/proj_func.h
+// FILE: src/games/agg/proj_func.h
 // Pre-defined functions for contribution-independent function nodes
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_AGG_PROJFUNC_H
-#define GAMBIT_AGG_PROJFUNC_H
+#ifndef GAMBIT_GAMES_AGG_PROJ_FUNC_H
+#define GAMBIT_GAMES_AGG_PROJ_FUNC_H
 
 #include <iostream>
 #include <iterator>
@@ -295,4 +295,4 @@ inline projtype make_proj_func(TypeEnum type, std::istream &in, int S, int P)
 
 } // end namespace Gambit::agg
 
-#endif // GAMBIT_AGG_PROJFUNC_H
+#endif // GAMBIT_GAMES_AGG_PROJ_FUNC_H

--- a/src/games/agg/trie_map.cc
+++ b/src/games/agg/trie_map.cc
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/trie_map.cc
+// FILE: src/games/agg/trie_map.cc
 // Trie with STL-like interfaces
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/games/agg/trie_map.h
+++ b/src/games/agg/trie_map.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/trie_map.h
+// FILE: src/games/agg/trie_map.h
 // Trie with STL-like interfaces
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_AGG_TRIEMAP_H
-#define GAMBIT_AGG_TRIEMAP_H
+#ifndef GAMBIT_GAMES_AGG_TRIE_MAP_H
+#define GAMBIT_GAMES_AGG_TRIE_MAP_H
 
 // Mapping from vector of ints to type V.
 // WARNING: traversal using the iterators is in the reverse order of insertion.
@@ -277,4 +277,4 @@ template <class V> std::ostream &operator<<(std::ostream &s, const trie_map<V> &
 
 } // end namespace Gambit::agg
 
-#endif // GAMBIT_AGG_TRIEMAP_H
+#endif // GAMBIT_GAMES_AGG_TRIE_MAP_H

--- a/src/games/agg/trie_map.imp
+++ b/src/games/agg/trie_map.imp
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: src/libagg/trie_map.imp
+// FILE: src/games/agg/trie_map.imp
 // Trie with STL-like interfaces
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/games/behavmixed.cc
+++ b/src/games/behavmixed.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/behav.cc
+// FILE: src/games/behavmixed.cc
 // Instantiation of behavior profile classes.
 //
 // This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <numeric>
 
-#include "gambit.h"
+#include "games.h"
 #include "behavmixed.h"
 
 namespace Gambit {

--- a/src/games/behavmixed.h
+++ b/src/games/behavmixed.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/behav.h
+// FILE: src/games/behavmixed.h
 // Behavior strategy profile classes
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,13 +20,14 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_BEHAV_H
-#define LIBGAMBIT_BEHAV_H
+#ifndef GAMBIT_GAMES_BEHAVMIXED_H
+#define GAMBIT_GAMES_BEHAVMIXED_H
 
 #include <random>
 #include <vector>
 
 #include "game.h"
+#include "behavspt.h"
 #include "seqmixed.h"
 
 namespace Gambit {
@@ -408,4 +409,4 @@ NewRandomBehaviorProfiles(const Game &p_game, int count, int denom)
 
 } // end namespace Gambit
 
-#endif // LIBGAMBIT_BEHAV_H
+#endif // GAMBIT_GAMES_BEHAVMIXED_H

--- a/src/games/behavpure.cc
+++ b/src/games/behavpure.cc
@@ -22,7 +22,7 @@
 
 #include <ranges>
 
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit {
 

--- a/src/games/behavspt.cc
+++ b/src/games/behavspt.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/behavspt.cc
+// FILE: src/games/behavspt.cc
 // Implementation of supports for extensive forms
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit {
 

--- a/src/games/behavspt.h
+++ b/src/games/behavspt.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/behavspt.h
+// FILE: src/games/behavspt.h
 // Interface to supports for extensive forms
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_BEHAVSPT_H
-#define LIBGAMBIT_BEHAVSPT_H
+#ifndef GAMBIT_GAMES_BEHAVSPT_H
+#define GAMBIT_GAMES_BEHAVSPT_H
 
 #include <list>
 #include <map>
@@ -218,4 +218,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // LIBGAMBIT_BEHAVSPT_H
+#endif // GAMBIT_GAMES_BEHAVSPT_H

--- a/src/games/file.cc
+++ b/src/games/file.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/file.cc
+// FILE: src/games/file.cc
 // Parser for reading game savefiles
 //
 // This program is free software; you can redistribute it and/or modify
@@ -27,7 +27,7 @@
 #include <set>
 #include <algorithm>
 
-#include "gambit.h"
+#include "games.h"
 #include "gameagg.h"
 
 namespace {

--- a/src/games/game.cc
+++ b/src/games/game.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/game.cc
+// FILE: src/games/game.cc
 // Implementation of extensive form game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -24,7 +24,7 @@
 #include <numeric>
 #include <random>
 
-#include "gambit.h"
+#include "games.h"
 #include "writer.h"
 
 // The references to the tree representations violate the logic

--- a/src/games/game.h
+++ b/src/games/game.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/game.h
+// FILE: src/games/game.h
 // Declaration of base class for representing games
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_GAME_H
-#define LIBGAMBIT_GAME_H
+#ifndef GAMBIT_GAMES_GAME_H
+#define GAMBIT_GAMES_GAME_H
 
 #include <algorithm>
 #include <compare>
@@ -33,6 +33,7 @@
 #include <set>
 #include <stack>
 
+#include "core/array.h"
 #include "number.h"
 #include "gameobject.h"
 
@@ -1774,4 +1775,4 @@ std::list<Rational> UniformOnSimplex(int p_denom, size_t p_dim, Generator &gener
 
 } // namespace Gambit
 
-#endif // LIBGAMBIT_GAME_H
+#endif // GAMBIT_GAMES_GAME_H

--- a/src/games/gameagg.cc
+++ b/src/games/gameagg.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gameagg.cc
+// FILE: src/games/gameagg.cc
 // Implementation of action-graph game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <iostream>
 
-#include "gambit.h"
+#include "games.h"
 #include "gameagg.h"
 
 namespace Gambit {

--- a/src/games/gameagg.h
+++ b/src/games/gameagg.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gameagg.h
+// FILE: src/games/gameagg.h
 // Declaration of GameAGGRep, the action-graph game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,9 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMEAGG_H
-#define GAMEAGG_H
+#ifndef GAMBIT_GAMES_GAMEAGG_H
+#define GAMBIT_GAMES_GAMEAGG_H
 
+#include "games/game.h"
 #include "games/agg/agg.h"
 
 namespace Gambit {
@@ -109,4 +110,4 @@ public:
 
 } // namespace Gambit
 
-#endif // GAMEAGG_H
+#endif // GAMBIT_GAMES_GAMEAGG_H

--- a/src/games/gamebagg.cc
+++ b/src/games/gamebagg.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gamebagg.cc
+// FILE: src/games/gamebagg.cc
 // Implementation of Bayesian action-graph game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <iostream>
 
-#include "gambit.h"
+#include "games.h"
 #include "gamebagg.h"
 
 namespace Gambit {

--- a/src/games/gamebagg.h
+++ b/src/games/gamebagg.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gameagg.h
+// FILE: src/games/gamebagg.h
 // Declaration of the Bayesian action-graph game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,9 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMEBAGG_H
-#define GAMEBAGG_H
+#ifndef GAMBIT_GAMES_GAMEBAGG_H
+#define GAMBIT_GAMES_GAMEBAGG_H
 
+#include "games/game.h"
 #include "games/agg/bagg.h"
 
 namespace Gambit {
@@ -116,4 +117,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // GAMEBAGG_H
+#endif // GAMBIT_GAMES_GAMEBAGG_H

--- a/src/games/gameexpl.cc
+++ b/src/games/gameexpl.cc
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <numeric>
 
-#include "gambit.h"
+#include "games.h"
 #include "gameexpl.h"
 
 namespace Gambit {

--- a/src/games/gameexpl.h
+++ b/src/games/gameexpl.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gameexpl.h
+// FILE: src/games/gameexpl.h
 // Declaration of base class for explicit game representations
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMEEXPL_H
-#define GAMEEXPL_H
+#ifndef GAMBIT_GAMES_GAMEEXPL_H
+#define GAMBIT_GAMES_GAMEEXPL_H
 
 #include "game.h"
 
@@ -52,4 +52,4 @@ public:
 
 } // namespace Gambit
 
-#endif // GAMEEXPL_H
+#endif // GAMBIT_GAMES_GAMEEXPL_H

--- a/src/games/gameobject.h
+++ b/src/games/gameobject.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/game.h
+// FILE: src/games/gameobject.h
 // Declaration of base class for representing games
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/games/gametable.cc
+++ b/src/games/gametable.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gametable.cc
+// FILE: src/games/gametable.cc
 // Implementation of strategic game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <iostream>
 
-#include "gambit.h"
+#include "games.h"
 #include "gametable.h"
 #include "writer.h"
 

--- a/src/games/gametable.h
+++ b/src/games/gametable.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gametable.h
+// FILE: src/games/gametable.h
 // Declaration of strategic game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMETABLE_H
-#define GAMETABLE_H
+#ifndef GAMBIT_GAMES_GAMETABLE_H
+#define GAMBIT_GAMES_GAMETABLE_H
 
 #include "gameexpl.h"
 
@@ -119,4 +119,4 @@ public:
 
 } // namespace Gambit
 
-#endif // GAMETABLE_H
+#endif // GAMBIT_GAMES_GAMETABLE_H

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gametree.cc
+// FILE: src/games/gametree.cc
 // Implementation of extensive game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -31,7 +31,7 @@
 #include <unordered_set>
 #include <variant>
 
-#include "gambit.h"
+#include "games.h"
 #include "gametree.h"
 #include "writer.h"
 

--- a/src/games/gametree.h
+++ b/src/games/gametree.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/gametree.h
+// FILE: src/games/gametree.h
 // Declaration of extensive game representation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMETREE_H
-#define GAMETREE_H
+#ifndef GAMBIT_GAMES_GAMETREE_H
+#define GAMBIT_GAMES_GAMETREE_H
 
 #include "core/lazy.h"
 #include "gameexpl.h"
@@ -240,4 +240,4 @@ private:
 
 } // namespace Gambit
 
-#endif // GAMETREE_H
+#endif // GAMBIT_GAMES_GAMETREE_H

--- a/src/games/layout.cc
+++ b/src/games/layout.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/gui/efglayout.cc
+// FILE: src/games/layout.cc
 // Implementation of tree layout representation
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/games/layout.h
+++ b/src/games/layout.h
@@ -20,12 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GAMES_TREELAYOUT_H
-#define GAMBIT_GAMES_TREELAYOUT_H
+#ifndef GAMBIT_GAMES_LAYOUT_H
+#define GAMBIT_GAMES_LAYOUT_H
 
 #include <map>
 
-#include "gambit.h"
 #include "game.h"
 
 namespace Gambit {
@@ -73,4 +72,4 @@ public:
 
 } // namespace Gambit
 
-#endif // GAMBIT_GAMES_TREELAYOUT_H
+#endif // GAMBIT_GAMES_LAYOUT_H

--- a/src/games/ndarray.h
+++ b/src/games/ndarray.h
@@ -25,7 +25,7 @@
 
 #include <numeric>
 
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit {
 

--- a/src/games/number.h
+++ b/src/games/number.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/number.h
+// FILE: src/games/number.h
 // A simple class for storing numerical data in a game
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_NUMBER_H
-#define LIBGAMBIT_NUMBER_H
+#ifndef GAMBIT_GAMES_NUMBER_H
+#define GAMBIT_GAMES_NUMBER_H
 
 #include <string>
 #include <ostream>
@@ -95,4 +95,4 @@ public:
 
 } // namespace Gambit
 
-#endif // LIBGAMBIT_NUMBER_H
+#endif // GAMBIT_GAMES_NUMBER_H

--- a/src/games/seqpure.cc
+++ b/src/games/seqpure.cc
@@ -22,7 +22,7 @@
 
 #include <stack>
 
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit {
 

--- a/src/games/stratmixed.h
+++ b/src/games/stratmixed.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/mixed.h
+// FILE: src/games/stratmixed.h
 // Declaration of mixed strategy profile classes
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,13 +20,16 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_MIXED_H
-#define LIBGAMBIT_MIXED_H
+#ifndef GAMBIT_GAMES_STRATMIXED_H
+#define GAMBIT_GAMES_STRATMIXED_H
 
 #include <random>
 #include <vector>
 
 #include "core/vector.h"
+#include "core/segment.h"
+#include "games/game.h"
+#include "games/stratspt.h"
 #include "games/gamebagg.h"
 
 namespace Gambit {
@@ -450,4 +453,4 @@ NewRandomStrategyProfiles(const Game &p_game, int count, int denom)
 
 } // end namespace Gambit
 
-#endif // LIBGAMBIT_MIXED_H
+#endif // GAMBIT_GAMES_STRATMIXED_H

--- a/src/games/stratpure.h
+++ b/src/games/stratpure.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "game.h"
+#include "stratspt.h"
 
 namespace Gambit {
 

--- a/src/games/stratspt.cc
+++ b/src/games/stratspt.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/stratspt.cc
+// FILE: src/games/stratspt.cc
 // Implementation of strategy classes for normal forms
 //
 // This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <numeric>
 
-#include "gambit.h"
+#include "games.h"
 #include "gametable.h"
 
 namespace Gambit {

--- a/src/games/stratspt.h
+++ b/src/games/stratspt.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/stratspt.h
+// FILE: src/games/stratspt.h
 // Interface to strategy classes for normal forms
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_STRATSPT_H
-#define LIBGAMBIT_STRATSPT_H
+#ifndef GAMBIT_GAMES_STRATSPT_H
+#define GAMBIT_GAMES_STRATSPT_H
 
-#include "gambit.h"
+#include <map>
+
+#include "game.h"
 
 namespace Gambit {
 
@@ -172,4 +174,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // LIBGAMBIT_STRATSPT_H
+#endif // GAMBIT_GAMES_STRATSPT_H

--- a/src/games/writer.cc
+++ b/src/games/writer.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/writer.h
+// FILE: src/games/writer.cc
 // Classes for writing out games to various formats
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit {
 

--- a/src/games/writer.h
+++ b/src/games/writer.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/writer.h
+// FILE: src/games/writer.h
 // Classes for writing out games to various formats
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_WRITER_H
-#define LIBGAMBIT_WRITER_H
+#ifndef GAMBIT_GAMES_WRITER_H
+#define GAMBIT_GAMES_WRITER_H
 
 #include <string>
 
@@ -92,4 +92,4 @@ std::string WriteLaTeXFile(const Game &p_game, const GamePlayer &p_rowPlayer,
 
 } // end namespace Gambit
 
-#endif // LIBGAMBIT_WRITER_H
+#endif // GAMBIT_GAMES_WRITER_H

--- a/src/gui/analysis.cc
+++ b/src/gui/analysis.cc
@@ -25,7 +25,7 @@
 #include <wx/wx.h>
 #endif // WX_PRECOMP
 #include <wx/tokenzr.h>
-#include "gambit.h"
+#include "games.h"
 #include "games/workspace.h"
 
 #include "analysis.h"

--- a/src/gui/app.cc
+++ b/src/gui/app.cc
@@ -30,7 +30,7 @@
 #include <wx/display.h>
 #include <wx/image.h>
 
-#include "gambit.h"
+#include "games.h"
 
 #include "app.h"
 #include "gameframe.h"

--- a/src/gui/dlabout.cc
+++ b/src/gui/dlabout.cc
@@ -32,7 +32,7 @@
 #include <wx/hyperlink.h>
 #include <wx/sizer.h>
 
-#include "gambit.h"
+#include "games.h"
 #include "dlabout.h"
 #include "bitmaps/gambitbig.xpm"
 

--- a/src/gui/dleditmove.cc
+++ b/src/gui/dleditmove.cc
@@ -32,7 +32,7 @@
 #include <memory>
 #include <set>
 
-#include "gambit.h"
+#include "games.h"
 #include "dleditmove.h"
 #include "valnumber.h"
 #include "editlabel.h"

--- a/src/gui/dleditnode.cc
+++ b/src/gui/dleditnode.cc
@@ -25,7 +25,7 @@
 #include <wx/wx.h>
 #endif // WX_PRECOMP
 #include <wx/richmsgdlg.h>
-#include "gambit.h"
+#include "games.h"
 #include "dleditnode.h"
 
 namespace Gambit::GUI {

--- a/src/gui/dlefgreveal.cc
+++ b/src/gui/dlefgreveal.cc
@@ -27,7 +27,7 @@
 #include <wx/wx.h>
 #endif // WX_PRECOMP
 
-#include "gambit.h"
+#include "games.h"
 #include "gamedoc.h"
 
 namespace {

--- a/src/gui/dlinsertmove.cc
+++ b/src/gui/dlinsertmove.cc
@@ -24,7 +24,7 @@
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif // WX_PRECOMP
-#include "gambit.h"
+#include "games.h"
 #include "dlinsertmove.h"
 
 namespace Gambit::GUI {

--- a/src/gui/efgdisplay.cc
+++ b/src/gui/efgdisplay.cc
@@ -29,7 +29,7 @@
 #include <wx/dnd.h>
 #include <wx/popupwin.h>
 
-#include "gambit.h"
+#include "games.h"
 
 #include "efgdisplay.h"
 #include "menuconst.h"

--- a/src/gui/efglayout.h
+++ b/src/gui/efglayout.h
@@ -23,7 +23,6 @@
 #ifndef GAMBIT_GUI_EFGLAYOUT_H
 #define GAMBIT_GUI_EFGLAYOUT_H
 
-#include "gambit.h"
 #include "gamedoc.h"
 
 #include "games/layout.h"

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <set>
 
-#include "gambit.h"
+#include "games.h"
 #include "games/workspace.h"
 
 #include "app.h" // for wxGetApp()

--- a/src/gui/gamedoc.h
+++ b/src/gui/gamedoc.h
@@ -25,7 +25,8 @@
 
 #include <map>
 
-#include "gambit.h"
+#include "games/behavspt.h"
+#include "games/stratspt.h"
 #include "style.h"
 #include "analysis.h"
 

--- a/src/gui/gameframe.cc
+++ b/src/gui/gameframe.cc
@@ -36,7 +36,7 @@
 #include <wx/splitter.h>
 #include <wx/artprov.h>
 
-#include "gambit.h"
+#include "games.h"
 
 #include "app.h" // for wxGetApp()
 #include "gameframe.h"

--- a/src/gui/nashspec.h
+++ b/src/gui/nashspec.h
@@ -27,7 +27,7 @@
 #include <variant>
 
 #include "core/cancel.h"
-#include "games/nash.h"
+#include "solvers/nash.h"
 #include "core/rational.h"
 
 namespace Gambit::GUI {

--- a/src/gui/nfgtable.h
+++ b/src/gui/nfgtable.h
@@ -25,6 +25,8 @@
 
 #include <wx/grid.h>
 
+#include "games/stratpure.h"
+
 namespace Gambit::GUI {
 class GameDocument;
 class NfgPanel;

--- a/src/gui/style.h
+++ b/src/gui/style.h
@@ -25,7 +25,7 @@
 
 #include <functional>
 
-#include "gambit.h"
+#include "games/game.h"
 #include "games/workspace.h"
 
 class wxFont;

--- a/src/gui/valnumber.cc
+++ b/src/gui/valnumber.cc
@@ -27,7 +27,7 @@
 #include <wx/wx.h>
 #endif // WX_PRECOMP
 
-#include "gambit.h"
+#include "games.h"
 #include "valnumber.h"
 
 namespace Gambit::GUI {

--- a/src/gui/valnumber.h
+++ b/src/gui/valnumber.h
@@ -24,7 +24,7 @@
 #define GAMBIT_GUI_VALNUMBER_H
 
 #include <wx/validate.h>
-#include "gambit.h"
+#include "core/rational.h"
 
 namespace Gambit::GUI {
 class NumberValidator final : public wxValidator {

--- a/src/gui/welcome.cc
+++ b/src/gui/welcome.cc
@@ -6,7 +6,7 @@
 #include <wx/filedlg.h>
 #include <wx/msgdlg.h>
 
-#include "gambit.h"
+#include "games.h"
 
 #include "welcome.h"
 #include "app.h"

--- a/src/pygambit/gambit.pxd
+++ b/src/pygambit/gambit.pxd
@@ -8,7 +8,7 @@ from libcpp.map cimport map as stdmap
 from libcpp.optional cimport optional
 
 
-cdef extern from "gambit.h":
+cdef extern from "games.h":
     # We don't wrap anything from the basic header, but it ensures
     # it gets included in the output
     pass

--- a/src/pygambit/nash.h
+++ b/src/pygambit/nash.h
@@ -20,7 +20,6 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
 #include "solvers/logit/logit.h"
 
 using namespace std;

--- a/src/pygambit/util.h
+++ b/src/pygambit/util.h
@@ -29,10 +29,12 @@
 #include <string>
 #include <fstream>
 #include <sstream>
-#include "gambit.h"
+#include "games/game.h"
+#include "games/writer.h"
+#include "games/stratspt.h"
 #include "games/gameagg.h"
 #include "games/gamebagg.h"
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 using namespace std;
 using namespace Gambit;

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -2,8 +2,8 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/gambit.h
-// Top-level include file for all of Gambit
+// FILE: src/solvers.h
+// Top-level include file for Gambit's equilibrium-computation algorithms
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,10 +20,21 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_H
-#define GAMBIT_H
+#ifndef GAMBIT_SOLVERS_H
+#define GAMBIT_SOLVERS_H
 
 #include "games.h"
-#include "solvers.h"
 
-#endif // GAMBIT_H
+#include "solvers/enumpure/enumpure.h"
+#include "solvers/enummixed/enummixed.h"
+#include "solvers/lcp/lcp.h"
+#include "solvers/lp/lp.h"
+#include "solvers/liap/liap.h"
+#include "solvers/simpdiv/simpdiv.h"
+#include "solvers/gnm/gnm.h"
+#include "solvers/ipa/ipa.h"
+#include "solvers/nashsupport/nashsupport.h"
+#include "solvers/enumpoly/enumpoly.h"
+#include "solvers/logit/logit.h"
+
+#endif // GAMBIT_SOLVERS_H

--- a/src/solvers/enummixed/clique.cc
+++ b/src/solvers/enummixed/clique.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enummixed/clique.cc
+// FILE: src/solvers/enummixed/clique.cc
 // Maximal cliques and solution components via von Stengel's algorithm
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 //
 
 #include "clique.h"
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit::Nash {
 

--- a/src/solvers/enummixed/clique.h
+++ b/src/solvers/enummixed/clique.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/enummixed/clique.h
+// FILE: src/solvers/enummixed/clique.h
 // Maximal cliques and connected components
 //
 // This program is free software; you can redistribute it and/or modify
@@ -175,11 +175,11 @@
 //    have to be updated.  Hence,  NOT and CAND are kept as
 //    separate sets  NOT1,  NOT2  and CAND1, CAND2.
 
-#ifndef GAMBIT_ENUMMIXED_CLIQUE_H
-#define GAMBIT_ENUMMIXED_CLIQUE_H
+#ifndef GAMBIT_SOLVERS_ENUMMIXED_CLIQUE_H
+#define GAMBIT_SOLVERS_ENUMMIXED_CLIQUE_H
 
 #include <cstdio>
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit::Nash {
 
@@ -264,4 +264,4 @@ private:
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_ENUMMIXED_CLIQUE_H
+#endif // GAMBIT_SOLVERS_ENUMMIXED_CLIQUE_H

--- a/src/solvers/enummixed/enummixed.cc
+++ b/src/solvers/enummixed/enummixed.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enummixed/enummixed.cc
+// FILE: src/solvers/enummixed/enummixed.cc
 // Compute Nash equilibria via Mangasarian's algorithm
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 #include "solvers/linalg/vertenum.imp"
 #include "solvers/enummixed/enummixed.h"
 #include "clique.h"

--- a/src/solvers/enummixed/enummixed.h
+++ b/src/solvers/enummixed/enummixed.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/enummixed.h
+// FILE: src/solvers/enummixed/enummixed.h
 // Enumerate all mixed strategy equilibria of two-player games
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_ENUMMIXED_H
-#define GAMBIT_NASH_ENUMMIXED_H
+#ifndef GAMBIT_SOLVERS_ENUMMIXED_ENUMMIXED_H
+#define GAMBIT_SOLVERS_ENUMMIXED_ENUMMIXED_H
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -78,4 +78,4 @@ EnumMixedStrategySolve(const Game &p_game,
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_ENUMMIXED_H
+#endif // GAMBIT_SOLVERS_ENUMMIXED_ENUMMIXED_H

--- a/src/solvers/enumpoly/enumpoly.h
+++ b/src/solvers/enumpoly/enumpoly.h
@@ -26,7 +26,7 @@
 
 #include <variant>
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 #include "solvers/nashsupport/nashsupport.h"
 
 namespace Gambit::Nash {

--- a/src/solvers/enumpoly/indexproduct.h
+++ b/src/solvers/enumpoly/indexproduct.h
@@ -20,10 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef INDEXPRODUCT_H
-#define INDEXPRODUCT_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_INDEXPRODUCT_H
+#define GAMBIT_SOLVERS_ENUMPOLY_INDEXPRODUCT_H
 
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit {
 
@@ -85,4 +85,4 @@ public:
 
 } // namespace Gambit
 
-#endif // INDEXPRODUCT_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_INDEXPRODUCT_H

--- a/src/solvers/enumpoly/nfgpoly.cc
+++ b/src/solvers/enumpoly/nfgpoly.cc
@@ -23,6 +23,7 @@
 
 #include <numeric>
 
+#include "games/stratpure.h"
 #include "enumpoly.h"
 #include "solvers/nashsupport/nashsupport.h"
 #include "polysystem.h"

--- a/src/solvers/enumpoly/poly.h
+++ b/src/solvers/enumpoly/poly.h
@@ -20,13 +20,14 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef POLY_H
-#define POLY_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_POLY_H
+#define GAMBIT_SOLVERS_ENUMPOLY_POLY_H
 
 #include <algorithm>
 #include <compare>
+#include <memory>
 
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit {
 
@@ -399,4 +400,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // POLY_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_POLY_H

--- a/src/solvers/enumpoly/polypartial.h
+++ b/src/solvers/enumpoly/polypartial.h
@@ -20,10 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef POLYPARTIAL_H
-#define POLYPARTIAL_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_POLYPARTIAL_H
+#define GAMBIT_SOLVERS_ENUMPOLY_POLYPARTIAL_H
 
-#include "gambit.h"
+#include <list>
+
+#include "core/core.h"
 #include "rectangle.h"
 #include "polysystem.h"
 
@@ -104,4 +106,4 @@ public:
 
 } // namespace Gambit
 
-#endif // POLYPARTIAL_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_POLYPARTIAL_H

--- a/src/solvers/enumpoly/polypartial.imp
+++ b/src/solvers/enumpoly/polypartial.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (http://www.gambit-project.org)
 //
-// FILE: src/solver/enumpoly/polypartial.imp
+// FILE: src/solvers/enumpoly/polypartial.imp
 // Implementation of partial derivatives of polynomials
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/enumpoly/polysolver.h
+++ b/src/solvers/enumpoly/polysolver.h
@@ -20,11 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef POLYSOLVER_H
-#define POLYSOLVER_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_POLYSOLVER_H
+#define GAMBIT_SOLVERS_ENUMPOLY_POLYSOLVER_H
 
 #include "core/cancel.h"
-#include "gambit.h"
+#include "core/core.h"
 #include "rectangle.h"
 #include "polysystem.h"
 #include "polypartial.h"
@@ -103,4 +103,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // POLYSOLVER_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_POLYSOLVER_H

--- a/src/solvers/enumpoly/polysystem.h
+++ b/src/solvers/enumpoly/polysystem.h
@@ -20,8 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef POLYSYSTEM_H
-#define POLYSYSTEM_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_POLYSYSTEM_H
+#define GAMBIT_SOLVERS_ENUMPOLY_POLYSYSTEM_H
+
+#include <list>
+#include <memory>
 
 #include "poly.h"
 
@@ -105,4 +108,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // POLYSYSTEM_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_POLYSYSTEM_H

--- a/src/solvers/enumpoly/rectangle.h
+++ b/src/solvers/enumpoly/rectangle.h
@@ -20,10 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef RECTANGLE_H
-#define RECTANGLE_H
+#ifndef GAMBIT_SOLVERS_ENUMPOLY_RECTANGLE_H
+#define GAMBIT_SOLVERS_ENUMPOLY_RECTANGLE_H
 
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit {
 
@@ -178,4 +178,4 @@ public:
 
 } // end namespace Gambit
 
-#endif // RECTANGLE_H
+#endif // GAMBIT_SOLVERS_ENUMPOLY_RECTANGLE_H

--- a/src/solvers/enumpure/enumpure.h
+++ b/src/solvers/enumpure/enumpure.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/enumpure.h
+// FILE: src/solvers/enumpure/enumpure.h
 // Enumerate pure-strategy equilibrium profiles of games
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_ENUMPURE_H
-#define GAMBIT_NASH_ENUMPURE_H
+#ifndef GAMBIT_SOLVERS_ENUMPURE_ENUMPURE_H
+#define GAMBIT_SOLVERS_ENUMPURE_ENUMPURE_H
 
-#include "games/nash.h"
+#include "games/stratpure.h"
+#include "games/behavpure.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -105,4 +107,4 @@ EnumPureAgentSolve(const Game &p_game,
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_ENUMPURE_H
+#endif // GAMBIT_SOLVERS_ENUMPURE_ENUMPURE_H

--- a/src/solvers/gnm/gnm.cc
+++ b/src/solvers/gnm/gnm.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/gnm/gnm.cc
+// FILE: src/solvers/gnm/gnm.cc
 // Compute Nash equilibria via the global Newton method
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 //
 
 #include <numeric>
-#include "gambit.h"
+#include "games.h"
 #include "solvers/gnm/gnm.h"
 #include "solvers/gtracer/gtracer.h"
 

--- a/src/solvers/gnm/gnm.h
+++ b/src/solvers/gnm/gnm.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/gnm.h
+// FILE: src/solvers/gnm/gnm.h
 // Compute Nash equilibria via the global Newton method
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,12 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_GNM_H
-#define GAMBIT_NASH_GNM_H
+#ifndef GAMBIT_SOLVERS_GNM_GNM_H
+#define GAMBIT_SOLVERS_GNM_GNM_H
 
 #include <variant>
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 #include "solvers/gtracer/gtracer.h"
 
 namespace Gambit::Nash {
@@ -78,4 +78,4 @@ GNMStrategySolve(const MixedStrategyProfile<double> &p_profile, double p_lambdaE
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_GNM_H
+#endif // GAMBIT_SOLVERS_GNM_GNM_H

--- a/src/solvers/gtracer/aggame.cc
+++ b/src/solvers/gtracer/aggame.cc
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: library/src/gtracer/aggame.cc
+// FILE: src/solvers/gtracer/aggame.cc
 // Implement GNM-specific routines for action graph games
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/gtracer/aggame.h
+++ b/src/solvers/gtracer/aggame.h
@@ -3,7 +3,7 @@
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //                          Albert Xin Jiang <albertjiang@gmail.com>
 //
-// FILE: library/include/gambit/gtracer/aggame.h
+// FILE: src/solvers/gtracer/aggame.h
 // Interface to GNM-specific routines for action graph games
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,13 +21,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GTRACER_AGGAME_H
-#define GAMBIT_GTRACER_AGGAME_H
+#ifndef GAMBIT_SOLVERS_GTRACER_AGGAME_H
+#define GAMBIT_SOLVERS_GTRACER_AGGAME_H
 
 #include "cmatrix.h"
 #include "gnmgame.h"
 #include "games/agg/agg.h"
-#include "gambit.h"
 #include "games/gameagg.h"
 
 namespace Gambit::gametracer {
@@ -93,4 +92,4 @@ private:
 
 } // end namespace Gambit::gametracer
 
-#endif // GAMBIT_GTRACER_AGGAME_H
+#endif // GAMBIT_SOLVERS_GTRACER_AGGAME_H

--- a/src/solvers/gtracer/cmatrix.cc
+++ b/src/solvers/gtracer/cmatrix.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/gtracer/cmatrix.cc
+// FILE: src/solvers/gtracer/cmatrix.cc
 // Implementation of matrix classes for Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton

--- a/src/solvers/gtracer/cmatrix.h
+++ b/src/solvers/gtracer/cmatrix.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gtracer/cmatrix.h
+// FILE: src/solvers/gtracer/cmatrix.h
 // Definition of matrix classes for Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -22,8 +22,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GTRACER_CMATRIX_H
-#define GAMBIT_GTRACER_CMATRIX_H
+#ifndef GAMBIT_SOLVERS_GTRACER_CMATRIX_H
+#define GAMBIT_SOLVERS_GTRACER_CMATRIX_H
 
 #include <iostream>
 #include <cmath>
@@ -765,4 +765,4 @@ inline std::ostream &operator<<(std::ostream &s, const cmatrix &ma)
 
 } // end namespace Gambit::gametracer
 
-#endif // GAMBIT_GTRACER_CMATRIX_H
+#endif // GAMBIT_SOLVERS_GTRACER_CMATRIX_H

--- a/src/solvers/gtracer/gnm.cc
+++ b/src/solvers/gtracer/gnm.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/gtracer/gnm.cc
+// FILE: src/solvers/gtracer/gnm.cc
 // Implementation of Global Newton Method from Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -22,7 +22,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 #include "gtracer.h"
 
 namespace Gambit::gametracer {

--- a/src/solvers/gtracer/gnmgame.cc
+++ b/src/solvers/gtracer/gnmgame.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/gtracer/gnmgame.cc
+// FILE: src/solvers/gtracer/gnmgame.cc
 // Implementation of basic game representation class in Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton

--- a/src/solvers/gtracer/gnmgame.h
+++ b/src/solvers/gtracer/gnmgame.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gtracer/gnmgame.h
+// FILE: src/solvers/gtracer/gnmgame.h
 // Definition of basic game representation class in Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -22,8 +22,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GTRACER_GNMGAME_H
-#define GAMBIT_GTRACER_GNMGAME_H
+#ifndef GAMBIT_SOLVERS_GTRACER_GNMGAME_H
+#define GAMBIT_SOLVERS_GTRACER_GNMGAME_H
 
 #include "cmatrix.h"
 
@@ -119,4 +119,4 @@ protected:
 
 } // end namespace Gambit::gametracer
 
-#endif // GAMBIT_GTRACER_GNMGAME_H
+#endif // GAMBIT_SOLVERS_GTRACER_GNMGAME_H

--- a/src/solvers/gtracer/gtracer.cc
+++ b/src/solvers/gtracer/gtracer.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gtracer/gtracer.cc
+// FILE: src/solvers/gtracer/gtracer.cc
 // Top-level include file for Gametracer embedding in Gambit
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -24,7 +24,7 @@
 
 #include <algorithm>
 #include "gtracer.h"
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit::gametracer {
 

--- a/src/solvers/gtracer/gtracer.h
+++ b/src/solvers/gtracer/gtracer.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gtracer/gtracer.h
+// FILE: src/solvers/gtracer/gtracer.h
 // Top-level include file for Gametracer embedding in Gambit
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -22,15 +22,15 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GTRACER_GTRACER_H
-#define GAMBIT_GTRACER_GTRACER_H
+#ifndef GAMBIT_SOLVERS_GTRACER_GTRACER_H
+#define GAMBIT_SOLVERS_GTRACER_GTRACER_H
 
 #include <functional>
 #include "core/cancel.h"
 #include "cmatrix.h"
 #include "nfgame.h"
 #include "aggame.h"
-#include "gambit.h"
+#include "games/game.h"
 
 namespace Gambit::gametracer {
 
@@ -143,4 +143,4 @@ MixedStrategyProfile<double> ToProfile(const Game &p_game, const cvector &p_prof
 
 } // end namespace Gambit::gametracer
 
-#endif // GAMBIT_GTRACER_GTRACER_H
+#endif // GAMBIT_SOLVERS_GTRACER_GTRACER_H

--- a/src/solvers/gtracer/ipa.cc
+++ b/src/solvers/gtracer/ipa.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/gtracer/gnm.cc
+// FILE: src/solvers/gtracer/ipa.cc
 // Implementation of Global Newton Method from Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton

--- a/src/solvers/gtracer/nfgame.cc
+++ b/src/solvers/gtracer/nfgame.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/src/gtracer/nfgame.cc
+// FILE: src/solvers/gtracer/nfgame.cc
 // Implementation of normal form game class for Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -26,7 +26,7 @@
 #include <vector>
 #include "cmatrix.h"
 #include "nfgame.h"
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit::gametracer {
 

--- a/src/solvers/gtracer/nfgame.h
+++ b/src/solvers/gtracer/nfgame.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gtracer/nfgame.h
+// FILE: src/solvers/gtracer/nfgame.h
 // Definition of normal form game class for Gametracer
 // This file is based on GameTracer v0.2, which is
 // Copyright (c) 2002, Ben Blum and Christian Shelton
@@ -22,8 +22,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_GTRACER_NFGAME_H
-#define GAMBIT_GTRACER_NFGAME_H
+#ifndef GAMBIT_SOLVERS_GTRACER_NFGAME_H
+#define GAMBIT_SOLVERS_GTRACER_NFGAME_H
 
 #include "gnmgame.h"
 #include "cmatrix.h"
@@ -89,4 +89,4 @@ inline std::ostream &operator<<(std::ostream &s, nfgame &g)
 
 } // end namespace Gambit::gametracer
 
-#endif // GAMBIT_GTRACER_NFGAME_H
+#endif // GAMBIT_SOLVERS_GTRACER_NFGAME_H

--- a/src/solvers/ipa/ipa.cc
+++ b/src/solvers/ipa/ipa.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/ipa/ipa.cc
+// FILE: src/solvers/ipa/ipa.cc
 // Compute Nash equilibria via iterated polymatrix approximation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 //
 
 #include <algorithm>
-#include "gambit.h"
+#include "games.h"
 #include "solvers/ipa/ipa.h"
 #include "solvers/gtracer/gtracer.h"
 

--- a/src/solvers/ipa/ipa.h
+++ b/src/solvers/ipa/ipa.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/ipa.h
+// FILE: src/solvers/ipa/ipa.h
 // Compute Nash equilibria via iterated polymatrix approximation
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,12 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_IPA_H
-#define GAMBIT_NASH_IPA_H
+#ifndef GAMBIT_SOLVERS_IPA_IPA_H
+#define GAMBIT_SOLVERS_IPA_IPA_H
 
 #include <variant>
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 #include "solvers/gtracer/gtracer.h"
 
 namespace Gambit::Nash {
@@ -66,4 +66,4 @@ IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
 
 } // namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_IPA_H
+#endif // GAMBIT_SOLVERS_IPA_IPA_H

--- a/src/solvers/lcp/efglcp.cc
+++ b/src/solvers/lcp/efglcp.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/efglcp.cc
+// FILE: src/solvers/lcp/efglcp.cc
 // Implementation of algorithm to solve extensive forms using linear
 // complementarity program from sequence form
 //
@@ -21,7 +21,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 #include "solvers/linalg/lemketab.h"
 #include "solvers/lcp/lcp.h"
 

--- a/src/solvers/lcp/lcp.h
+++ b/src/solvers/lcp/lcp.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/lcp.h
+// FILE: src/solvers/lcp/lcp.h
 // Compute Nash equilibria via linear complementarity programming
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_LCP_H
-#define GAMBIT_NASH_LCP_H
+#ifndef GAMBIT_SOLVERS_LCP_LCP_H
+#define GAMBIT_SOLVERS_LCP_LCP_H
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -41,4 +41,4 @@ LcpBehaviorSolve(const Game &p_game,
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_LCP_H
+#endif // GAMBIT_SOLVERS_LCP_LCP_H

--- a/src/solvers/lcp/nfglcp.cc
+++ b/src/solvers/lcp/nfglcp.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/nfglcp.cc
+// FILE: src/solvers/lcp/nfglcp.cc
 // Compute Nash equilibria via Lemke-Howson algorithm
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <algorithm>
 
-#include "gambit.h"
+#include "games.h"
 #include "solvers/linalg/lhtab.h"
 #include "solvers/lcp/lcp.h"
 

--- a/src/solvers/liap/efgliap.cc
+++ b/src/solvers/liap/efgliap.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/liap/efgliap.cc
+// FILE: src/solvers/liap/efgliap.cc
 // Compute Nash equilibria via Lyapunov function minimization
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <numeric>
 
-#include "gambit.h"
+#include "games.h"
 #include "core/function.h"
 #include "liap.h"
 

--- a/src/solvers/liap/liap.h
+++ b/src/solvers/liap/liap.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/liap/efgliap.h
+// FILE: src/solvers/liap/liap.h
 // Compute Nash equilibria by minimizing Liapunov function on extensive game
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_LIAP_H
-#define GAMBIT_NASH_LIAP_H
+#ifndef GAMBIT_SOLVERS_LIAP_LIAP_H
+#define GAMBIT_SOLVERS_LIAP_LIAP_H
 
 #include <variant>
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -61,4 +61,4 @@ LiapStrategySolve(const MixedStrategyProfile<double> &p_start, double p_maxregre
 
 } // namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_LIAP_H
+#endif // GAMBIT_SOLVERS_LIAP_LIAP_H

--- a/src/solvers/liap/nfgliap.cc
+++ b/src/solvers/liap/nfgliap.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/liap/nfgliap.cc
+// FILE: src/solvers/liap/nfgliap.cc
 // Compute Nash equilibria by minimizing Liapunov function
 //
 // This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 
 #include <numeric>
 
-#include "gambit.h"
+#include "games.h"
 #include "core/function.h"
 #include "liap.h"
 

--- a/src/solvers/linalg/btableau.h
+++ b/src/solvers/linalg/btableau.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/btableau.h
+// FILE: src/solvers/linalg/btableau.h
 // Interface to base tableau classes
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,12 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef BTABLEAU_H
-#define BTABLEAU_H
+#ifndef GAMBIT_SOLVERS_LINALG_BTABLEAU_H
+#define GAMBIT_SOLVERS_LINALG_BTABLEAU_H
 
 #include <set>
 
-#include "gambit.h"
+#include "core/core.h"
 
 namespace Gambit::linalg {
 
@@ -310,4 +310,4 @@ public:
 
 } // end namespace Gambit::linalg
 
-#endif // BTABLEAU_H
+#endif // GAMBIT_SOLVERS_LINALG_BTABLEAU_H

--- a/src/solvers/linalg/lemketab.cc
+++ b/src/solvers/linalg/lemketab.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lemketab.cc
+// FILE: src/solvers/linalg/lemketab.cc
 // Lemke tableau instantiations
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lemketab.h
+++ b/src/solvers/linalg/lemketab.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lemketab.h
+// FILE: src/solvers/linalg/lemketab.h
 // Declaration of Lemke tableau class
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_LINALG_LEMKETAB_H
-#define GAMBIT_LINALG_LEMKETAB_H
+#ifndef GAMBIT_SOLVERS_LINALG_LEMKETAB_H
+#define GAMBIT_SOLVERS_LINALG_LEMKETAB_H
 
 #include "core/cancel.h"
 #include "tableau.h"
@@ -53,4 +53,4 @@ public:
 
 } // end namespace Gambit::linalg
 
-#endif // GAMBIT_LINALG_LEMKETAB_H
+#endif // GAMBIT_SOLVERS_LINALG_LEMKETAB_H

--- a/src/solvers/linalg/lemketab.imp
+++ b/src/solvers/linalg/lemketab.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lemketab.imp
+// FILE: src/solvers/linalg/lemketab.imp
 // Implementation of Lemke tableau class
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lhtab.cc
+++ b/src/solvers/linalg/lhtab.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lhtab.cc
+// FILE: src/solvers/linalg/lhtab.cc
 // Tableau class for Lemke-Howson algorithm
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lhtab.h
+++ b/src/solvers/linalg/lhtab.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lhtab.h
+// FILE: src/solvers/linalg/lhtab.h
 // Tableau class for Lemke-Howson algorithm
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_LINALG_LHTAB_H
-#define GAMBIT_LINALG_LHTAB_H
+#ifndef GAMBIT_SOLVERS_LINALG_LHTAB_H
+#define GAMBIT_SOLVERS_LINALG_LHTAB_H
 
 #include "core/cancel.h"
 #include "lemketab.h"
@@ -85,4 +85,4 @@ protected:
 
 } // end namespace Gambit::linalg
 
-#endif // GAMBIT_LINALG_LHTAB_H
+#endif // GAMBIT_SOLVERS_LINALG_LHTAB_H

--- a/src/solvers/linalg/lhtab.imp
+++ b/src/solvers/linalg/lhtab.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/lhtab.imp
+// FILE: src/solvers/linalg/lhtab.imp
 // Tableau class for Lemke-Howson algorithm
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 //
 
 #include "lhtab.h"
-#include "gambit.h"
+#include "games.h"
 
 namespace Gambit::linalg {
 

--- a/src/solvers/linalg/lpsolve.cc
+++ b/src/solvers/linalg/lpsolve.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lpsolve.cc
+// FILE: src/solvers/linalg/lpsolve.cc
 // Instantiation of common LP solvers
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lpsolve.h
+++ b/src/solvers/linalg/lpsolve.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lpsolve.h
+// FILE: src/solvers/linalg/lpsolve.h
 // Interface to LP solvers
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LPSOLVE_H
-#define LPSOLVE_H
+#ifndef GAMBIT_SOLVERS_LINALG_LPSOLVE_H
+#define GAMBIT_SOLVERS_LINALG_LPSOLVE_H
 
 #include "core/cancel.h"
-#include "gambit.h"
+#include "core/core.h"
 #include "lptab.h"
 
 namespace Gambit::linalg {
@@ -75,4 +75,4 @@ public:
 
 } // end namespace Gambit::linalg
 
-#endif // LPSOLVE_H
+#endif // GAMBIT_SOLVERS_LINALG_LPSOLVE_H

--- a/src/solvers/linalg/lpsolve.imp
+++ b/src/solvers/linalg/lpsolve.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lpsolve.imp
+// FILE: src/solvers/linalg/lpsolve.imp
 // Implementation of LP solver
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lptab.cc
+++ b/src/solvers/linalg/lptab.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lptab.cc
+// FILE: src/solvers/linalg/lptab.cc
 // Instantiation of LP tableau
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/lptab.h
+++ b/src/solvers/linalg/lptab.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lptab.h
+// FILE: src/solvers/linalg/lptab.h
 // Interface to LP tableaus
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LPTAB_H
-#define LPTAB_H
+#ifndef GAMBIT_SOLVERS_LINALG_LPTAB_H
+#define GAMBIT_SOLVERS_LINALG_LPTAB_H
+
+#include <list>
 
 #include "tableau.h"
 
@@ -61,4 +63,4 @@ public:
 
 } // end namespace Gambit::linalg
 
-#endif // LPTAB_H
+#endif // GAMBIT_SOLVERS_LINALG_LPTAB_H

--- a/src/solvers/linalg/lptab.imp
+++ b/src/solvers/linalg/lptab.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/lptab.imp
+// FILE: src/solvers/linalg/lptab.imp
 // Implementation of LP tableaus
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/ludecomp.cc
+++ b/src/solvers/linalg/ludecomp.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/ludecomp.cc
+// FILE: src/solvers/linalg/ludecomp.cc
 // Instantiation of LU decomposition
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/ludecomp.h
+++ b/src/solvers/linalg/ludecomp.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/ludecomp.h
+// FILE: src/solvers/linalg/ludecomp.h
 // Interface to LU decomposition classes
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,12 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LUDECOMP_H
-#define LUDECOMP_H
+#ifndef GAMBIT_SOLVERS_LINALG_LUDECOMP_H
+#define GAMBIT_SOLVERS_LINALG_LUDECOMP_H
 
-#include "gambit.h"
+#include <list>
+
+#include "core/core.h"
 #include "btableau.h"
 
 namespace Gambit::linalg {
@@ -133,4 +135,4 @@ private:
 
 } // end namespace Gambit::linalg
 
-#endif // LUDECOMP_H
+#endif // GAMBIT_SOLVERS_LINALG_LUDECOMP_H

--- a/src/solvers/linalg/ludecomp.imp
+++ b/src/solvers/linalg/ludecomp.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/ludecomp.imp
+// FILE: src/solvers/linalg/ludecomp.imp
 // Implementation of LU decomposition
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 #include "ludecomp.h"
 #include "tableau.h"
 

--- a/src/solvers/linalg/tableau.cc
+++ b/src/solvers/linalg/tableau.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/tableau.imp
+// FILE: src/solvers/linalg/tableau.cc
 // Implementation of tableau class
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/linalg/tableau.h
+++ b/src/solvers/linalg/tableau.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/liblinear/tableau.h
+// FILE: src/solvers/linalg/tableau.h
 // Interface to tableau class
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef TABLEAU_H
-#define TABLEAU_H
+#ifndef GAMBIT_SOLVERS_LINALG_TABLEAU_H
+#define GAMBIT_SOLVERS_LINALG_TABLEAU_H
 
 #include "btableau.h"
 #include "ludecomp.h"
@@ -109,4 +109,4 @@ public:
 
 } // end namespace Gambit::linalg
 
-#endif // TABLEAU_H
+#endif // GAMBIT_SOLVERS_LINALG_TABLEAU_H

--- a/src/solvers/linalg/vertenum.h
+++ b/src/solvers/linalg/vertenum.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enummixed/vertenum.h
+// FILE: src/solvers/linalg/vertenum.h
 // Interface to vertex enumerator
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,13 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_LINALG_VERTENUM_H
-#define GAMBIT_LINALG_VERTENUM_H
+#ifndef GAMBIT_SOLVERS_LINALG_VERTENUM_H
+#define GAMBIT_SOLVERS_LINALG_VERTENUM_H
+
+#include <list>
 
 #include "core/cancel.h"
-#include "gambit.h"
+#include "core/core.h"
 #include "lptab.h"
 
 namespace Gambit::linalg {
@@ -71,4 +73,4 @@ public:
 
 } // namespace Gambit::linalg
 
-#endif // GAMBIT_LINALG_VERTENUM_H
+#endif // GAMBIT_SOLVERS_LINALG_VERTENUM_H

--- a/src/solvers/linalg/vertenum.imp
+++ b/src/solvers/linalg/vertenum.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enummixed/vertenum.imp
+// FILE: src/solvers/linalg/vertenum.imp
 // Implementation of vertex enumerator
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/logit/efglogit.cc
+++ b/src/solvers/logit/efglogit.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/efglogit.cc
+// FILE: src/solvers/logit/efglogit.cc
 // Computation of agent quantal response equilibrium correspondence for
 // extensive games.
 //
@@ -23,7 +23,7 @@
 
 #include <cmath>
 
-#include "gambit.h"
+#include "games.h"
 #include "logit.h"
 #include "logbehav.imp"
 #include "path.h"

--- a/src/solvers/logit/logbehav.h
+++ b/src/solvers/logit/logbehav.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/logbehav.h
+// FILE: src/solvers/logit/logbehav.h
 // Behavior strategy profile where action probabilities are represented using
 // logarithms.
 //
@@ -21,8 +21,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LOGBEHAV_H
-#define LOGBEHAV_H
+#ifndef GAMBIT_SOLVERS_LOGIT_LOGBEHAV_H
+#define GAMBIT_SOLVERS_LOGIT_LOGBEHAV_H
 
 using namespace Gambit;
 
@@ -131,4 +131,4 @@ public:
   //@}
 };
 
-#endif // LOGBEHAV_H
+#endif // GAMBIT_SOLVERS_LOGIT_LOGBEHAV_H

--- a/src/solvers/logit/logbehav.imp
+++ b/src/solvers/logit/logbehav.imp
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/logbehav.imp
+// FILE: src/solvers/logit/logbehav.imp
 // Behavior strategy profile where action probabilities are represented using
 // logarithms.
 //

--- a/src/solvers/logit/logit.h
+++ b/src/solvers/logit/logit.h
@@ -20,13 +20,13 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef SOLVERS_LOGIT_H
-#define SOLVERS_LOGIT_H
+#ifndef GAMBIT_SOLVERS_LOGIT_LOGIT_H
+#define GAMBIT_SOLVERS_LOGIT_LOGIT_H
 
 #include <functional>
 #include <variant>
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit {
 
@@ -137,4 +137,4 @@ LogitBehaviorEstimate(const MixedBehaviorProfile<double> &p_frequencies, double 
 
 } // namespace Gambit
 
-#endif // SOLVERS_LOGIT_H
+#endif // GAMBIT_SOLVERS_LOGIT_LOGIT_H

--- a/src/solvers/logit/nfglogit.cc
+++ b/src/solvers/logit/nfglogit.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/nfglogit.cc
+// FILE: src/solvers/logit/nfglogit.cc
 // Computation of quantal response equilibrium correspondence for
 // normal form games.
 //
@@ -23,7 +23,7 @@
 
 #include <cmath>
 
-#include "gambit.h"
+#include "games.h"
 #include "logit.h"
 #include "path.h"
 

--- a/src/solvers/logit/path.cc
+++ b/src/solvers/logit/path.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/path.cc
+// FILE: src/solvers/logit/path.cc
 // Implementation of generic smooth path-following algorithm.
 //
 // This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <algorithm> // for std::max
 
-#include "gambit.h"
+#include "games.h"
 #include "path.h"
 
 namespace Gambit {

--- a/src/solvers/logit/path.h
+++ b/src/solvers/logit/path.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/logit/path.h
+// FILE: src/solvers/logit/path.h
 // Interface to generic smooth path-following algorithm.
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef PATH_H
-#define PATH_H
+#ifndef GAMBIT_SOLVERS_LOGIT_PATH_H
+#define GAMBIT_SOLVERS_LOGIT_PATH_H
 
 #include <functional>
 #include "core/cancel.h"
@@ -96,4 +96,4 @@ private:
 
 } // end namespace Gambit
 
-#endif // PATH_H
+#endif // GAMBIT_SOLVERS_LOGIT_PATH_H

--- a/src/solvers/lp/lp.cc
+++ b/src/solvers/lp/lp.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lp/efglp.cc
+// FILE: src/solvers/lp/lp.cc
 // Implementation of algorithm to solve efgs via linear programming
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 #include "solvers/lp/lp.h"
 #include "solvers/linalg/lpsolve.h"
 

--- a/src/solvers/lp/lp.h
+++ b/src/solvers/lp/lp.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/lcp/efglp.h
+// FILE: src/solvers/lp/lp.h
 // Compute Nash equilibria via linear programming
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,10 +20,10 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LP_LP_H
-#define LP_LP_H
+#ifndef GAMBIT_SOLVERS_LP_LP_H
+#define GAMBIT_SOLVERS_LP_LP_H
 
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -41,4 +41,4 @@ LpBehaviorSolve(const Game &p_game,
 
 }; // namespace Gambit::Nash
 
-#endif // LP_LP_H
+#endif // GAMBIT_SOLVERS_LP_LP_H

--- a/src/solvers/nash.h
+++ b/src/solvers/nash.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/libgambit/nash.h
+// FILE: src/solvers/nash.h
 // Framework for computing (sub)sets of Nash equilibria.
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,12 +20,15 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef LIBGAMBIT_NASH_H
-#define LIBGAMBIT_NASH_H
+#ifndef GAMBIT_SOLVERS_NASH_H
+#define GAMBIT_SOLVERS_NASH_H
 
 #include <functional>
+#include <list>
+
 #include "core/cancel.h"
-#include "gambit.h"
+#include "games/stratmixed.h"
+#include "games/behavmixed.h"
 
 namespace Gambit::Nash {
 
@@ -54,4 +57,4 @@ ToMixedBehaviorProfile(const std::list<MixedStrategyProfile<T>> &p_list)
 
 } // namespace Gambit::Nash
 
-#endif // LIBGAMBIT_NASH_H
+#endif // GAMBIT_SOLVERS_NASH_H

--- a/src/solvers/nashsupport/efgsupport.cc
+++ b/src/solvers/nashsupport/efgsupport.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enumpoly/efgensup.cc
+// FILE: src/solvers/nashsupport/efgsupport.cc
 // Enumerate undominated subsupports
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/solvers/nashsupport/nashsupport.h
+++ b/src/solvers/nashsupport/nashsupport.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/enumpoly/nfgensup.h
+// FILE: src/solvers/nashsupport/nashsupport.h
 // Enumerate undominated subsupports of a support
 //
 // This program is free software; you can redistribute it and/or modify
@@ -26,7 +26,8 @@
 #include <memory>
 #include <optional>
 
-#include "gambit.h"
+#include "games/stratspt.h"
+#include "games/behavspt.h"
 
 using namespace Gambit;
 

--- a/src/solvers/simpdiv/simpdiv.cc
+++ b/src/solvers/simpdiv/simpdiv.cc
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: src/tools/simpdiv/simpdiv.cc
+// FILE: src/solvers/simpdiv/simpdiv.cc
 // Compute Nash equilibria via simplicial subdivision on the normal form
 //
 // This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 //
 
 #include <numeric>
-#include "gambit.h"
+#include "games.h"
 #include "solvers/simpdiv/simpdiv.h"
 
 namespace Gambit::Nash {

--- a/src/solvers/simpdiv/simpdiv.h
+++ b/src/solvers/simpdiv/simpdiv.h
@@ -2,7 +2,7 @@
 // This file is part of Gambit
 // Copyright (c) 1994-2026, The Gambit Project (https://www.gambit-project.org)
 //
-// FILE: library/include/gambit/nash/simpdiv.h
+// FILE: src/solvers/simpdiv/simpdiv.h
 // Compute Nash equilibria via simplicial subdivision on the normal form
 //
 // This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,11 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#ifndef GAMBIT_NASH_SIMPDIV_H
-#define GAMBIT_NASH_SIMPDIV_H
+#ifndef GAMBIT_SOLVERS_SIMPDIV_SIMPDIV_H
+#define GAMBIT_SOLVERS_SIMPDIV_SIMPDIV_H
 
 #include <variant>
-#include "games/nash.h"
+#include "solvers/nash.h"
 
 namespace Gambit::Nash {
 
@@ -72,4 +72,4 @@ std::list<MixedStrategyProfile<Rational>> SimpdivStrategySolve(
 
 } // end namespace Gambit::Nash
 
-#endif // GAMBIT_NASH_SIMPDIV_H
+#endif // GAMBIT_SOLVERS_SIMPDIV_SIMPDIV_H

--- a/src/tools/convert/convert.cc
+++ b/src/tools/convert/convert.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <getopt.h>
 
-#include "gambit.h"
+#include "games.h"
 #include "games/writer.h"
 
 using namespace Gambit;

--- a/src/tools/enummixed/enummixed.cc
+++ b/src/tools/enummixed/enummixed.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <fstream>
 
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/enummixed/enummixed.h"
 

--- a/src/tools/enumpoly/enumpoly.cc
+++ b/src/tools/enumpoly/enumpoly.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <getopt.h>
 #include <type_traits>
-#include "gambit.h"
+#include "games.h"
 #include "solvers/enumpoly/enumpoly.h"
 
 using namespace Gambit;

--- a/src/tools/enumpure/enumpure.cc
+++ b/src/tools/enumpure/enumpure.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <fstream>
 
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/enumpure/enumpure.h"
 

--- a/src/tools/gt/nfggnm.cc
+++ b/src/tools/gt/nfggnm.cc
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <fstream>
 #include <type_traits>
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/gnm/gnm.h"
 

--- a/src/tools/gt/nfggt.cc
+++ b/src/tools/gt/nfggt.cc
@@ -20,7 +20,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //
 
-#include "gambit.h"
+#include "games.h"
 
 using namespace Gambit;
 

--- a/src/tools/gt/nfgipa.cc
+++ b/src/tools/gt/nfgipa.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <fstream>
 #include <type_traits>
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/ipa/ipa.h"
 

--- a/src/tools/lcp/lcp.cc
+++ b/src/tools/lcp/lcp.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <memory>
 #include <getopt.h>
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/lcp/lcp.h"
 

--- a/src/tools/liap/liap.cc
+++ b/src/tools/liap/liap.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <type_traits>
 #include <getopt.h>
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/liap/liap.h"
 

--- a/src/tools/logit/logit.cc
+++ b/src/tools/logit/logit.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <fstream>
 #include <getopt.h>
-#include "gambit.h"
+#include "games.h"
 #include "solvers/logit/logit.h"
 
 using namespace Gambit;

--- a/src/tools/lp/lp.cc
+++ b/src/tools/lp/lp.cc
@@ -26,7 +26,7 @@
 #include <memory>
 #include <getopt.h>
 
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/lp/lp.h"
 

--- a/src/tools/simpdiv/nfgsimpdiv.cc
+++ b/src/tools/simpdiv/nfgsimpdiv.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <fstream>
 #include <type_traits>
-#include "gambit.h"
+#include "games.h"
 #include "tools/util.h"
 #include "solvers/simpdiv/simpdiv.h"
 

--- a/src/tools/util.h
+++ b/src/tools/util.h
@@ -25,7 +25,8 @@
 
 #include <optional>
 #include <random>
-#include "gambit.h"
+#include "games/stratmixed.h"
+#include "games/behavmixed.h"
 
 namespace Gambit {
 


### PR DESCRIPTION
We are not yet prepared to commit to offering a separate C++ library, but it is on the roadmap. That aside, being consistent internally with organisation of header files and conceptual modules is useful.

This commit:
* Sets rules for the structure of including header files, especially avoiding tacit inclusion.
* Updates include guards and filenames in comments to clear up historical drift.
* Organises the C++ build to use autotools' convenience libraries.
* Adds some developer documentation memorialising the key conventions to follow to enable library builds down the line.
