### PR TITLE
Restore undo/redo in graphical interface.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ## [17.0.0-alpha.2] - unreleased
 
 ### Added
+- Undo/redo support has been re-enabled in the graphical interface.
 - `MixedStrategyProfile.payoffs`, `.player_regrets`, `.strategy_values`, and
   `.strategy_regrets` return the corresponding quantity for every player (and, for the
   latter two, every strategy) at once, rather than one at a time.

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,8 @@ EXTRA_DIST = \
 	src/gui/bitmaps/tobegin.xpm \
 	src/gui/bitmaps/toend.xpm \
 	src/gui/bitmaps/tree.xpm \
+	src/gui/bitmaps/undo.xpm \
+	src/gui/bitmaps/redo.xpm \
 	src/gui/bitmaps/zoomfit.xpm \
 	src/gui/bitmaps/zoomin.xpm \
 	src/gui/bitmaps/zoomout.xpm \

--- a/src/gui/efgtooltip.cc
+++ b/src/gui/efgtooltip.cc
@@ -428,6 +428,9 @@ public:
 
   void ShowForNode(const GameNode &p_node);
 
+protected:
+  void OnDismiss() override { m_node = nullptr; }
+
 private:
   void BuildControls();
   void PositionPopup();

--- a/src/gui/gamedoc.cc
+++ b/src/gui/gamedoc.cc
@@ -207,9 +207,7 @@ GameDocument::GameDocument(Game p_game)
   : m_game(p_game), m_gameModified(false), m_workspaceModified(false), m_workspace(this)
 {
   wxGetApp().AddDocument(this);
-
-  std::ostringstream s;
-  SaveWorkspace(s);
+  ResetUndoHistory();
 }
 
 GameDocument::~GameDocument() { wxGetApp().RemoveDocument(this); }
@@ -229,6 +227,7 @@ GameDocument::LoadOutcome GameDocument::Load(const wxString &p_filename)
     if (doc->m_workspace.Load(workspace.analyses)) {
       doc->m_style.Load(workspace);
       doc->SetFilename(p_filename);
+      doc->ResetUndoHistory();
       return {LoadResult::Success, doc};
     }
   }
@@ -283,12 +282,61 @@ void GameDocument::NotifyChanged(GameModificationType p_modifications)
                       GameModificationType::GameForm | GameModificationType::GamePayoffs)) {
     m_workspace.ResetForGameChange();
   }
+  if (p_modifications != GameModificationType::None) {
+    m_redoList.clear();
+    std::ostringstream s;
+    SaveWorkspace(s);
+    m_undoList.push_back(s.str());
+  }
   UpdateViews();
 }
 
 void GameDocument::UpdateViews()
 {
   std::for_each(m_views.begin(), m_views.end(), std::mem_fn(&GameView::OnUpdate));
+}
+
+void GameDocument::ResetUndoHistory()
+{
+  m_undoList.clear();
+  m_redoList.clear();
+  std::ostringstream s;
+  SaveWorkspace(s);
+  m_undoList.push_back(s.str());
+}
+
+void GameDocument::RestoreSnapshot(const std::string &p_snapshot)
+{
+  std::istringstream input(p_snapshot);
+  const LegacyWorkspaceFile workspace = ReadLegacyWorkspace(input);
+  std::istringstream game_text(workspace.game);
+  m_game = ReadGame(game_text);
+  m_workspace.Load(workspace.analyses);
+  m_style.Load(workspace);
+}
+
+void GameDocument::Undo()
+{
+  if (!CanUndo()) {
+    return;
+  }
+  m_redoList.push_back(m_undoList.back());
+  m_undoList.pop_back();
+  RestoreSnapshot(m_undoList.back());
+  m_gameModified = m_workspaceModified = true;
+  UpdateViews();
+}
+
+void GameDocument::Redo()
+{
+  if (!CanRedo()) {
+    return;
+  }
+  m_undoList.push_back(m_redoList.back());
+  m_redoList.pop_back();
+  RestoreSnapshot(m_undoList.back());
+  m_gameModified = m_workspaceModified = true;
+  UpdateViews();
 }
 
 void GameDocument::PostPendingChanges()

--- a/src/gui/gamedoc.h
+++ b/src/gui/gamedoc.h
@@ -224,8 +224,16 @@ class GameDocument {
 
   AnalysisWorkspace m_workspace;
 
+  std::list<std::string> m_undoList, m_redoList;
+
   void NotifyChanged(GameModificationType p_modifications);
   void UpdateViews();
+
+  /// Discard all undo/redo history, taking the current state as the new baseline
+  void ResetUndoHistory();
+  /// Replace the game, workspace, and style with those saved in a snapshot
+  /// previously produced by `SaveWorkspace`
+  void RestoreSnapshot(const std::string &p_snapshot);
 
 public:
   explicit GameDocument(Game p_game);
@@ -262,6 +270,17 @@ public:
   void SetWorkspaceModified(bool p_unsaved) { m_workspaceModified = p_unsaved; }
 
   const AnalysisWorkspace &GetWorkspace() const { return m_workspace; }
+
+  //!
+  //! @name Undo/redo
+  //!
+  //@{
+  bool CanUndo() const { return m_undoList.size() > 1; }
+  void Undo();
+
+  bool CanRedo() const { return !m_redoList.empty(); }
+  void Redo();
+  //@}
 
   const TreeRenderConfig &GetStyle() const { return m_style; }
   void SetStyle(const TreeRenderConfig &p_style);

--- a/src/gui/gameframe.cc
+++ b/src/gui/gameframe.cc
@@ -196,6 +196,8 @@ EVT_MENU(wxID_PREVIEW, GameFrame::OnFilePrintPreview)
 EVT_MENU(wxID_PRINT, GameFrame::OnFilePrint)
 EVT_MENU(wxID_EXIT, GameFrame::OnFileExit)
 EVT_MENU_RANGE(wxID_FILE1, wxID_FILE9, GameFrame::OnFileMRUFile)
+EVT_MENU(wxID_UNDO, GameFrame::OnEditUndo)
+EVT_MENU(wxID_REDO, GameFrame::OnEditRedo)
 EVT_MENU(GBT_MENU_EDIT_GAME, GameFrame::OnEditGame)
 EVT_MENU(GBT_MENU_EDIT_NEWPLAYER, GameFrame::OnEditNewPlayer)
 EVT_MENU(GBT_MENU_VIEW_PROFILES, GameFrame::OnViewProfiles)
@@ -238,7 +240,7 @@ GameFrame::GameFrame(wxWindow *p_parent, const std::shared_ptr<GameDocument> &p_
   MakeMenus();
   MakeToolbar();
 
-  wxAcceleratorEntry entries[10];
+  wxAcceleratorEntry entries[12];
   entries[0].Set(wxACCEL_CTRL, 'o', wxID_OPEN);
   entries[1].Set(wxACCEL_CTRL, 's', wxID_SAVE);
   entries[2].Set(wxACCEL_CTRL | wxACCEL_SHIFT, 's', wxID_SAVEAS);
@@ -249,7 +251,9 @@ GameFrame::GameFrame(wxWindow *p_parent, const std::shared_ptr<GameDocument> &p_
   entries[7].Set(wxACCEL_CTRL, '=', GBT_MENU_VIEW_ZOOMIN);
   entries[8].Set(wxACCEL_CTRL, '-', GBT_MENU_VIEW_ZOOMOUT);
   entries[9].Set(wxACCEL_CTRL, '0', GBT_MENU_VIEW_ZOOM100);
-  const wxAcceleratorTable accel(10, entries);
+  entries[10].Set(wxACCEL_CTRL, 'z', wxID_UNDO);
+  entries[11].Set(wxACCEL_CTRL | wxACCEL_SHIFT, 'z', wxID_REDO);
+  const wxAcceleratorTable accel(12, entries);
   wxWindowBase::SetAcceleratorTable(accel);
 
   m_splitter = new wxSplitterWindow(this, wxID_ANY);
@@ -311,6 +315,11 @@ void GameFrame::OnUpdate()
 
   wxMenuBar *menuBar = GetMenuBar();
 
+  menuBar->Enable(wxID_UNDO, m_doc->CanUndo());
+  menuBar->Enable(wxID_REDO, m_doc->CanRedo());
+  GetToolBar()->EnableTool(wxID_UNDO, m_doc->CanUndo());
+  GetToolBar()->EnableTool(wxID_REDO, m_doc->CanRedo());
+
   GetToolBar()->EnableTool(GBT_MENU_EDIT_NEWPLAYER, !m_efgPanel || m_efgPanel->IsShown());
 
   menuBar->Enable(GBT_MENU_VIEW_PROFILES, m_doc->GetWorkspace().NumProfileLists() > 0);
@@ -354,9 +363,11 @@ void GameFrame::OnUpdate()
 #include "bitmaps/preview.xpm"
 #include "bitmaps/print.xpm"
 #include "bitmaps/profiles.xpm"
+#include "bitmaps/redo.xpm"
 #include "bitmaps/save.xpm"
 #include "bitmaps/saveas.xpm"
 #include "bitmaps/table.xpm"
+#include "bitmaps/undo.xpm"
 #include "bitmaps/zoomfit.xpm"
 #include "bitmaps/zoomin.xpm"
 #include "bitmaps/zoomout.xpm"
@@ -430,6 +441,11 @@ void GameFrame::MakeMenus()
   AppendBitmapItem(fileMenu, wxID_EXIT, _("E&xit\tCtrl-Q"), _("Exit Gambit"), wxBitmap(exit_xpm));
 
   auto *editMenu = new wxMenu;
+  AppendBitmapItem(editMenu, wxID_UNDO, _("&Undo\tCtrl-Z"), _("Undo the last change"),
+                   wxBitmap(undo_xpm));
+  AppendBitmapItem(editMenu, wxID_REDO, _("&Redo\tShift-Ctrl-Z"), _("Redo the last undone change"),
+                   wxBitmap(redo_xpm));
+  editMenu->AppendSeparator();
   AppendBitmapItem(editMenu, GBT_MENU_EDIT_NEWPLAYER, _("Add p&layer"),
                    _("Add a new player to the game"), wxBitmap(newplayer_xpm));
 
@@ -515,6 +531,13 @@ void GameFrame::MakeToolbar()
                    _("Save this game"), _("Save this game"), nullptr);
   toolBar->AddTool(wxID_SAVEAS, wxEmptyString, wxBitmap(saveas_xpm), wxNullBitmap, wxITEM_NORMAL,
                    _("Save to a different file"), _("Save this game to another file"), nullptr);
+
+  toolBar->AddSeparator();
+
+  toolBar->AddTool(wxID_UNDO, wxEmptyString, wxBitmap(undo_xpm), wxNullBitmap, wxITEM_NORMAL,
+                   _("Undo the last change"), _("Undo the last change"), nullptr);
+  toolBar->AddTool(wxID_REDO, wxEmptyString, wxBitmap(redo_xpm), wxNullBitmap, wxITEM_NORMAL,
+                   _("Redo the last undone change"), _("Redo the last undone change"), nullptr);
 
   toolBar->AddSeparator();
 
@@ -873,6 +896,10 @@ void GameFrame::OnFileMRUFile(wxCommandEvent &p_event)
 //----------------------------------------------------------------------
 //                GameFrame: Menu handlers - Edit menu
 //----------------------------------------------------------------------
+
+void GameFrame::OnEditUndo(wxCommandEvent &) { m_doc->Undo(); }
+
+void GameFrame::OnEditRedo(wxCommandEvent &) { m_doc->Redo(); }
 
 void GameFrame::OnEditGame(wxCommandEvent &)
 {

--- a/src/gui/gameframe.h
+++ b/src/gui/gameframe.h
@@ -66,6 +66,9 @@ class GameFrame final : public wxFrame, public GameView {
   void OnFileExit(wxCommandEvent &);
   void OnFileMRUFile(wxCommandEvent &);
 
+  void OnEditUndo(wxCommandEvent &);
+  void OnEditRedo(wxCommandEvent &);
+
   void OnEditGame(wxCommandEvent &);
 
   void OnEditNewPlayer(wxCommandEvent &);


### PR DESCRIPTION
This returns undo/redo functionality to the graphical interface.

This is essentially the same mechanism as was previously used before it was withdrawn temporarily. The problems underlying undo/redo - holding onto references to game objects rather than working from the game object each time - have now been fixed.
