### PR TITLE
A few improvements to the build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,6 @@
 ## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 ##
 
-ACLOCAL_AMFLAGS = -I m4
-
 include build_support/catalog/catalog.am
 
 EXTRA_DIST = \
@@ -348,11 +346,8 @@ if WITH_GUI
 bin_PROGRAMS = gambit
 endif
 
-# Read version from GAMBIT_VERSION file for use in compilation
-GAMBIT_VERSION = $(shell cat $(top_srcdir)/build_support/GAMBIT_VERSION)
-
 # Define VERSION for all C++ compilations and set include paths
-AM_CPPFLAGS = -I$(top_srcdir)/src -DVERSION=\"$(GAMBIT_VERSION)\"
+AM_CPPFLAGS = -I$(top_srcdir)/src -DVERSION=\"$(VERSION)\"
 
 AM_CXXFLAGS = ${LLVM_CXXFLAGS}
 
@@ -485,6 +480,6 @@ msw-msi:
 	light -ext WixUIExtension gambit.wixobj
 
 clang-tidy:
-	clang-tidy ${top_srcdir}/src/core/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(GAMBIT_VERSION)\"
-	clang-tidy ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(GAMBIT_VERSION)\"
-	clang-tidy ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(GAMBIT_VERSION)\"
+	clang-tidy ${top_srcdir}/src/core/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"
+	clang-tidy ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"
+	clang-tidy ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -420,8 +420,6 @@ AC_DEFUN([AM_PATH_WXRC],
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 18
-
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,6 @@ dnl
 AC_INIT([gambit],[m4_esyscmd_s([cat build_support/GAMBIT_VERSION])])
 AC_CONFIG_SRCDIR([src/gambit.h])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
-dnl AC_CONFIG_MACRO_DIR([m4])
 AM_OPTIONS_WXCONFIG
 
 dnl User-specified options
@@ -50,7 +49,6 @@ dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_RANLIB
-dnl LT_INIT
 AM_PROG_CC_C_O
 MINGW_AC_WIN32_NATIVE_HOST
 AM_CONDITIONAL(IS_WIN32, [test x$mingw_cv_win32_host = xyes])
@@ -149,7 +147,7 @@ AC_SUBST(WX_CXXFLAGS)
 REZFLAGS=`echo $CXXFLAGS $WX_CXXFLAGS | sed 's/-mthreads//g' | sed 's/-g//g' | sed 's/-O. / /g' | sed 's/-I/--include-dir /g'`
 AC_SUBST(REZFLAGS)
 
-GAMBIT_VERSION=`cat build_support/GAMBIT_VERSION`
+GAMBIT_VERSION=$VERSION
 AC_SUBST(GAMBIT_VERSION)
 
 dnl WiX requires the Product/@Version attribute to be a purely numeric

--- a/doc/developer.contributing.rst
+++ b/doc/developer.contributing.rst
@@ -309,7 +309,21 @@ When making a new release of Gambit, follow these steps:
    - `doc/conf.py` reads from GAMBIT_VERSION file at documentation build time
    - Documentation pages reference the `|release|` substitution variable to automatically reflect the updated version number.
 
-   The Windows ``.msi`` installer is the one exception: Windows Installer's ``ProductVersion``
+   .. note::
+
+      The C++ build is the one case that does *not* pick up the change automatically.
+      ``configure.ac`` embeds the version via ``AC_INIT`` at *autoconf-generation* time,
+      not at ``./configure``-run time, so the version baked into the ``configure`` script
+      (and from there into ``make dist`` tarball names, ``Makefile``, and the compiled
+      binaries) stays stale until ``configure`` is regenerated. Autoconf's own
+      ``autom4te.cache`` can also serve a stale cached expansion even when you do
+      regenerate, since it isn't aware that ``configure.ac`` depends on the contents of
+      ``GAMBIT_VERSION``. After editing ``GAMBIT_VERSION``, always force a full
+      regeneration before building or running ``make dist``::
+
+          rm -rf autom4te.cache && autoreconf -fi
+
+   The Windows ``.msi`` installer is another exception: Windows Installer's ``ProductVersion``
    must be a plain numeric ``major.minor.build`` triple.  So, ``configure.ac`` derives a separate
    ``GAMBIT_MSI_VERSION`` for ``gambit.wxs`` instead of substituting ``GAMBIT_VERSION`` directly.
    The build field is banded by release stage so that alpha < beta < rc < the final release of


### PR DESCRIPTION
* Tidy up how version number is pulled in
* Clean up a few warnings
* Add a note to the developer documentation on needing to autoreconf after version number changes.
