### PR TITLE
Cleanups to coding standards checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: |
   -*,
+  clang-diagnostic-*,
   bugprone-reserved-identifier,
   modernize-*,
   -modernize-use-trailing-return-type,
@@ -14,42 +15,15 @@ Checks: |
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle:     none
-User:            arbiter
 CheckOptions:
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           'false'
   - key:             modernize-loop-convert.MinConfidence
     value:           reasonable
   - key:             modernize-replace-auto-ptr.IncludeStyle
     value:           llvm
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           'false'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           'false'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           'true'
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           'true'
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           'false'
   - key:             modernize-loop-convert.NamingStyle
     value:           CamelCase
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           'false'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
 ...

--- a/Makefile.am
+++ b/Makefile.am
@@ -480,6 +480,4 @@ msw-msi:
 	light -ext WixUIExtension gambit.wixobj
 
 clang-tidy:
-	clang-tidy ${top_srcdir}/src/core/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code
-	clang-tidy ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code
-	clang-tidy ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code
+	clang-tidy ${top_srcdir}/src/core/*.cc ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code -Wextra-semi -Wdouble-promotion

--- a/Makefile.am
+++ b/Makefile.am
@@ -349,7 +349,7 @@ endif
 # Define VERSION for all C++ compilations and set include paths
 AM_CPPFLAGS = -I$(top_srcdir)/src -DVERSION=\"$(VERSION)\"
 
-AM_CXXFLAGS = ${LLVM_CXXFLAGS}
+AM_CXXFLAGS = ${LLVM_CXXFLAGS} -Wall -Wsign-compare -Wunreachable-code
 
 ## Convenience libraries
 ##
@@ -480,6 +480,6 @@ msw-msi:
 	light -ext WixUIExtension gambit.wixobj
 
 clang-tidy:
-	clang-tidy ${top_srcdir}/src/core/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"
-	clang-tidy ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"
-	clang-tidy ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\"
+	clang-tidy ${top_srcdir}/src/core/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code
+	clang-tidy ${top_srcdir}/src/games/*.cc ${top_srcdir}/src/games/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code
+	clang-tidy ${top_srcdir}/src/solvers/*/*.cc -- --std=c++20 -I ${top_srcdir}/src -DVERSION=\"$(VERSION)\" -Wall -Wsign-compare -Wunreachable-code

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -78,85 +78,87 @@ void ConjugatePRMinimizer::AlphaXPlusY(double alpha, const Vector<double> &x, Ve
 // These routines are drawn from comparably-named ones in
 // multimin/directional_minimize.c in GSL.
 
-void ConjugatePRMinimizer::TakeStep(const Vector<double> &x, const Vector<double> &p, double step,
-                                    double lambda, Vector<double> &x1, Vector<double> &dx)
+void ConjugatePRMinimizer::TakeStep(const Vector<double> &p_x, const Vector<double> &p_p,
+                                    double p_step, double p_lambda, Vector<double> &p_x1,
+                                    Vector<double> &p_dx)
 {
-  dx = 0.0;
-  AlphaXPlusY(-step * lambda, p, dx);
-  x1 = x;
-  AlphaXPlusY(1.0, dx, x1);
+  p_dx = 0.0;
+  AlphaXPlusY(-p_step * p_lambda, p_p, p_dx);
+  p_x1 = p_x;
+  AlphaXPlusY(1.0, p_dx, p_x1);
 }
 
-void ConjugatePRMinimizer::IntermediatePoint(const Function &fdf, const Vector<double> &x,
-                                             const Vector<double> &p, double lambda, double pg,
-                                             double stepa, double stepc, double fa, double fc,
-                                             Vector<double> &x1, Vector<double> &dx,
-                                             Vector<double> &gradient, double &step, double &f)
+void ConjugatePRMinimizer::IntermediatePoint(const Function &p_fdf, const Vector<double> &p_x,
+                                             const Vector<double> &p_p, double p_lambda,
+                                             double p_pg, double p_stepa, double p_stepc,
+                                             double p_fa, double p_fc, Vector<double> &p_x1,
+                                             Vector<double> &p_dx, Vector<double> &p_gradient,
+                                             double &p_step, double &p_f)
 {
   double stepb, fb;
 
 trial:
-  const double u = fabs(pg * lambda * stepc);
-  if ((fc - fa) + u == 0) {
+  const double u = fabs(p_pg * p_lambda * p_stepc);
+  if ((p_fc - p_fa) + u == 0) {
     // TLT: Added this check 2002/08/31 due to floating point exceptions
     // under MSW.  Not really sure how to handle this correctly.
     throw FunctionMinimizerError();
   }
-  stepb = 0.5 * stepc * u / ((fc - fa) + u);
+  stepb = 0.5 * p_stepc * u / ((p_fc - p_fa) + u);
 
-  TakeStep(x, p, stepb, lambda, x1, dx);
+  TakeStep(p_x, p_p, stepb, p_lambda, p_x1, p_dx);
 
-  fb = fdf.Value(x1);
+  fb = p_fdf.Value(p_x1);
 
-  if (fb >= fa && stepb > 0.0) {
+  if (fb >= p_fa && stepb > 0.0) {
     /* downhill step failed, reduce step-size and try again */
-    fc = fb;
-    stepc = stepb;
+    p_fc = fb;
+    p_stepc = stepb;
     goto trial;
   }
 
-  step = stepb;
-  f = fb;
-  fdf.Gradient(x1, gradient);
+  p_step = stepb;
+  p_f = fb;
+  p_fdf.Gradient(p_x1, p_gradient);
 }
 
-void ConjugatePRMinimizer::Minimize(const Function &fdf, const Vector<double> &x,
-                                    const Vector<double> &p, double lambda, double stepa,
-                                    double stepb, double stepc, double fa, double fb, double fc,
-                                    double tol, Vector<double> &x1, Vector<double> &dx1,
-                                    Vector<double> &x2, Vector<double> &dx2,
-                                    Vector<double> &gradient, double &step, double &f,
-                                    double &gnorm)
+void ConjugatePRMinimizer::Minimize(const Function &p_fdf, const Vector<double> &p_x,
+                                    const Vector<double> &p_p, double p_lambda, double p_stepa,
+                                    double p_stepb, double p_stepc, double p_fa, double p_fb,
+                                    double p_fc, double p_tol, Vector<double> &p_x1,
+                                    Vector<double> &p_dx1, Vector<double> &p_x2,
+                                    Vector<double> &p_dx2, Vector<double> &p_gradient,
+                                    double &p_step, double &p_f, double &p_gnorm)
 {
   /* Starting at (x0, f0) move along the direction p to find a minimum
      f(x0 - lambda * p), returning the new point x1 = x0-lambda*p,
      f1=f(x1) and g1 = grad(f) at x1.  */
 
-  double u = stepb;
-  double v = stepa;
-  double w = stepc;
-  double fu = fb;
-  double fv = fa;
-  double fw = fc;
+  double u = p_stepb;
+  double v = p_stepa;
+  double w = p_stepc;
+  double fu = p_fb;
+  double fv = p_fa;
+  double fw = p_fc;
 
   double old2 = fabs(w - v);
   double old1 = fabs(v - u);
 
   double stepm, fm, pg, gnorm1;
 
-  double iter = 0;
+  double num_trials = 0;
 
-  x2 = x1;
-  dx2 = dx1;
+  p_x2 = p_x1;
+  p_dx2 = p_dx1;
 
-  f = fb;
-  step = stepb;
-  gnorm = std::sqrt(gradient.NormSquared());
+  p_f = p_fb;
+  p_step = p_stepb;
+  p_gnorm = std::sqrt(p_gradient.NormSquared());
 
 mid_trial:
-  iter++;
+  num_trials++;
 
-  if (iter > 10) {
+  if (num_trials > 10) {
     return; /* MAX ITERATIONS */
   }
 
@@ -171,24 +173,24 @@ mid_trial:
     du = e1 / e2;
   }
 
-  if (du > 0 && du < (stepc - stepb) && fabs(du) < 0.5 * old2) {
+  if (du > 0 && du < (p_stepc - p_stepb) && fabs(du) < 0.5 * old2) {
     stepm = u + du;
   }
-  else if (du < 0 && du > (stepa - stepb) && fabs(du) < 0.5 * old2) {
+  else if (du < 0 && du > (p_stepa - p_stepb) && fabs(du) < 0.5 * old2) {
     stepm = u + du;
   }
-  else if ((stepc - stepb) > (stepb - stepa)) {
-    stepm = 0.38 * (stepc - stepb) + stepb;
+  else if ((p_stepc - p_stepb) > (p_stepb - p_stepa)) {
+    stepm = 0.38 * (p_stepc - p_stepb) + p_stepb;
   }
   else {
-    stepm = stepb - 0.38 * (stepb - stepa);
+    stepm = p_stepb - 0.38 * (p_stepb - p_stepa);
   }
 
-  TakeStep(x, p, stepm, lambda, x1, dx1);
+  TakeStep(p_x, p_p, stepm, p_lambda, p_x1, p_dx1);
 
-  fm = fdf.Value(x1);
+  fm = p_fdf.Value(p_x1);
 
-  if (fm > fb) {
+  if (fm > p_fb) {
     if (fm < fv) {
       w = v;
       v = stepm;
@@ -200,17 +202,17 @@ mid_trial:
       fw = fm;
     }
 
-    if (stepm < stepb) {
-      stepa = stepm;
-      fa = fm;
+    if (stepm < p_stepb) {
+      p_stepa = stepm;
+      p_fa = fm;
     }
     else {
-      stepc = stepm;
-      fc = fm;
+      p_stepc = stepm;
+      p_fc = fm;
     }
     goto mid_trial;
   }
-  else if (fm <= fb) {
+  else if (fm <= p_fb) {
     old2 = old1;
     old1 = fabs(u - stepm);
     w = v;
@@ -220,36 +222,36 @@ mid_trial:
     fv = fu;
     fu = fm;
 
-    x2 = x1;
-    dx2 = dx1;
+    p_x2 = p_x1;
+    p_dx2 = p_dx1;
 
-    fdf.Gradient(x1, gradient);
-    pg = p * gradient;
-    gnorm1 = std::sqrt(gradient.NormSquared());
+    p_fdf.Gradient(p_x1, p_gradient);
+    pg = p_p * p_gradient;
+    gnorm1 = std::sqrt(p_gradient.NormSquared());
 
-    f = fm;
-    step = stepm;
-    gnorm = gnorm1;
+    p_f = fm;
+    p_step = stepm;
+    p_gnorm = gnorm1;
 
     if (gnorm1 == 0.0) {
       return;
     }
 
-    if (fabs(pg * lambda / gnorm1) < tol) {
+    if (fabs(pg * p_lambda / gnorm1) < p_tol) {
       return; /* SUCCESS */
     }
 
-    if (stepm < stepb) {
-      stepc = stepb;
-      fc = fb;
-      stepb = stepm;
-      fb = fm;
+    if (stepm < p_stepb) {
+      p_stepc = p_stepb;
+      p_fc = p_fb;
+      p_stepb = stepm;
+      p_fb = fm;
     }
     else {
-      stepa = stepb;
-      fa = fb;
-      stepb = stepm;
-      fb = fm;
+      p_stepa = p_stepb;
+      p_fa = p_fb;
+      p_stepb = stepm;
+      p_fb = fm;
     }
     goto mid_trial;
   }

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -91,17 +91,18 @@ private:
   Vector<double> g0;
 
   void AlphaXPlusY(double alpha, const Vector<double> &x, Vector<double> &y);
-  void TakeStep(const Vector<double> &x, const Vector<double> &p, double step, double lambda,
-                Vector<double> &x1, Vector<double> &dx);
-  void IntermediatePoint(const Function &fdf, const Vector<double> &x, const Vector<double> &p,
-                         double lambda, double pg, double stepa, double stepc, double fa,
-                         double fc, Vector<double> &x1, Vector<double> &dx,
-                         Vector<double> &gradient, double &step, double &f);
-  void Minimize(const Function &fdf, const Vector<double> &x, const Vector<double> &p,
-                double lambda, double stepa, double stepb, double stepc, double fa, double fb,
-                double fc, double tol, Vector<double> &x1, Vector<double> &dx1, Vector<double> &x2,
-                Vector<double> &dx2, Vector<double> &gradient, double &step, double &f,
-                double &gnorm);
+  void TakeStep(const Vector<double> &p_x, const Vector<double> &p_p, double p_step,
+                double p_lambda, Vector<double> &p_x1, Vector<double> &p_dx);
+  void IntermediatePoint(const Function &p_fdf, const Vector<double> &p_x,
+                         const Vector<double> &p_p, double p_lambda, double p_pg, double p_stepa,
+                         double p_stepc, double p_fa, double p_fc, Vector<double> &p_x1,
+                         Vector<double> &p_dx, Vector<double> &p_gradient, double &p_step,
+                         double &p_f);
+  void Minimize(const Function &p_fdf, const Vector<double> &p_x, const Vector<double> &p_p,
+                double p_lambda, double p_stepa, double p_stepb, double p_stepc, double p_fa,
+                double p_fb, double p_fc, double p_tol, Vector<double> &p_x1,
+                Vector<double> &p_dx1, Vector<double> &p_x2, Vector<double> &p_dx2,
+                Vector<double> &p_gradient, double &p_step, double &p_f, double &p_gnorm);
 };
 
 } // end namespace Gambit

--- a/src/core/integer.cc
+++ b/src/core/integer.cc
@@ -175,10 +175,14 @@ static IntegerRep *Inew(int newlen)
     allocsiz <<= 1; // find a power of 2
   }
   allocsiz -= MALLOC_MIN_OVERHEAD;
-  // assert((unsigned long) allocsiz < MAX_INTREP_SIZE * sizeof(short));
+
+  const unsigned int repSize = (allocsiz - sizeof(IntegerRep) + sizeof(short)) / sizeof(short);
+  if (repSize > std::numeric_limits<unsigned short>::max()) {
+    throw std::overflow_error("Integer: requested precision too large");
+  }
 
   auto *rep = reinterpret_cast<IntegerRep *>(new char[allocsiz]);
-  rep->sz = (allocsiz - sizeof(IntegerRep) + sizeof(short)) / sizeof(short);
+  rep->sz = static_cast<unsigned short>(repSize);
   return rep;
 }
 

--- a/src/core/integer.h
+++ b/src/core/integer.h
@@ -209,8 +209,8 @@ public:
 
   // coercion & conversion
 
-  int fits_in_long() const { return Iislong(rep); }
-  int fits_in_double() const { return Iisdouble(rep); }
+  bool fits_in_long() const { return Iislong(rep); }
+  bool fits_in_double() const { return Iisdouble(rep); }
 
   long as_long() const { return Itolong(rep); }
   double as_double() const { return Itodouble(rep); }

--- a/src/core/rational.cc
+++ b/src/core/rational.cc
@@ -368,8 +368,10 @@ bool Rational::OK() const
 
 bool Rational::fits_in_float() const
 {
+  // NOLINTBEGIN(clang-diagnostic-double-promotion)
   return Rational(std::numeric_limits<float>::min()) <= *this &&
          *this <= Rational(std::numeric_limits<float>::max());
+  // NOLINTEND(clang-diagnostic-double-promotion)
 }
 
 bool Rational::fits_in_double() const

--- a/src/core/rational.cc
+++ b/src/core/rational.cc
@@ -160,7 +160,7 @@ Rational::Rational(double x) : num(0), den(1)
       mantissa *= width;
       mantissa = modf(mantissa, &intpart);
       num <<= shift;
-      num += (long)intpart;
+      num += static_cast<long>(intpart);
       exponent -= shift;
     }
     if (exponent > 0) {
@@ -306,7 +306,7 @@ std::istream &operator>>(std::istream &f, Rational &y)
   }
   while (ch >= '0' && ch <= '9') {
     num *= 10;
-    num += (int)(ch - '0');
+    num += (ch - '0');
     f.get(ch);
     if (f.eof() || f.bad()) {
       ch = ' ';
@@ -321,7 +321,7 @@ std::istream &operator>>(std::istream &f, Rational &y)
     }
     while (ch >= '0' && ch <= '9') {
       denom *= 10;
-      denom += (int)(ch - '0');
+      denom += (ch - '0');
       f.get(ch);
       if (f.eof() || f.bad()) {
         ch = ' ';
@@ -337,7 +337,7 @@ std::istream &operator>>(std::istream &f, Rational &y)
     while (ch >= '0' && ch <= '9') {
       denom *= 10;
       num *= 10;
-      num += (int)(ch - '0');
+      num += (ch - '0');
       f.get(ch);
       if (f.eof() || f.bad()) {
         ch = ' ';
@@ -529,7 +529,7 @@ template <> Rational lexical_cast(const std::string &f)
 
   while (ch >= '0' && ch <= '9' && index <= length) {
     num *= 10;
-    num += (int)(ch - '0');
+    num += (ch - '0');
     ch = f[index++];
   }
 
@@ -538,7 +538,7 @@ template <> Rational lexical_cast(const std::string &f)
     ch = f[index++];
     while (ch >= '0' && ch <= '9' && index <= length) {
       denom *= 10;
-      denom += (int)(ch - '0');
+      denom += (ch - '0');
       ch = f[index++];
     }
   }
@@ -548,7 +548,7 @@ template <> Rational lexical_cast(const std::string &f)
     while (ch >= '0' && ch <= '9' && index <= length) {
       denom *= 10;
       num *= 10;
-      num += (int)(ch - '0');
+      num += (ch - '0');
       ch = f[index++];
     }
 
@@ -562,7 +562,7 @@ template <> Rational lexical_cast(const std::string &f)
       }
       while (ch >= '0' && ch <= '9' && index <= length) {
         exponent *= 10;
-        exponent += (int)(ch - '0');
+        exponent += (ch - '0');
         ch = f[index++];
       }
       if (exponent * expsign > 0) {
@@ -589,7 +589,7 @@ template <> Rational lexical_cast(const std::string &f)
     }
     while (ch >= '0' && ch <= '9' && index <= length) {
       exponent *= 10;
-      exponent += (int)(ch - '0');
+      exponent += (ch - '0');
       ch = f[index++];
     }
     if (exponent * expsign > 0) {

--- a/src/core/rational.cc
+++ b/src/core/rational.cc
@@ -27,7 +27,7 @@ Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include <iostream>
 #include <cmath>
-#include <cfloat>
+#include <limits>
 #include <cctype>
 
 #include "util.h"
@@ -366,14 +366,16 @@ bool Rational::OK() const
   return v;
 }
 
-int Rational::fits_in_float() const
+bool Rational::fits_in_float() const
 {
-  return Rational(FLT_MIN) <= *this && *this <= Rational(FLT_MAX);
+  return Rational(std::numeric_limits<float>::min()) <= *this &&
+         *this <= Rational(std::numeric_limits<float>::max());
 }
 
-int Rational::fits_in_double() const
+bool Rational::fits_in_double() const
 {
-  return Rational(DBL_MIN) <= *this && *this <= Rational(DBL_MAX);
+  return Rational(std::numeric_limits<double>::min()) <= *this &&
+         *this <= Rational(std::numeric_limits<double>::max());
 }
 
 //

--- a/src/core/rational.h
+++ b/src/core/rational.h
@@ -103,8 +103,8 @@ public:
   friend std::istream &operator>>(std::istream &s, Rational &y);
   friend std::ostream &operator<<(std::ostream &s, const Rational &y);
 
-  int fits_in_float() const;
-  int fits_in_double() const;
+  bool fits_in_float() const;
+  bool fits_in_double() const;
 
   // procedural versions of operators
 

--- a/src/games/agg/agg.cc
+++ b/src/games/agg/agg.cc
@@ -219,7 +219,7 @@ std::shared_ptr<AGG> AGG::makeAGG(istream &in)
       throw std::runtime_error("Error in game file: expected integer for type of function node #" +
                                std::to_string(i));
     }
-    projTypes[i] = make_proj_func((TypeEnum)pt, in, S, P);
+    projTypes[i] = make_proj_func(static_cast<TypeEnum>(pt), in, S, P);
   }
 
   vector<vector<ConfigDistribution<double>>> projS;
@@ -673,7 +673,7 @@ double AGG::getSymMixedPayoff(StrategyProfile<double> &s)
   }
 
   for (int node = 0; node < numActionNodes; ++node) {
-    if (s[node] > (double)0.0) {
+    if (s[node] > 0.0) {
       result += s[node] * getSymMixedPayoff(node, s);
     }
   }
@@ -715,12 +715,12 @@ double AGG::getSymMixedPayoff(int node, StrategyProfile<double> &s)
     if (neighbors[node][i] == node) {
       self = i;
     }
-    if (s[neighbors[node][i]] > (double)0) {
+    if (s[neighbors[node][i]] > 0) {
       support.push_back(i);
       null_prob -= s[neighbors[node][i]];
     }
   }
-  if (numNei < numActionNodes && null_prob > (double)0) {
+  if (numNei < numActionNodes && null_prob > 0) {
     support.push_back(-1);
   }
 
@@ -753,7 +753,7 @@ double AGG::getSymMixedPayoff(int node, StrategyProfile<double> &s)
     const double i_prob = (support.at(gc.i) != -1) ? s[neighbors[node][support[gc.i]]] : null_prob;
     const double d_prob = (support.at(gc.d) != -1) ? s[neighbors[node][support[gc.d]]] : null_prob;
     assert(i_prob > (double)0 && d_prob > (double)0);
-    prob *= ((double)(gc.get().at(gc.d) + 1)) * i_prob / (double)(gc.get().at(gc.i)) / d_prob;
+    prob *= (gc.get().at(gc.d) + 1) * i_prob / gc.get().at(gc.i) / d_prob;
 
   } // end while
 
@@ -785,7 +785,7 @@ void AGG::getSymConfigProb(int plClass, StrategyProfile<double> &s, int ownPlCla
     m_state.projectedStrat[node][player].reset();
     if (numPl > 0) {
       for (int j = 0; j < actions[player]; j++) {
-        if (s[j] > (double)0.0) {
+        if (s[j] > 0.0) {
           m_state.projectedStrat[node][player] += make_pair(projection[node][player][j], s[j]);
         }
       }
@@ -833,12 +833,12 @@ void AGG::getSymConfigProb(int plClass, StrategyProfile<double> &s, int ownPlCla
     }
 
     const int a = node2Action.at(neighbors[node][i]).at(p);
-    if (a >= 0 && s[a] > (double)0) {
+    if (a >= 0 && s[a] > 0) {
       support.push_back(i);
       null_prob -= s[a];
     }
   }
-  if (null_prob > (double)0) {
+  if (null_prob > 0) {
     support.push_back(-1);
   }
 
@@ -880,7 +880,7 @@ void AGG::getSymConfigProb(int plClass, StrategyProfile<double> &s, int ownPlCla
     const double d_prob =
         (support.at(gc.d) != -1) ? s[node2Action[neighbors[node][support[gc.d]]][p]] : null_prob;
     assert(i_prob > (double)0 && d_prob > (double)0);
-    prob *= ((double)(gc.get().at(gc.d) + 1)) * i_prob / (double)(gc.get().at(gc.i)) / d_prob;
+    prob *= (gc.get().at(gc.d) + 1) * i_prob / gc.get().at(gc.i) / d_prob;
 
   } // end while
 }
@@ -889,8 +889,8 @@ double AGG::getKSymMixedPayoff(int playerClass, vector<StrategyProfile<double>> 
 {
   double result = 0.0;
 
-  for (int act = 0; act < (int)uniqueActionSets[playerClass].size(); act++) {
-    if (s[playerClass][act] > (double)0.0) {
+  for (int act = 0; act < static_cast<int>(uniqueActionSets[playerClass].size()); act++) {
+    if (s[playerClass][act] > 0.0) {
 
       result += s[playerClass][act] * getKSymMixedPayoff(playerClass, act, s);
     }
@@ -902,8 +902,8 @@ double AGG::getKSymMixedPayoff(int playerClass, StrategyProfile<double> &s)
 {
   double result = 0.0;
 
-  for (int act = 0; act < (int)uniqueActionSets[playerClass].size(); act++) {
-    if (s[firstKSymAction(playerClass) + act] > (double)0.0) {
+  for (int act = 0; act < static_cast<int>(uniqueActionSets[playerClass].size()); act++) {
+    if (s[firstKSymAction(playerClass) + act] > 0.0) {
 
       result += s[firstKSymAction(playerClass) + act] * getKSymMixedPayoff(s, playerClass, act);
     }

--- a/src/games/agg/agg.cc
+++ b/src/games/agg/agg.cc
@@ -22,7 +22,6 @@
 //
 
 #include <iostream>
-#include <cassert>
 #include <algorithm>
 #include <type_traits>
 #include "games/agg/gray.h"
@@ -331,7 +330,9 @@ void AGG::setProjections(vector<vector<ConfigDistribution<double>>> &projS,
           }
           else if (neighb[Node][k] >= S) {
             const projtype f = projTypes[neighb[Node][k] - S];
-            assert(f);
+            if (!f) {
+              throw ValueException("AGG: encountered a null projection function");
+            }
             const pair<multiset<int>::iterator, multiset<int>::iterator> p =
                 an[neighb[Node][k] - S].equal_range(AS[i][j]);
             multiset<int> blah(p.first, p.second);
@@ -446,7 +447,9 @@ template void AGG::doProjection<Rational>(int Node, int i, Rational *s);
 
 template <class V> V AGG::getPurePayoff(int player, const std::vector<int> &s) const
 {
-  assert(player >= 0 && player < numPlayers);
+  if (player < 0 || player >= numPlayers) {
+    throw ValueException("AGG::getPurePayoff: player index out of range");
+  }
   const int Node = actionSets[player][s[player]];
   const int keylen = neighbors[Node].size();
   Config pureprofile(projection[Node][0][s[0]]);
@@ -634,7 +637,9 @@ template Rational AGG::payoffInnerProd<Rational>(int node,
 template <class V> V AGG::getMixedPayoff(int player, const StrategyProfile<V> &s)
 {
   V result(0);
-  assert(player >= 0 && player < numPlayers);
+  if (player < 0 || player >= numPlayers) {
+    throw ValueException("AGG::getMixedPayoff: player index out of range");
+  }
   for (int act = 0; act < actions[player]; ++act) {
     if (s[act + firstAction(player)] > V(0)) {
       result += s[act + firstAction(player)] * getV(player, act, s);
@@ -645,7 +650,9 @@ template <class V> V AGG::getMixedPayoff(int player, const StrategyProfile<V> &s
 
 void AGG::getPayoffVector(std::vector<double> &dest, int player, const StrategyProfile<double> &s)
 {
-  assert(player >= 0 && player < numPlayers);
+  if (player < 0 || player >= numPlayers) {
+    throw ValueException("AGG::getPayoffVector: player index out of range");
+  }
   for (int act = 0; act < actions[player]; ++act) {
     dest[act] = getV(player, act, s);
   }
@@ -696,7 +703,9 @@ double AGG::getSymMixedPayoff(int node, StrategyProfile<double> &s)
 
   if (!isPure[node]) { // then compute EU using trie_map::power()
     doProjection(node, 0, s);
-    assert(numPlayers > 1);
+    if (numPlayers <= 1) {
+      throw ValueException("AGG::getSymMixedPayoff: requires more than one player");
+    }
     // ConfigDistribution<double> *dest;
     // m_state.projectedStrat[node][0].power(numPlayers-1, dest, m_state.Pr,
     // numNei,projFunctions[node]);
@@ -752,7 +761,9 @@ double AGG::getSymMixedPayoff(int node, StrategyProfile<double> &s)
     // update prob
     const double i_prob = (support.at(gc.i) != -1) ? s[neighbors[node][support[gc.i]]] : null_prob;
     const double d_prob = (support.at(gc.d) != -1) ? s[neighbors[node][support[gc.d]]] : null_prob;
-    assert(i_prob > (double)0 && d_prob > (double)0);
+    if (i_prob <= 0 || d_prob <= 0) {
+      throw ValueException("AGG::getSymMixedPayoff: probabilities must be positive");
+    }
     prob *= (gc.get().at(gc.d) + 1) * i_prob / gc.get().at(gc.i) / d_prob;
 
   } // end while
@@ -769,7 +780,9 @@ void AGG::getSymConfigProb(int plClass, StrategyProfile<double> &s, int ownPlCla
 {
   const int node = uniqueActionSets.at(ownPlClass).at(act);
   int numPl = playerClasses.at(plClass).size();
-  assert(numPl > 0);
+  if (numPl <= 0) {
+    throw ValueException("AGG::getSymConfigProb: player class must be non-empty");
+  }
 
   if (plClass == ownPlClass) {
     numPl--;
@@ -879,7 +892,9 @@ void AGG::getSymConfigProb(int plClass, StrategyProfile<double> &s, int ownPlCla
         (support.at(gc.i) != -1) ? s[node2Action[neighbors[node][support[gc.i]]][p]] : null_prob;
     const double d_prob =
         (support.at(gc.d) != -1) ? s[node2Action[neighbors[node][support[gc.d]]][p]] : null_prob;
-    assert(i_prob > (double)0 && d_prob > (double)0);
+    if (i_prob <= 0 || d_prob <= 0) {
+      throw ValueException("AGG::getSymConfigProb: probabilities must be positive");
+    }
     prob *= (gc.get().at(gc.d) + 1) * i_prob / gc.get().at(gc.i) / d_prob;
 
   } // end while
@@ -991,7 +1006,9 @@ void AGG::makeMAPPINGpayoff(std::istream &in, PayoffTable &pay, ExactPayoffTable
     }
 
     c = in.get();
-    assert(in.good());
+    if (!in.good()) {
+      throw std::runtime_error("ERROR: unexpected end of input while reading configuration");
+    }
     if (c != AGG::LBRACKET) {
       throw std::runtime_error("ERROR: " + std::to_string(AGG::LBRACKET) +
                                " expected. Instead, got " + std::to_string(c));
@@ -1010,7 +1027,9 @@ void AGG::makeMAPPINGpayoff(std::istream &in, PayoffTable &pay, ExactPayoffTable
 
     in >> ws;
     c = in.get(); // get right bracket
-    assert(in.good());
+    if (!in.good()) {
+      throw std::runtime_error("ERROR: unexpected end of input while reading configuration");
+    }
 
     if (c != AGG::RBRACKET) {
       throw std::runtime_error("ERROR: " + std::to_string(AGG::RBRACKET) +
@@ -1059,7 +1078,9 @@ void AGG::makeMAPPINGpayoff(std::istream &in, PayoffTable &pay, ExactPayoffTable
 
 template <class V> V AGG::getMaxPayoff() const
 {
-  assert(numActionNodes > 0);
+  if (numActionNodes <= 0) {
+    throw ValueException("AGG::getMaxPayoff: game has no action nodes");
+  }
   if constexpr (std::is_same_v<V, Rational>) {
     Rational result = static_cast<Rational>(exactPayoffs[0].begin()->second);
     for (int i = 0; i < numActionNodes; i++) {
@@ -1082,7 +1103,9 @@ template <class V> V AGG::getMaxPayoff() const
 
 template <class V> V AGG::getMinPayoff() const
 {
-  assert(numActionNodes > 0);
+  if (numActionNodes <= 0) {
+    throw ValueException("AGG::getMinPayoff: game has no action nodes");
+  }
   if constexpr (std::is_same_v<V, Rational>) {
     Rational result = static_cast<Rational>(exactPayoffs[0].begin()->second);
     for (int i = 0; i < numActionNodes; i++) {

--- a/src/games/agg/bagg.cc
+++ b/src/games/agg/bagg.cc
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
-#include <cassert>
 #include <type_traits>
 #include "games/agg/bagg.h"
 
@@ -209,7 +208,9 @@ template <class V> V BAGG::getMixedPayoff(int player, int tp, const StrategyProf
 void BAGG::getPayoffVector(std::vector<double> &dest, int player, int tp,
                            const StrategyProfile<double> &s)
 {
-  assert(player >= 0 && player < getNumPlayers() && tp >= 0 && tp < getNumTypes(player));
+  if (player < 0 || player >= getNumPlayers() || tp < 0 || tp >= getNumTypes(player)) {
+    throw ValueException("BAGG::getPayoffVector: player or type index out of range");
+  }
   for (size_t act = 0; act < typeActionSets[player][tp].size(); ++act) {
     dest[act] = getV(player, tp, act, s);
   }

--- a/src/games/agg/trie_map.h
+++ b/src/games/agg/trie_map.h
@@ -50,7 +50,7 @@ template <class V> struct TrieNode {
 
   // constructor
   TrieNode(size_t branches, typename std::list<std::pair<std::vector<int>, V>>::iterator v)
-    : children(branches, (TrieNode *)nullptr), val(v)
+    : children(branches, nullptr), val(v)
   {
   }
 
@@ -60,7 +60,7 @@ template <class V> struct TrieNode {
       return children[i];
     }
     else {
-      children.resize(i + 1, (TrieNode *)nullptr);
+      children.resize(i + 1, nullptr);
       return children[i];
     }
   }
@@ -162,7 +162,7 @@ public:
   {
     size_t i = 0;
     TrieNode<V> *ptr = root;
-    for (; i < k.size() && k[i] < (int)ptr->children.size() && ptr->children[k[i]];
+    for (; i < k.size() && k[i] < static_cast<int>(ptr->children.size()) && ptr->children[k[i]];
          ptr = ptr->children[k[i++]]) {
     }
 
@@ -189,11 +189,11 @@ public:
              std::vector<projtype> &f);
 
   // inner product
-  V inner_prod(trie_map<V> &other, V init = (V)(0)) const;
+  V inner_prod(trie_map<V> &other, V init = static_cast<V>(0)) const;
 
   // first apply the action x, then inner prod
   V inner_prod(const std::vector<int> &x, size_t keylen, std::vector<projtype> &f,
-               trie_map<V> &other, V init = (V)(0)) const;
+               trie_map<V> &other, V init = static_cast<V>(0)) const;
 
   // polynomial division
   trie_map<V> &operator/=(const std::vector<V> &denom);

--- a/src/games/agg/trie_map.imp
+++ b/src/games/agg/trie_map.imp
@@ -40,7 +40,7 @@ trie_map<V>::insert(const trie_map<V>::value_type &x)
     // ind=x.first[i];
     ind = *(p++);
     if (ind >= ptr->children.size()) {
-      ptr->children.resize(ind + 1, (TrieNode<V> *)nullptr);
+      ptr->children.resize(ind + 1, nullptr);
     }
     if (ptr->children[ind] == nullptr) {
       ptr->children[ind] = new TrieNode<V>(initBranches, data.end());
@@ -62,7 +62,7 @@ typename trie_map<V>::iterator &trie_map<V>::find(const trie_map<V>::key_type &k
 {
   size_t i = 0;
   TrieNode<V> *ptr = root;
-  for (; i < k.size() && k[i] < (int)ptr->children.size() && ptr->children[k[i]];
+  for (; i < k.size() && k[i] < static_cast<int>(ptr->children.size()) && ptr->children[k[i]];
        ptr = ptr->children[k[i++]])
     ;
 
@@ -74,7 +74,7 @@ typename trie_map<V>::iterator trie_map<V>::findExact(const trie_map<V>::key_typ
 {
   size_t i = 0;
   TrieNode<V> *ptr = root;
-  for (; i < k.size() && k[i] < (int)ptr->children.size() && ptr->children[k[i]];
+  for (; i < k.size() && k[i] < static_cast<int>(ptr->children.size()) && ptr->children[k[i]];
        ptr = ptr->children[k[i++]])
     ;
 
@@ -128,14 +128,14 @@ void trie_map<V>::multiply(const trie_map<V> &t1, const trie_map<V> &t2, size_t 
   v.first.resize(keylen);
   reset();
   for (p1 = t1.begin(); p1 != t1.end(); ++p1) {
-    if ((*p1).second > (V)0) {
+    if ((*p1).second > static_cast<V>(0)) {
       for (p2 = t2.begin(); p2 != t2.end(); ++p2) {
-        if ((*p2).second > (V)0) {
+        if ((*p2).second > static_cast<V>(0)) {
           // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
-          v.second = (V)((*p1).second * (*p2).second);
+          v.second = (*p1).second * (*p2).second;
           (*this) += v;
         }
       } // end for(p2
@@ -161,21 +161,21 @@ void trie_map<V>::multiply(const trie_map<V> &other, size_t keylen, std::vector<
   TrieNode<V> *ptr;
 
   for (p1 = data2.begin(); p1 != data2.end(); ++p1) {
-    if ((*p1).second > (V)0.0) {
+    if ((*p1).second > static_cast<V>(0.0)) {
       for (auto p2 = other.begin(); p2 != other.end(); ++p2) {
-        if ((*p2).second > (V)0.0) {
+        if ((*p2).second > static_cast<V>(0.0)) {
           ptr = root;
           for (i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
-            if (v.first[i] >= (int)ptr->children.size()) {
-              ptr->children.resize(v.first[i] + 1, (TrieNode<V> *)nullptr);
+            if (v.first[i] >= static_cast<int>(ptr->children.size())) {
+              ptr->children.resize(v.first[i] + 1, nullptr);
             }
             if (ptr->children[v.first[i]] == nullptr) {
               ptr->children[v.first[i]] = new TrieNode<V>(initBranches, data.end());
             }
             ptr = ptr->children[v.first[i]];
           }
-          v.second = (V)((*p1).second * (*p2).second);
+          v.second = (*p1).second * (*p2).second;
           if (ptr->val != data.end()) {
             ptr->val->second += v.second;
           }
@@ -198,16 +198,16 @@ void trie_map<V>::square(trie_map<V> &dest, size_t keylen, std::vector<projtype>
   // assert(this!=&dest);
   dest.reset();
   for (auto p1 = begin(); p1 != end(); ++p1) {
-    if ((*p1).second > (V)0) {
+    if ((*p1).second > static_cast<V>(0)) {
       for (auto p2 = p1; p2 != end(); ++p2) {
-        if ((*p2).second > (V)0) {
+        if ((*p2).second > static_cast<V>(0)) {
           // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (size_t i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
-          v.second = (V)((*p1).second * (*p2).second);
+          v.second = (*p1).second * (*p2).second;
           if (p1 != p2) {
-            v.second *= (V)2;
+            v.second *= static_cast<V>(2);
           }
           dest += v;
         }
@@ -225,16 +225,16 @@ template <class V> void trie_map<V>::square(size_t keylen, std::vector<projtype>
   data2 = data;
   reset();
   for (p1 = data2.begin(); p1 != end(); ++p1) {
-    if ((*p1).second > (V)0) {
+    if ((*p1).second > static_cast<V>(0)) {
       for (p2 = p1; p2 != data2.end(); ++p2) {
-        if ((*p2).second > (V)0) {
+        if ((*p2).second > static_cast<V>(0)) {
           // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (size_t i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
-          v.second = (V)((*p1).second * (*p2).second);
+          v.second = (*p1).second * (*p2).second;
           if (p1 != p2) {
-            v.second *= (V)2;
+            v.second *= static_cast<V>(2);
           }
           (*this) += v;
         }
@@ -271,10 +271,10 @@ template <class V> V trie_map<V>::inner_prod(trie_map<V> &other, V init /*= (V) 
 {
   V result(init);
   for (auto p = begin(); p != end(); ++p) {
-    if ((*p).second > (V)0) {
+    if ((*p).second > static_cast<V>(0)) {
       auto p2 = other.find((*p).first);
       if (p2 == other.end()) {
-        if (p->second > (V)THRESH) {
+        if (p->second > static_cast<V>(THRESH)) {
           std::stringstream str;
           str << "inner_prod WARNING: discarding [";
           copy(p->first.begin(), p->first.end(), std::ostream_iterator<int>(str, " "));
@@ -299,7 +299,7 @@ V trie_map<V>::inner_prod(const std::vector<int> &x, size_t keylen, std::vector<
   static iterator p2;
   // V s(-1);
   for (auto p = begin(); p != end(); ++p) {
-    if ((*p).second > (V)0) {
+    if ((*p).second > static_cast<V>(0)) {
       value_type y = *p;
       // assert(y.first.size()==keylen);
       for (size_t i = 0; i < keylen; ++i) {
@@ -330,7 +330,7 @@ template <class V> trie_map<V> &trie_map<V>::operator/=(const std::vector<V> &de
   int piv = -1;
   for (size_t i = 0; i < denom.size(); ++i) {
     if (denom[i] > th) {
-      piv = (int)i;
+      piv = static_cast<int>(i);
       break;
     }
   }
@@ -368,14 +368,14 @@ void trie_map<V>::div(const std::vector<V> &denom, TrieNode<V> *n, int current, 
     return;
   }
 
-  for (i = 0; i < (int)(n->children.size()) - 1; i++) {
+  for (i = 0; i < static_cast<int>(n->children.size()) - 1; i++) {
     n->children[i] = n->children[i + 1];
   }
   n->children.pop_back();
 
   typename trie_map<V>::div_helper f(denom, pivot, data.end());
   for (i = n->children.size() - 1; i >= 0; i--) {
-    if (i < (int)(n->children.size()) - 1 && n->children[i + 1]) {
+    if (i < static_cast<int>(n->children.size()) - 1 && n->children[i + 1]) {
       // if(!n->children[i])n->children[i]=new TrieNode<V>(initBranches, data.end());
       typename trie_map<V>::div_helper_mul g(denom, pivot, n->children[i], data.end());
       in_order_subtree(g, n->children[i + 1]);
@@ -411,11 +411,11 @@ template <class V> void trie_map<V>::deleteNodes(TrieNode<V> *n)
 template <class V> void trie_map<V>::div_helper_mul::add(const std::vector<int> &conf, V y)
 {
   const size_t keylen = conf.size();
-  const double th(THRESH / (double)denom[pivot]);
+  const double th(THRESH / static_cast<double>(denom[pivot]));
   // if (y<=th&&y>=-th) return;
 
   if (!dest) {
-    if ((double)y > th || (double)y < -th) {
+    if (static_cast<double>(y) > th || static_cast<double>(y) < -th) {
       std::stringstream str;
       str << "division (pivot=" << denom[pivot] << ") WARNING: discarding " << y;
       throw std::runtime_error(str.str());
@@ -425,7 +425,7 @@ template <class V> void trie_map<V>::div_helper_mul::add(const std::vector<int> 
   TrieNode<V> *ptr = dest;
   for (size_t i = pivot + 1; i < keylen; ++i) {
     if ((*ptr)[conf[i]] == nullptr) {
-      if ((double)y > th || (double)y < -th) {
+      if (static_cast<double>(y) > th || static_cast<double>(y) < -th) {
         std::stringstream str;
         str << "division (pivot=" << denom[pivot] << ") WARNING: discarding " << y;
         throw std::runtime_error(str.str());
@@ -436,14 +436,14 @@ template <class V> void trie_map<V>::div_helper_mul::add(const std::vector<int> 
   }
   ptr->val->second += y;
   // assert(ptr->val->second>-THRESH);
-  if ((double)ptr->val->second <= -th) {
+  if (static_cast<double>(ptr->val->second) <= -th) {
     std::stringstream str;
     str << "division (pivot=" << denom[pivot] << ") WARNING: discarding " << ptr->val->second
         << std::endl;
     throw std::runtime_error(str.str());
   }
-  if (ptr->val->second < (V)0) {
-    ptr->val->second = (V)0;
+  if (ptr->val->second < static_cast<V>(0)) {
+    ptr->val->second = static_cast<V>(0);
   }
 }
 
@@ -454,10 +454,10 @@ template <class V> void trie_map<V>::div_helper_mul::operator()(iterator p)
   }
   const size_t keylen = p->first.size();
   // assert(keylen==denom.size());
-  V null_prob(((V)1) - denom[pivot]);
+  V null_prob(static_cast<V>(1) - denom[pivot]);
   // V th(THRESH);
   for (size_t i = pivot + 1; i < keylen; ++i) {
-    if (denom[i] > (V)0) {
+    if (denom[i] > static_cast<V>(0)) {
       p->first[i]++;
       add(p->first, -denom[i] * p->second);
       p->first[i]--;
@@ -465,7 +465,7 @@ template <class V> void trie_map<V>::div_helper_mul::operator()(iterator p)
     }
   }
 
-  if (null_prob > (V)0) {
+  if (null_prob > static_cast<V>(0)) {
     add(p->first, -null_prob * p->second);
   }
 }

--- a/src/games/agg/trie_map.imp
+++ b/src/games/agg/trie_map.imp
@@ -124,14 +124,12 @@ void trie_map<V>::multiply(const trie_map<V> &t1, const trie_map<V> &t2, size_t 
   static size_t i;
   static std::pair<std::vector<int>, V> v;
   const_iterator p1, p2;
-  // assert(this!=&t1 && this != &t2);
   v.first.resize(keylen);
   reset();
   for (p1 = t1.begin(); p1 != t1.end(); ++p1) {
     if ((*p1).second > static_cast<V>(0)) {
       for (p2 = t2.begin(); p2 != t2.end(); ++p2) {
         if ((*p2).second > static_cast<V>(0)) {
-          // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
@@ -150,7 +148,8 @@ void trie_map<V>::multiply(const trie_map<V> &other, size_t keylen, std::vector<
   static size_t i;
 
   if (&other == this) {
-    std::runtime_error("Error: (in-place) multiply: other should not be the same object as self");
+    throw std::runtime_error(
+        "Error: (in-place) multiply: other should not be the same object as self");
   }
   std::list<typename trie_map<V>::value_type> data2;
   data2 = data;
@@ -195,13 +194,11 @@ void trie_map<V>::square(trie_map<V> &dest, size_t keylen, std::vector<projtype>
 {
   static std::pair<std::vector<int>, V> v;
   v.first.resize(keylen);
-  // assert(this!=&dest);
   dest.reset();
   for (auto p1 = begin(); p1 != end(); ++p1) {
     if ((*p1).second > static_cast<V>(0)) {
       for (auto p2 = p1; p2 != end(); ++p2) {
         if ((*p2).second > static_cast<V>(0)) {
-          // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (size_t i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
@@ -228,7 +225,6 @@ template <class V> void trie_map<V>::square(size_t keylen, std::vector<projtype>
     if ((*p1).second > static_cast<V>(0)) {
       for (p2 = p1; p2 != data2.end(); ++p2) {
         if ((*p2).second > static_cast<V>(0)) {
-          // assert((*p1).first.size()==keylen&& (*p2).first.size()==keylen);
           for (size_t i = 0; i < keylen; ++i) {
             v.first[i] = (*(f[i]))((*p1).first[i], (*p2).first[i]);
           }
@@ -247,7 +243,6 @@ template <class V>
 void trie_map<V>::power(size_t p, trie_map<V> &dest, trie_map<V> &scratch, size_t keylen,
                         std::vector<projtype> &f)
 {
-  // assert(p>0 && this!=&dest );
   if (p == 1) {
     dest = *this;
     return;
@@ -301,7 +296,6 @@ V trie_map<V>::inner_prod(const std::vector<int> &x, size_t keylen, std::vector<
   for (auto p = begin(); p != end(); ++p) {
     if ((*p).second > static_cast<V>(0)) {
       value_type y = *p;
-      // assert(y.first.size()==keylen);
       for (size_t i = 0; i < keylen; ++i) {
         y.first[i] = (*(f[i]))(y.first[i], x[i]);
       }
@@ -435,7 +429,6 @@ template <class V> void trie_map<V>::div_helper_mul::add(const std::vector<int> 
     ptr = (*ptr)[conf[i]];
   }
   ptr->val->second += y;
-  // assert(ptr->val->second>-THRESH);
   if (static_cast<double>(ptr->val->second) <= -th) {
     std::stringstream str;
     str << "division (pivot=" << denom[pivot] << ") WARNING: discarding " << ptr->val->second
@@ -453,7 +446,6 @@ template <class V> void trie_map<V>::div_helper_mul::operator()(iterator p)
     return;
   }
   const size_t keylen = p->first.size();
-  // assert(keylen==denom.size());
   V null_prob(static_cast<V>(1) - denom[pivot]);
   // V th(THRESH);
   for (size_t i = pivot + 1; i < keylen; ++i) {

--- a/src/games/behavspt.h
+++ b/src/games/behavspt.h
@@ -210,7 +210,7 @@ public:
   GameRep::Players GetPlayers() const { return GetGame()->GetPlayers(); }
   template <class T>
   MixedBehaviorProfile<T> ToMixedBehaviorProfile(const std::map<GameSequence, T> &) const;
-  Infosets GetInfosets() const { return {this}; };
+  Infosets GetInfosets() const { return {this}; }
   SequenceContingencies GetSequenceContingencies() const;
 
   std::shared_ptr<std::map<GameInfoset, bool>> GetReachableInfosets() const;

--- a/src/games/game.cc
+++ b/src/games/game.cc
@@ -449,7 +449,6 @@ template <class T> void MixedStrategyProfile<T>::ComputePayoffs() const
       for (const auto &strategy : strategies) {
         newCache.m_strategyValues[player][strategy] = *value_it;
         ++value_it;
-        ;
       }
     }
     else {
@@ -460,7 +459,7 @@ template <class T> void MixedStrategyProfile<T>::ComputePayoffs() const
   }
   newCache.m_valid = true;
   m_cache = std::move(newCache);
-};
+}
 
 template <class T> T MixedStrategyProfile<T>::GetLiapValue() const
 {

--- a/src/games/gametree.cc
+++ b/src/games/gametree.cc
@@ -959,7 +959,7 @@ bool GameTreeRep::IsConstSum() const
     static void OnVisit(GameNode, int) {}
   };
 
-  ConstSumCallback callback{this};
+  ConstSumCallback callback{this, {}};
   WalkDFS(Game(const_cast<GameTreeRep *>(this)->shared_from_this()), m_root,
           TraversalOrder::Postorder, callback);
   return callback.m_isConstSum;
@@ -1000,7 +1000,7 @@ Rational GameTreeRep::AggregateSubtreePayoff(const GamePlayer &p_player,
     static void OnVisit(GameNode, int) {}
   };
 
-  AggregatePayoffCallback callback{p_player, std::move(p_aggregator)};
+  AggregatePayoffCallback callback{p_player, std::move(p_aggregator), {}};
 
   WalkDFS(Game(const_cast<GameTreeRep *>(this)->shared_from_this()), m_root,
           TraversalOrder::Postorder, callback);
@@ -1546,7 +1546,7 @@ const GameTreeRep::SubgameData &GameTreeRep::GetSubgameData() const
     SpanVisitor span_visitor{disc, hull};
     WalkDFS(game, m_root, TraversalOrder::Postorder, span_visitor);
 
-    BridgeVisitor bridge_visitor{disc, hull, sd.m_subgamePostorder};
+    BridgeVisitor bridge_visitor{disc, hull, sd.m_subgamePostorder, {}};
     WalkDFS(game, m_root, TraversalOrder::Postorder, bridge_visitor);
 
     // Phase 3: Build subgame tree with subgame differences
@@ -1599,8 +1599,8 @@ const GameTreeRep::SubgameData &GameTreeRep::GetSubgameData() const
     const std::unordered_set<GameNodeRep *> subgame_root_set(sd.m_subgamePostorder.begin(),
                                                              sd.m_subgamePostorder.end());
 
-    SubgameVisitor subgame_visitor{subgame_root_set, sd.m_subgameByRoot,
-                                   const_cast<GameTreeRep *>(this)};
+    SubgameVisitor subgame_visitor{
+        subgame_root_set, sd.m_subgameByRoot, const_cast<GameTreeRep *>(this), {}, {}};
     WalkDFS(game, m_root, TraversalOrder::Preorder, subgame_visitor);
     return sd;
   });

--- a/src/games/writer.h
+++ b/src/games/writer.h
@@ -68,17 +68,6 @@ std::string FormatList(const C &p_container, T p_renderer, bool p_commas = false
 }
 
 ///
-/// Abstract base class for objects that write games to various formats
-///
-class GameWriter {
-public:
-  ///
-  /// Convert the game to a string-based representation
-  ///
-  virtual std::string Write(const Game &) const = 0;
-};
-
-///
 /// Convert the game to HTML, selecting the row and column player.
 ///
 std::string WriteHTMLFile(const Game &p_game, const GamePlayer &p_rowPlayer,

--- a/src/pygambit/gambit.pyx
+++ b/src/pygambit/gambit.pyx
@@ -79,27 +79,6 @@ def _to_number(value: typing.Any) -> c_Number:
     return c_Number(_to_number_string(value).encode("ascii"))
 
 
-@cython.cfunc
-def _resolve_by_label(collection, label: str, scope: str, kind: str, kind_plural: str):
-    """Resolve a member of a game collection by its text label.
-
-    Game collections are accessed by label, not by position.  Lookup is by exact label match.
-
-    Failure modes:
-      * an empty label raises ``ValueError``;
-      * a label matching no member raises ``KeyError``;
-      * a label matching more than one member raises ``ValueError``.
-    """
-    if not label:
-        raise ValueError(f"{kind} label cannot be empty")
-    matches = [x for x in collection if x.label == label]
-    if not matches:
-        raise KeyError(f"{scope} has no {kind} with label '{label}'")
-    if len(matches) > 1:
-        raise ValueError(f"{scope} has multiple {kind_plural} with label '{label}'")
-    return matches[0]
-
-
 ProfileDType = float | Rational
 
 

--- a/src/solvers/enummixed/enummixed.cc
+++ b/src/solvers/enummixed/enummixed.cc
@@ -124,8 +124,8 @@ EnumMixedStrategySolveDetailed(const Game &p_game, StrategyCallbackType<T> p_onE
   // Construct vectors b1, b2
   Vector<T> b1(1, p_game->GetPlayer(1)->GetStrategies().size());
   Vector<T> b2(1, p_game->GetPlayer(2)->GetStrategies().size());
-  b1 = (T)-1;
-  b2 = (T)-1;
+  b1 = static_cast<T>(-1);
+  b2 = static_cast<T>(-1);
 
   // enumerate vertices of A1 x + b1 <= 0 and A2 x + b2 <= 0
   const auto poly1 = EnumerateVertices(A1, b1, p_cancel);

--- a/src/solvers/gtracer/aggame.cc
+++ b/src/solvers/gtracer/aggame.cc
@@ -76,7 +76,7 @@ void aggame::KSymPayoffMatrix(cmatrix &dest, const cvector &s, double fuzz) cons
         for (int cola = 0; cola < getNumKSymActions(colcls); ++cola) {
 
           dest(rowa + firstKSymAction(rowcls), cola + firstKSymAction(colcls)) =
-              (double)multiplier * aggPtr->getKSymMixedPayoff(sp, rowcls, rowa, colcls, cola);
+              multiplier * aggPtr->getKSymMixedPayoff(sp, rowcls, rowa, colcls, cola);
         }
       }
     }

--- a/src/solvers/gtracer/cmatrix.cc
+++ b/src/solvers/gtracer/cmatrix.cc
@@ -48,7 +48,7 @@ int cmatrix::LUdecomp(cmatrix &LU, std::vector<int> &ix) const
         vv[i] = dum;
       }
     }
-    if (vv[i] == (double)0.0) {
+    if (vv[i] == 0.0) {
       delete[] vv;
       return 0;
     }

--- a/src/solvers/gtracer/cmatrix.h
+++ b/src/solvers/gtracer/cmatrix.h
@@ -30,6 +30,8 @@
 #include <cstring>
 #include <vector>
 
+#include "core/util.h"
+
 namespace Gambit::gametracer {
 
 class cvector {
@@ -709,7 +711,9 @@ public:
 
   void multiply(const cvector &source, cvector &dest) const
   {
-    // assert(n == source.m && m == dest.m);
+    if (n != source.m || m != dest.m) {
+      throw DimensionException();
+    }
     int i, j, c = 0;
     for (i = 0; i < m; i++) {
       dest[i] = 0;

--- a/src/solvers/gtracer/gnm.cc
+++ b/src/solvers/gtracer/gnm.cc
@@ -27,7 +27,7 @@
 
 namespace Gambit::gametracer {
 
-const double BIGFLOAT = 3.0e+28F;
+const double BIGFLOAT = 3.0e+28;
 
 // LNM runs the local Newton method on z to attempt to bring it closer to
 // the image of the graph of the equilibrium correspondence above the ray,

--- a/src/solvers/gtracer/gnm.cc
+++ b/src/solvers/gtracer/gnm.cc
@@ -44,7 +44,7 @@ double LNM(const gnmgame &game, cvector &z, const cvector &g, double det, cmatri
     for (k = 0; k < MaxLNM; k++) {
       //      del = z - s - DG*s / (double)(numPlayers - 1) - g;
       DG.multiply(s, del);
-      del /= (double)(game.getNumPlayers() - 1);
+      del /= (game.getNumPlayers() - 1);
       del += g;
       del += s;
       del -= z;
@@ -174,7 +174,7 @@ GNMResult GNM(gnmgame &A, cvector &g, int steps, double fuzz, int LNMFreq, int L
 
   A.payoffMatrix(DG, sigma, fuzz);
   DG.multiply(sigma, v);
-  v /= (double)(N - 1);
+  v /= (N - 1);
 
   // Scale g until the equilibrium sigma calculated above
   // is in fact the one unique equilibrium, and set lambda
@@ -247,7 +247,7 @@ GNMResult GNM(gnmgame &A, cvector &g, int steps, double fuzz, int LNMFreq, int L
 
       // Calculate payoff cvector
       DG.multiply(sigma, v);
-      v /= (double)(N - 1);
+      v /= (N - 1);
       ym1 = g;
       ym1 *= lambda;
       v += ym1;
@@ -386,7 +386,7 @@ GNMResult GNM(gnmgame &A, cvector &g, int steps, double fuzz, int LNMFreq, int L
       } // already at the support boundary
 
       DG.multiply(sigma, err);
-      err /= (double)(N - 1);
+      err /= (N - 1);
       g0 = g;
       g0 *= lambda;
       err += g0;
@@ -401,7 +401,7 @@ GNMResult GNM(gnmgame &A, cvector &g, int steps, double fuzz, int LNMFreq, int L
       if (ee > threshold) { // if we've accumulated too much error, either
         if (wobble) {       // wobble or quit.
           DG.multiply(sigma, ym1);
-          ym1 /= (double)(N - 1);
+          ym1 /= (N - 1);
           g = z;
           g -= sigma;
           g -= ym1;
@@ -459,7 +459,7 @@ GNMResult GNM(gnmgame &A, cvector &g, int steps, double fuzz, int LNMFreq, int L
     if (N > 2 && wobble) {
       A.payoffMatrix(DG, sigma, fuzz);
       DG.multiply(sigma, ym1);
-      ym1 /= (double)(N - 1);
+      ym1 /= (N - 1);
       g = z;
       g -= sigma;
       g -= ym1;

--- a/src/solvers/gtracer/gnmgame.cc
+++ b/src/solvers/gtracer/gnmgame.cc
@@ -95,7 +95,7 @@ void gnmgame::retract(cvector &dest, const cvector &z) const
       }
       sumz += y[i];
     }
-    v = (sumz - 1) / (double)(i - firstAction(n));
+    v = (sumz - 1) / (i - firstAction(n));
     for (i = firstAction(n); i < lastAction(n); i++) {
       dest[i] = z[i] - v;
       if (dest[i] < 0.0) {

--- a/src/solvers/gtracer/ipa.cc
+++ b/src/solvers/gtracer/ipa.cc
@@ -78,7 +78,7 @@ int Pivot(cmatrix &T, int pr, int pc, std::vector<int> &row, std::vector<int> &c
 
 void LemkeHowson(const gnmgame &game, cvector &dest, cmatrix &T, std::vector<int> &Im)
 {
-  const double BIGFLOAT = 3.0e+28F;
+  const double BIGFLOAT = 3.0e+28;
   const int numActions = game.getNumActions(), numPlayers = game.getNumPlayers();
   double D = 1;
   const int cg = numActions + numPlayers;

--- a/src/solvers/gtracer/ipa.cc
+++ b/src/solvers/gtracer/ipa.cc
@@ -245,7 +245,7 @@ IPAResult IPA(const gnmgame &A, const cvector &g, cvector &zh, double alpha, dou
   for (unsigned int iter = 1; iter <= maxiter; iter++) {
     p_cancel.Check();
     A.payoffMatrix(DG, sh, 0.0);
-    DG /= (double)(N - 1); // find the Jacobian of the approximating bimatrix game
+    DG /= (N - 1); // find the Jacobian of the approximating bimatrix game
 
     InitialiseLHTableau(T, A, DG, g);
 

--- a/src/solvers/ipa/ipa.cc
+++ b/src/solvers/ipa/ipa.cc
@@ -91,7 +91,8 @@ IPAStrategySolve(const MixedStrategyProfile<double> &p_pert,
         .profile = profile, .iteration = p_iteration, .zDiff = p_zDiff, .sDiff = p_sDiff});
   };
 
-  IPAResult result{cvector(A->getNumActions()), IPATerminationReason::MaxIterationsReached, 0};
+  IPAResult result{
+      cvector(A->getNumActions()), IPATerminationReason::MaxIterationsReached, 0, 0, 0, 0.0};
   for (int restart = 0; restart < MAX_RESTARTS; restart++) {
     p_cancel.Check();
     result = IPA(*A, g, zh, ALPHA, EQERR, 100, onStep, p_cancel);

--- a/src/solvers/lcp/nfglcp.cc
+++ b/src/solvers/lcp/nfglcp.cc
@@ -96,7 +96,7 @@ template <class T> Matrix<T> Make_A2(const Game &p_game)
 template <class T> Vector<T> Make_b1(const Game &p_game)
 {
   Vector<T> b1(1, p_game->GetPlayer(1)->GetStrategies().size());
-  b1 = -(T)1;
+  b1 = -static_cast<T>(1);
   return b1;
 }
 
@@ -105,7 +105,7 @@ template <class T> Vector<T> Make_b2(const Game &p_game)
   Vector<T> b2(p_game->GetPlayer(1)->GetStrategies().size() + 1,
                p_game->GetPlayer(1)->GetStrategies().size() +
                    p_game->GetPlayer(2)->GetStrategies().size());
-  b2 = -(T)1;
+  b2 = -static_cast<T>(1);
   return b2;
 }
 
@@ -175,14 +175,14 @@ NashLcpStrategySolver<T>::OnBFS(const Game &p_game, linalg::LHTableau<T> &p_tabl
   MixedStrategyProfile<T> profile(p_game->NewMixedStrategyProfile(static_cast<T>(0.0)));
   const int n1 = p_game->GetPlayer(1)->GetStrategies().size();
   const int n2 = p_game->GetPlayer(2)->GetStrategies().size();
-  T sum = (T)0;
+  T sum = static_cast<T>(0);
 
   for (int j = 1; j <= n1; j++) {
     if (cbfs.count(j)) {
       sum += cbfs[j];
     }
   }
-  if (sum == (T)0) {
+  if (sum == static_cast<T>(0)) {
     // This is the trivial CBFS.
     return SearchResult::PruneBranch;
   }
@@ -193,11 +193,11 @@ NashLcpStrategySolver<T>::OnBFS(const Game &p_game, linalg::LHTableau<T> &p_tabl
       profile[strategy] = cbfs[j] / sum;
     }
     else {
-      profile[strategy] = (T)0;
+      profile[strategy] = static_cast<T>(0);
     }
   }
 
-  sum = (T)0;
+  sum = static_cast<T>(0);
   for (int j = 1; j <= n2; j++) {
     if (cbfs.count(n1 + j)) {
       sum += cbfs[n1 + j];
@@ -210,7 +210,7 @@ NashLcpStrategySolver<T>::OnBFS(const Game &p_game, linalg::LHTableau<T> &p_tabl
       profile[strategy] = cbfs[n1 + j] / sum;
     }
     else {
-      profile[strategy] = (T)0;
+      profile[strategy] = static_cast<T>(0);
     }
   }
 

--- a/src/solvers/linalg/lptab.cc
+++ b/src/solvers/linalg/lptab.cc
@@ -104,7 +104,7 @@ template <> Rational LPTableau<Rational>::ComputeTotalCost() const
   GetBasisVector(sol);
   for (int i = tmpcol.front_index(); i <= tmpcol.back_index(); i++) {
     if (GetLabel(i) > 0) {
-      tmpcol[i] /= (Rational)Tableau<Rational>::GetTotalDenominator();
+      tmpcol[i] /= static_cast<Rational>(Tableau<Rational>::GetTotalDenominator());
     }
   }
 
@@ -118,7 +118,7 @@ template <class T> T LPTableau<T>::ComputeRelativeCost(int col) const
     return m_unitCost[-col] - m_dual[-col];
   }
   else {
-    this->GetColumn(col, (Vector<T> &)tmpcol);
+    this->GetColumn(col, tmpcol);
     return m_cost[col] - m_dual * tmpcol;
   }
 }

--- a/src/solvers/linalg/tableau.cc
+++ b/src/solvers/linalg/tableau.cc
@@ -195,9 +195,10 @@ Integer find_lcd(const Vector<Rational> &vec)
 //
 
 Tableau<Rational>::Tableau(const Matrix<Rational> &A, const Vector<Rational> &b)
-  : TableauBase<Rational>(A, b), m_tableauData(A.MinRow(), A.MaxRow(), A.MinCol(), A.MaxCol()),
+  : TableauBase<Rational>(A, b), m_nonbasicLabels(A.MinCol(), A.MaxCol()),
+    m_tableauData(A.MinRow(), A.MaxRow(), A.MinCol(), A.MaxCol()),
     m_scaledRHS(b.front_index(), b.back_index()), m_pivotDenominator(1),
-    m_scratchColumn(b.front_index(), b.back_index()), m_nonbasicLabels(A.MinCol(), A.MaxCol())
+    m_scratchColumn(b.front_index(), b.back_index())
 {
   for (int j = MinCol(); j <= MaxCol(); j++) {
     m_nonbasicLabels[j] = j;
@@ -231,11 +232,10 @@ Tableau<Rational>::Tableau(const Matrix<Rational> &A, const Vector<Rational> &b)
 
 Tableau<Rational>::Tableau(const Matrix<Rational> &A, const Array<int> &art,
                            const Vector<Rational> &b)
-  : TableauBase<Rational>(A, art, b),
+  : TableauBase<Rational>(A, art, b), m_nonbasicLabels(A.MinCol(), A.MaxCol() + art.size()),
     m_tableauData(A.MinRow(), A.MaxRow(), A.MinCol(), A.MaxCol() + art.size()),
     m_scaledRHS(b.front_index(), b.back_index()), m_pivotDenominator(1),
-    m_scratchColumn(b.front_index(), b.back_index()),
-    m_nonbasicLabels(A.MinCol(), A.MaxCol() + art.size())
+    m_scratchColumn(b.front_index(), b.back_index())
 {
   for (int j = MinCol(); j <= MaxCol(); j++) {
     m_nonbasicLabels[j] = j;

--- a/src/solvers/linalg/vertenum.cc
+++ b/src/solvers/linalg/vertenum.cc
@@ -125,10 +125,10 @@ VertexEnumerationResult<T> EnumerateVertices(const Matrix<T> &A, const Vector<T>
 template <class T> std::list<Vector<T>> VertexEnumerationResult<T>::GetVertices() const
 {
   std::list<Vector<T>> verts;
-  for (int i = 1; i <= vertices.size(); i++) {
+  for (int i = vertices.front_index(); i <= vertices.back_index(); i++) {
     Vector<T> vert(numColumns);
     vert = T{0};
-    for (int j = 1; j <= vert.size(); j++) {
+    for (int j = vert.front_index(); j <= vert.back_index(); j++) {
       if (vertices[i].count(j)) {
         vert[j] = -vertices[i][j];
       }

--- a/src/solvers/lp/lp.h
+++ b/src/solvers/lp/lp.h
@@ -39,6 +39,6 @@ LpBehaviorSolve(const Game &p_game,
                 BehaviorCallbackType<T> p_onEquilibrium = NullBehaviorCallback<T>,
                 const CancelToken &p_cancel = CancelToken());
 
-}; // namespace Gambit::Nash
+} // namespace Gambit::Nash
 
 #endif // GAMBIT_SOLVERS_LP_LP_H


### PR DESCRIPTION
This tightens up some of the coding-standards checks, with an eye especially towards warnings not creeping in on the `pygambit` build that are not being caught elsewhere.

* Cleans up .clang-tidy configuration
* Eliminate remaining uses of assert() in favour of exceptions where appropriate
* Remove C-style casts and avoid unneeded float-double casts
